### PR TITLE
Remove @username suffix from project dropdown (closes #22)

### DIFF
--- a/gui/workflow_frontend/src/views/home/components/projectSelector.tsx
+++ b/gui/workflow_frontend/src/views/home/components/projectSelector.tsx
@@ -477,18 +477,12 @@ export const ProjectSelector = ({
               marginTop={2}
             >
               {projects.map(project => {
-                const ownerLabel = project.is_owned_by_me
-                  ? ''
-                  : project.owner?.username
-                  ? ` · @${project.owner.username}`
-                  : '';
                 const visLabel =
                   project.visibility === 'public' ? ' (Public)' : '';
                 return (
                   <option key={project.id} value={project.id} style={{ color: '#2D3748' }}>
                     {project.name}
                     {visLabel}
-                    {ownerLabel}
                   </option>
                 );
               })}


### PR DESCRIPTION
## Summary
- Drop the ` · @username` owner suffix from each option in the home view's project selection dropdown to address #22 (confusion over workflow attribution).
- Keep the ` (Public)` visibility hint and the underlying API/type fields (`owner`, `is_owned_by_me`) intact for future owner-filter UI.

## Test plan
- [ ] `cd gui && docker-compose up`, sign in, and open the project dropdown on the home view.
- [ ] Verify own projects still render as `Project Name`.
- [ ] Verify shared public projects render as `Project Name (Public)` (no ` · @username`).
- [ ] Verify shared private projects render as `Project Name` only.
- [ ] Confirm selecting a project still opens it (no change to `onProjectChange`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)