### PR TITLE
Add reference and HPC target fields to FlowProject

### DIFF
--- a/gui/workflow_backend/django-project/app/workflow/models.py
+++ b/gui/workflow_backend/django-project/app/workflow/models.py
@@ -8,6 +8,10 @@ class FlowProject(models.Model):
         PRIVATE = "private", "Private"
         PUBLIC = "public", "Public"
 
+    class HpcTarget(models.TextChoices):
+        RIKEN = "riken", "Riken"
+        FUGAKU = "fugaku", "Fugaku"
+
     id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
     name = models.CharField(max_length=255)
     description = models.TextField(blank=True, null=True)
@@ -20,6 +24,13 @@ class FlowProject(models.Model):
         choices=Visibility.choices,
         default=Visibility.PRIVATE,
         db_index=True,
+    )
+    reference = models.TextField(blank=True, default="")
+    hpc_target = models.CharField(
+        max_length=32,
+        choices=HpcTarget.choices,
+        blank=True,
+        default="",
     )
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)

--- a/gui/workflow_backend/django-project/app/workflow/serializers.py
+++ b/gui/workflow_backend/django-project/app/workflow/serializers.py
@@ -34,6 +34,8 @@ class FlowProjectSerializer(serializers.ModelSerializer):
             "workflow_context",
             "owner",
             "visibility",
+            "reference",
+            "hpc_target",
             "created_at",
             "updated_at",
             "is_active",

--- a/gui/workflow_frontend/src/views/file/createView.tsx
+++ b/gui/workflow_frontend/src/views/file/createView.tsx
@@ -16,18 +16,21 @@ import {
   useColorModeValue,
   Radio,
   RadioGroup,
+  Select,
   Stack,
 } from '@chakra-ui/react';
 import { useNavigate } from 'react-router-dom';
 import { createAuthHeaders } from '../../api/authHeaders'; // for authentication header
 import { WorkflowContextEditor } from '../../components/WorkflowContextEditor';
