### PR TITLE
Switch DRF default permission to IsAuthenticated (closes #19)

### DIFF
--- a/gui/workflow_backend/django-project/app/auth/authViews.py
+++ b/gui/workflow_backend/django-project/app/auth/authViews.py
@@ -1,9 +1,15 @@
-from rest_framework.decorators import api_view, permission_classes
+from rest_framework.decorators import (
+    api_view,
+    authentication_classes,
+    permission_classes,
+)
 from rest_framework.permissions import IsAuthenticated, AllowAny
 from rest_framework.response import Response
 
 
 @api_view(["GET"])
+@authentication_classes([])
+@permission_classes([AllowAny])
 def health_check(request):
     """Authentication-free health checks"""
     return Response({"status": "ok", "message": "Django server is running"})

--- a/gui/workflow_backend/django-project/config/settings.py
+++ b/gui/workflow_backend/django-project/config/settings.py
@@ -116,14 +116,11 @@ AUTH_PASSWORD_VALIDATORS = [
 # ==============================================================================
 
 REST_FRAMEWORK = {
-    # "DEFAULT_AUTHENTICATION_CLASSES": [
-    #     "app.auth.authentication.SupabaseAuthentication",
-    # ],
-    # "DEFAULT_PERMISSION_CLASSES": [
-    #     "rest_framework.permissions.IsAuthenticated",
-    # ],
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "app.auth.authentication.CombinedJWTAuthentication",
+    ],
     "DEFAULT_PERMISSION_CLASSES": [
-        "rest_framework.permissions.AllowAny",  
+        "rest_framework.permissions.IsAuthenticated",
     ],
     "DEFAULT_RENDERER_CLASSES": [
         "rest_framework.renderers.JSONRenderer",

--- a/gui/workflow_backend/django-project/tests/test_permissions_default.py
+++ b/gui/workflow_backend/django-project/tests/test_permissions_default.py
@@ -1,0 +1,46 @@
+"""Regression tests guarding DRF DEFAULT_PERMISSION_CLASSES = IsAuthenticated.
+
+If a future change reverts the default to AllowAny, or drops permission_classes
+from a protected view, these tests fail.
+"""
+import pytest
+from django.urls import reverse
+
+pytestmark = pytest.mark.django_db
+
+
+def test_drf_default_permission_is_isauthenticated(settings):
+    perms = settings.REST_FRAMEWORK.get("DEFAULT_PERMISSION_CLASSES", [])
+    assert "rest_framework.permissions.IsAuthenticated" in perms
+    assert "rest_framework.permissions.AllowAny" not in perms
+
+
+def test_health_check_allows_anonymous(auth_client):
+    client = auth_client()
+    resp = client.get(reverse("health_check"))
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "ok"
+
+
+def test_public_box_categories_allows_anonymous(auth_client):
+    client = auth_client()
+    resp = client.get(reverse("box:node-categories"))
+    # The view may hit the filesystem and fail; the contract here is only
+    # "not 401" — the explicit AllowAny on NodeCategoryListView must hold.
+    assert resp.status_code != 401, (
+        "box:node-categories must remain publicly readable."
+    )
+
+
+def test_protected_workflow_list_rejects_anonymous(auth_client):
+    client = auth_client()
+    url = reverse("workflow:workflow-list-create")
+    assert client.get(url).status_code == 401
+    assert client.post(url, {"name": "X"}, format="json").status_code == 401
+
+
+def test_protected_workflow_list_accepts_authenticated(auth_client, user_alice):
+    client = auth_client(user_alice)
+    resp = client.get(reverse("workflow:workflow-list-create"))
+    assert resp.status_code == 200
+    assert isinstance(resp.json(), list)

--- a/gui/workflow_backend/django-project/tests/test_permissions_default.py
+++ b/gui/workflow_backend/django-project/tests/test_permissions_default.py
@@ -1,18 +1,24 @@
-"""Regression tests guarding DRF DEFAULT_PERMISSION_CLASSES = IsAuthenticated.
+"""Regression tests guarding DRF secure-by-default settings.
 
-If a future change reverts the default to AllowAny, or drops permission_classes
-from a protected view, these tests fail.
+If a future change reverts DEFAULT_PERMISSION_CLASSES to AllowAny, drops
+DEFAULT_AUTHENTICATION_CLASSES, or removes permission_classes from a
+protected view, these tests fail.
 """
+import json
+
 import pytest
 from django.urls import reverse
 
 pytestmark = pytest.mark.django_db
 
 
-def test_drf_default_permission_is_isauthenticated(settings):
-    perms = settings.REST_FRAMEWORK.get("DEFAULT_PERMISSION_CLASSES", [])
+def test_drf_defaults_are_secure_by_default(settings):
+    framework = settings.REST_FRAMEWORK
+    perms = framework.get("DEFAULT_PERMISSION_CLASSES", [])
+    auths = framework.get("DEFAULT_AUTHENTICATION_CLASSES", [])
     assert "rest_framework.permissions.IsAuthenticated" in perms
     assert "rest_framework.permissions.AllowAny" not in perms
+    assert "app.auth.authentication.CombinedJWTAuthentication" in auths
 
 
 def test_health_check_allows_anonymous(auth_client):
@@ -22,14 +28,28 @@ def test_health_check_allows_anonymous(auth_client):
     assert resp.json()["status"] == "ok"
 
 
-def test_public_box_categories_allows_anonymous(auth_client):
+def test_public_box_categories_allows_anonymous(auth_client, settings, tmp_path):
+    """AllowAny on NodeCategoryListView keeps the public endpoint reachable.
+
+    Point MEDIA_ROOT at a tmp dir and pre-create category folders + default
+    .settings files so the view exercises its success path (returns 200 with
+    a categories list) rather than just any non-401.
+    """
+    from app.box.models import NODE_CATEGORIES
+
+    settings.MEDIA_ROOT = str(tmp_path)
+    for cat, _label in NODE_CATEGORIES:
+        cat_dir = tmp_path / cat
+        cat_dir.mkdir()
+        (cat_dir / ".settings").write_text(json.dumps({"color": "#6b46c1"}))
+
     client = auth_client()
     resp = client.get(reverse("box:node-categories"))
-    # The view may hit the filesystem and fail; the contract here is only
-    # "not 401" — the explicit AllowAny on NodeCategoryListView must hold.
-    assert resp.status_code != 401, (
-        "box:node-categories must remain publicly readable."
-    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert isinstance(body.get("categories"), list)
+    assert body.get("default") == "analysis"
 
 
 def test_protected_workflow_list_rejects_anonymous(auth_client):


### PR DESCRIPTION
Flip DEFAULT_PERMISSION_CLASSES from AllowAny to IsAuthenticated and default DEFAULT_AUTHENTICATION_CLASSES to CombinedJWTAuthentication so future DRF views are protected by default. All existing views already declare permission_classes explicitly, so runtime behavior is unchanged.

Add explicit @authentication_classes([]) + @permission_classes([AllowAny]) to health_check, which was @api_view-decorated with no permission override and would have started returning 401 after the default flip.

Add tests/test_permissions_default.py covering: default setting, public health_check, public box:node-categories, anonymous 401 on workflow list, authenticated 200 on workflow list.