### PR TITLE
Remove destructive MCP tools delete_project and delete_python_file (closes #23)

### DIFF
--- a/gui/mcp_server/workflow_mcp.py
+++ b/gui/mcp_server/workflow_mcp.py
@@ -190,23 +190,6 @@ async def update_project(workflow_id: str, payload: dict) -> dict[str, Any]:
     return {"status": "success", "project": data}
 
 
-@mcp.tool()
-async def delete_project(workflow_id: str) -> dict[str, Any]:
-    """Soft-delete a workflow project by marking it inactive (is_active=False).
-
-    The project and its associated nodes/edges are preserved in the database
-    but excluded from list queries.
-
-    Args:
-        workflow_id: UUID of the project to delete.
-    """
-    url = f"{DJANGO_API_URL}/workflow/{workflow_id}/"
-    data = await _make_delete_request(url)
-    if data is None:
-        return {"status": "error", "error": f"Failed to delete project {workflow_id}"}
-    return {"status": "success", "result": data}
-
-
 # Flow endpoints
 @mcp.tool()
 async def get_flow(workflow_id: str) -> dict[str, Any]:
@@ -795,23 +778,6 @@ async def get_python_file(pk: str) -> dict[str, Any]:
     if data is None:
         return {"status": "error", "error": f"Failed to fetch python file {pk}"}
     return {"status": "success", "file": data}
-
-
-@mcp.tool()
-async def delete_python_file(pk: str) -> dict[str, Any]:
-    """Soft-delete an uploaded Python file by marking it inactive.
-
-    Sets is_active=False and removes the file from the filesystem.
-    Only the file owner can perform this operation. Returns 204 on success.
-
-    Args:
-        pk: UUID primary key of the file to delete.
-    """
-    url = f"{DJANGO_API_URL}/box/files/{pk}/"
-    data = await _make_delete_request(url)
-    if data is None:
-        return {"status": "error", "error": f"Failed to delete python file {pk}"}
-    return {"status": "success", "result": data}
 
 
 # list of node definitions


### PR DESCRIPTION
## Summary
- Drops `delete_project` and `delete_python_file` from the MCP tool surface in `gui/mcp_server/workflow_mcp.py` so an LLM agent can no longer reach those code paths.
- Closes #23: an MCP agent had invoked DELETE tools and removed user workflows; the LLM cannot delete what it cannot see.
- UI-initiated DELETE through the Django REST endpoints (`/api/workflow/{id}/`, `/api/box/files/{pk}/`) is untouched, so the human-driven delete flows behind `DeleteConfirmDialog` keep working.
- `delete_node` and `delete_edge` are intentionally retained — their impact is granular and easily recoverable by re-creating the node or edge in the editor, and removing them would gut the agent's ability to refactor a flow.

## Test plan
- [ ] `docker-compose up --build mcp` starts cleanly (no syntax / import errors).
- [ ] `tools/list` JSON-RPC against `http://localhost:8001/mcp` returns the tool list **without** `delete_project` and `delete_python_file`, while `delete_node` and `delete_edge` are still present.
- [ ] In the chat UI, asking the agent to "delete project X" results in the agent reporting that no such tool exists (instead of issuing a DELETE).
- [ ] Project deletion from the home view via the 3-dot menu → `DeleteConfirmDialog` still succeeds and removes the project from the list.
- [ ] Python file deletion from the file UI still succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)