-import type { Visibility } from '../home/type';
+import type { HpcTarget, Visibility } from '../home/type';
 
 interface CreateFlowProjectRequest {
   name: string;
   description: string;
   workflow_context?: Record<string, any>;
   visibility: Visibility;
+  reference: string;
+  hpc_target: HpcTarget;
 }
 
 interface CreateFlowProjectResponse {
@@ -53,6 +56,8 @@ const CreateFlowPj: React.FC = () => {
   const [isContextValid, setIsContextValid] = useState<boolean>(true);
   const [contextResetKey, setContextResetKey] = useState<number>(0);
   const [visibility, setVisibility] = useState<Visibility>('private');
+  const [reference, setReference] = useState<string>('');
+  const [hpcTarget, setHpcTarget] = useState<HpcTarget>('');
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const toast = useToast();
   const navigate = useNavigate();
@@ -140,6 +145,8 @@ const CreateFlowPj: React.FC = () => {
         name: projectName.trim(),
         description: note.trim() || '', // Default to empty string
         visibility,
+        reference,
+        hpc_target: hpcTarget,
         ...(workflowContextPayload ? { workflow_context: workflowContextPayload } : {}),
       };
 
@@ -161,6 +168,8 @@ const CreateFlowPj: React.FC = () => {
       setIsContextValid(true);
       setContextResetKey(prev => prev + 1);
       setVisibility('private');
+      setReference('');
+      setHpcTarget('');
 
       // Go to the details screen of the created workflow (using UUID)
       // navigate(`/workflow/${response.id}`);
@@ -204,6 +213,8 @@ const CreateFlowPj: React.FC = () => {
     setWorkflowContext(null);
     setIsContextValid(true);
     setContextResetKey(prev => prev + 1);
+    setReference('');
+    setHpcTarget('');
     navigate(-1);
   };
 
@@ -280,6 +291,43 @@ const CreateFlowPj: React.FC = () => {
               </Radio>
             </Stack>
           </RadioGroup>
+        </FormControl>
+
+        <FormControl>
+          <FormLabel htmlFor="reference" fontSize="sm" fontWeight="semibold" color={textColor}>
+            Reference (Optional)
+          </FormLabel>
+          <Textarea
+            id="reference"
+            placeholder="Papers, URLs, or other references for this workflow..."
+            rows={3}
+            value={reference}
+            onChange={(e) => setReference(e.target.value)}
+            isDisabled={isLoading}
+            borderColor={inputBorder}
+            _hover={{ borderColor: inputHoverBorder }}
+            _focus={{ borderColor: inputFocusBorder, boxShadow: inputFocusShadow }}
+            resize="vertical"
+          />
+        </FormControl>
+
+        <FormControl>
+          <FormLabel htmlFor="hpcTarget" fontSize="sm" fontWeight="semibold" color={textColor}>
+            HPC Target (Optional)
+          </FormLabel>
+          <Select
+            id="hpcTarget"
+            value={hpcTarget}
+            onChange={(e) => setHpcTarget(e.target.value as HpcTarget)}
+            isDisabled={isLoading}
+            borderColor={inputBorder}
+            _hover={{ borderColor: inputHoverBorder }}
+            _focus={{ borderColor: inputFocusBorder, boxShadow: inputFocusShadow }}
+          >
+            <option value="">Not specified</option>
+            <option value="riken">Riken</option>
+            <option value="fugaku">Fugaku</option>
+          </Select>
         </FormControl>
 
         <FormControl>

--- a/gui/workflow_frontend/src/views/home/components/projectSelector.tsx
+++ b/gui/workflow_frontend/src/views/home/components/projectSelector.tsx
@@ -1,5 +1,5 @@
 import { useState, useCallback, useRef } from 'react';
-import { Project, Visibility } from '../type'
+import { HpcTarget, Project, Visibility } from '../type'
 import {
   HStack,
   Box,
@@ -59,6 +59,8 @@ export const ProjectSelector = ({
   const [contextResetKey, setContextResetKey] = useState<number>(0);
   const [descriptionDraft, setDescriptionDraft] = useState<string>('');
   const [visibilityDraft, setVisibilityDraft] = useState<Visibility>('private');
+  const [referenceDraft, setReferenceDraft] = useState<string>('');
+  const [hpcTargetDraft, setHpcTargetDraft] = useState<HpcTarget>('');
   const currentProject = selectedProject
     ? projects.find((p) => p.id === selectedProject) ?? null
     : null;
@@ -105,6 +107,8 @@ export const ProjectSelector = ({
     const payload: Record<string, any> = {
       workflow_context: parsedContext,
       description: descriptionPayload,
+      reference: referenceDraft,
+      hpc_target: hpcTargetDraft,
     };
     if (currentProject?.can_change_visibility && visibilityDraft !== currentProject.visibility) {
       payload.visibility = visibilityDraft;
@@ -140,6 +144,12 @@ export const ProjectSelector = ({
       setContextDraft(parsedContext);
       if (updated.visibility) {
         setVisibilityDraft(updated.visibility);
+      }
+      if (updated.reference !== undefined) {
+        setReferenceDraft(updated.reference);
+      }
+      if (updated.hpc_target !== undefined) {
+        setHpcTargetDraft(updated.hpc_target);
       }
       onContextClose();
     } catch (error) {
@@ -515,6 +525,8 @@ export const ProjectSelector = ({
                     setIsContextValid(true);
                     setContextResetKey(prev => prev + 1);
                     setVisibilityDraft(project?.visibility ?? 'private');
+                    setReferenceDraft(project?.reference ?? '');
+                    setHpcTargetDraft(project?.hpc_target ?? '');
                     onContextOpen();
                   }}
                   _hover={{
@@ -619,6 +631,25 @@ export const ProjectSelector = ({
                   Only the project owner can change visibility.
                 </Text>
               )}
+            </Box>
+            <Box mb={4}>
+              <FormLabel fontSize="sm">Reference</FormLabel>
+              <Textarea
+                value={referenceDraft}
+                onChange={(e) => setReferenceDraft(e.target.value)}
+                placeholder="Papers, URLs, or other references for this workflow..."
+              />
+            </Box>
+            <Box mb={4}>
+              <FormLabel fontSize="sm">HPC Target</FormLabel>
+              <Select
+                value={hpcTargetDraft}
+                onChange={(e) => setHpcTargetDraft(e.target.value as HpcTarget)}
+              >
+                <option value="">Not specified</option>
+                <option value="riken">Riken</option>
+                <option value="fugaku">Fugaku</option>
+              </Select>
             </Box>
             <WorkflowContextEditor
               key={contextResetKey}

--- a/gui/workflow_frontend/src/views/home/type.ts
+++ b/gui/workflow_frontend/src/views/home/type.ts
@@ -73,6 +73,8 @@ export interface CalculationNodeData {
 
 export type Visibility = "private" | "public";
 
+export type HpcTarget = "" | "riken" | "fugaku";
+
 export interface ProjectOwner {
   id: number;
   username: string;
@@ -87,6 +89,8 @@ export interface Project {
   description?: string;
   workflow_context?: Record<string, any>;
   visibility: Visibility;
+  reference?: string;
+  hpc_target?: HpcTarget;
   owner?: ProjectOwner;
   is_owned_by_me: boolean;
   can_edit: boolean;


### PR DESCRIPTION
## Summary

- Add two new metadata properties to `FlowProject`:
  - **`reference`**: free-text field (TextField) for citing papers, URLs, or related works.
  - **`hpc_target`**: optional choice (`riken` / `fugaku` / unset) indicating the intended HPC destination for job submission.
- Surface both fields in the **project settings modal** (`projectSelector.tsx`) and in the **new project creation form** (`createView.tsx`).
- Wiring of actual job dispatch to Riken / Fugaku is **out of scope** — this PR only introduces the schema and UI surface so the data can start being captured.

## Implementation notes

- Naming: chose `hpc_target` rather than `hpc_backend` because `WorkflowRun.Backend` (`local` / `slurm` / `jupyter`) already exists and represents a different concept (execution backend kind, not physical HPC site).
- Both fields default to empty string and follow the same pattern as the existing `visibility` field.
- Migrations are auto-generated per environment (the repo's `.gitignore` excludes numbered migration files), so applying this PR requires running `makemigrations workflow` followed by `migrate`.

## Test plan

- [ ] `poetry run python django-project/manage.py makemigrations workflow && migrate` succeeds
- [ ] `GET /api/workflow/{id}/` returns `reference: ""` and `hpc_target: ""` for existing projects
- [ ] `PATCH /api/workflow/{id}/` with `{"reference": "...", "hpc_target": "fugaku"}` persists the values
- [ ] `PATCH` with an invalid `hpc_target` (e.g. `"nasa"`) returns 400
- [ ] `/file/new`: creating a project with the new fields populated stores them correctly
- [ ] Project settings modal: editing/saving the two fields persists across reload
- [ ] HPC Target's "Not specified" option clears the value back to empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)