### PR TITLE
Surface re-auth modal before redirecting on session expiry

### DIFF
--- a/gui/workflow_frontend/src/api/apiInterceptors.ts
+++ b/gui/workflow_frontend/src/api/apiInterceptors.ts
@@ -1,4 +1,4 @@
-import { authService } from "../auth/authService";
+import { reAuthBus } from "../auth/reAuthBus";
 import { createAuthHeaders } from "./authHeaders";
 import { isDebugMode } from "./config";
 
@@ -27,14 +27,7 @@ export const onResponse = async (response: Response): Promise<Response> => {
 
   if (response.status === 401) {
     console.warn("Unauthorized - token may be expired");
-    try {
-      await authService.signOut();
-      if (typeof window !== "undefined") {
-        window.location.href = "/login";
-      }
-    } catch (error) {
-      console.error("Error during automatic logout:", error);
-    }
+    reAuthBus.emit("api-401");
   }
 
   if (response.status === 403) {

--- a/gui/workflow_frontend/src/auth/ReAuthGate.tsx
+++ b/gui/workflow_frontend/src/auth/ReAuthGate.tsx
@@ -1,0 +1,154 @@
+import { useCallback, useState } from 'react';
+import {
+  Alert,
+  AlertDescription,
+  AlertIcon,
+  AlertTitle,
+  Button,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+  UnorderedList,
+  ListItem,
+  VStack,
+} from '@chakra-ui/react';
+import { useAuth } from './authContext';
+import { getKeycloak } from './keycloak';
+
+const ReAuthGate = () => {
+  const {
+    reAuthRequired,
+    reAuthReason,
+    hasPendingSaves,
+    runController,
+    flushPendingSaves,
+  } = useAuth();
+
+  const [isWorking, setIsWorking] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  const isRunning = !!runController?.isRunning;
+
+  const goToLogin = useCallback(() => {
+    // Bypass our wrapped signIn (which toggles loading state). Direct kc.login()
+    // navigates the browser to Keycloak; React state after this is irrelevant.
+    getKeycloak().login();
+  }, []);
+
+  const handlePrimary = useCallback(async () => {
+    setErrorMsg(null);
+    setIsWorking(true);
+    try {
+      if (isRunning) {
+        runController?.abort();
+      }
+      if (hasPendingSaves) {
+        await flushPendingSaves();
+      }
+      goToLogin();
+    } catch (err) {
+      console.error('Re-auth flush failed:', err);
+      setErrorMsg(
+        err instanceof Error
+          ? `Failed to save before re-login: ${err.message}`
+          : 'Failed to save before re-login.'
+      );
+      setIsWorking(false);
+    }
+  }, [isRunning, runController, hasPendingSaves, flushPendingSaves, goToLogin]);
+
+  const handleSecondary = useCallback(() => {
+    // Discard pending work and proceed to login immediately.
+    goToLogin();
+  }, [goToLogin]);
+
+  let primaryLabel = 'Re-login';
+  if (isRunning) {
+    primaryLabel = 'Abort & re-login';
+  } else if (hasPendingSaves) {
+    primaryLabel = 'Save & re-login';
+  }
+
+  const showSecondary = isRunning || hasPendingSaves;
+
+  const reasonText =
+    reAuthReason === 'api-401'
+      ? 'The server rejected the request (401). Your session may have expired.'
+      : 'Your session has expired.';
+
+  return (
+    <Modal
+      isOpen={reAuthRequired}
+      onClose={() => {
+        /* prevent close via overlay/Esc; user must pick a button */
+      }}
+      closeOnEsc={false}
+      closeOnOverlayClick={false}
+      isCentered
+      size="md"
+    >
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Session expired</ModalHeader>
+        <ModalBody>
+          <VStack align="stretch" spacing={3}>
+            <Text>{reasonText}</Text>
+            {(isRunning || hasPendingSaves) && (
+              <Alert status="warning" variant="left-accent" borderRadius="md">
+                <AlertIcon />
+                <VStack align="start" spacing={1}>
+                  <AlertTitle fontSize="sm">Save before signing back in</AlertTitle>
+                  <AlertDescription fontSize="sm">
+                    <UnorderedList spacing={1} pl={3}>
+                      {isRunning && (
+                        <ListItem>
+                          A workflow run is in progress and will be aborted if you re-login now.
+                        </ListItem>
+                      )}
+                      {hasPendingSaves && (
+                        <ListItem>
+                          Unsaved changes on the canvas may be lost.
+                        </ListItem>
+                      )}
+                    </UnorderedList>
+                  </AlertDescription>
+                </VStack>
+              </Alert>
+            )}
+            {errorMsg && (
+              <Alert status="error" borderRadius="md">
+                <AlertIcon />
+                <AlertDescription fontSize="sm">{errorMsg}</AlertDescription>
+              </Alert>
+            )}
+          </VStack>
+        </ModalBody>
+        <ModalFooter gap={2}>
+          {showSecondary && (
+            <Button
+              variant="ghost"
+              onClick={handleSecondary}
+              isDisabled={isWorking}
+            >
+              Sign in now (discard)
+            </Button>
+          )}
+          <Button
+            colorScheme="blue"
+            onClick={handlePrimary}
+            isLoading={isWorking}
+            loadingText={hasPendingSaves ? 'Saving...' : 'Working...'}
+          >
+            {primaryLabel}
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default ReAuthGate;

--- a/gui/workflow_frontend/src/auth/authContext.tsx
+++ b/gui/workflow_frontend/src/auth/authContext.tsx
@@ -1,6 +1,12 @@
-import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import React, { createContext, useCallback, useContext, useEffect, useRef, useState, ReactNode } from 'react';
 import { authService } from './authService';
+import { reAuthBus, ReAuthReason } from './reAuthBus';
 import { User, AuthResult } from './types';
+
+export type RunController = {
+  isRunning: boolean;
+  abort: () => void;
+};
 
 interface AuthContextType {
   user: User | null;
@@ -8,6 +14,16 @@ interface AuthContextType {
   signUp: () => Promise<AuthResult>;
   signIn: () => Promise<AuthResult>;
   signOut: () => Promise<AuthResult>;
+  // Re-auth modal coordination
+  reAuthRequired: boolean;
+  reAuthReason: ReAuthReason | null;
+  dismissReAuth: () => void;
+  hasPendingSaves: boolean;
+  setHasPendingSaves: (v: boolean) => void;
+  registerSaveFlusher: (fn: (() => Promise<void>) | null) => void;
+  registerRunController: (ctrl: RunController | null) => void;
+  flushPendingSaves: () => Promise<void>;
+  runController: RunController | null;
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined);
@@ -19,6 +35,18 @@ interface AuthProviderProps {
 export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
   const [user, setUser] = useState<User | null>(null);
   const [loading, setLoading] = useState(true);
+
+  const [reAuthRequired, setReAuthRequired] = useState(false);
+  const [reAuthReason, setReAuthReason] = useState<ReAuthReason | null>(null);
+  const [hasPendingSaves, setHasPendingSaves] = useState(false);
+  const [runController, setRunController] = useState<RunController | null>(null);
+
+  const saveFlusherRef = useRef<(() => Promise<void>) | null>(null);
+  const reAuthRequiredRef = useRef(false);
+
+  useEffect(() => {
+    reAuthRequiredRef.current = reAuthRequired;
+  }, [reAuthRequired]);
 
   useEffect(() => {
     const init = async () => {
@@ -54,6 +82,37 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     };
   }, []);
 
+  // Subscribe to re-auth events from authService / apiInterceptors
+  useEffect(() => {
+    const unsubscribe = reAuthBus.subscribe((reason) => {
+      // Suppress repeated emits while the modal is already up (avoids 401 loops)
+      if (reAuthRequiredRef.current) return;
+      setReAuthReason(reason);
+      setReAuthRequired(true);
+    });
+    return unsubscribe;
+  }, []);
+
+  const dismissReAuth = useCallback(() => {
+    setReAuthRequired(false);
+    setReAuthReason(null);
+  }, []);
+
+  const registerSaveFlusher = useCallback((fn: (() => Promise<void>) | null) => {
+    saveFlusherRef.current = fn;
+  }, []);
+
+  const registerRunController = useCallback((ctrl: RunController | null) => {
+    setRunController(ctrl);
+  }, []);
+
+  const flushPendingSaves = useCallback(async () => {
+    const fn = saveFlusherRef.current;
+    if (fn) {
+      await fn();
+    }
+  }, []);
+
   const signUp = async () => {
     setLoading(true);
     try {
@@ -81,7 +140,22 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     }
   };
 
-  const value = { user, loading, signUp, signIn, signOut };
+  const value: AuthContextType = {
+    user,
+    loading,
+    signUp,
+    signIn,
+    signOut,
+    reAuthRequired,
+    reAuthReason,
+    dismissReAuth,
+    hasPendingSaves,
+    setHasPendingSaves,
+    registerSaveFlusher,
+    registerRunController,
+    flushPendingSaves,
+    runController,
+  };
 
   return (
     <AuthContext.Provider value={value}>

--- a/gui/workflow_frontend/src/auth/authContext.tsx
+++ b/gui/workflow_frontend/src/auth/authContext.tsx
@@ -43,18 +43,10 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   const saveFlusherRef = useRef<(() => Promise<void>) | null>(null);
   const reAuthRequiredRef = useRef(false);
-  const signOutTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     reAuthRequiredRef.current = reAuthRequired;
   }, [reAuthRequired]);
-
-  const cancelPendingSignOut = useCallback(() => {
-    if (signOutTimerRef.current !== null) {
-      clearTimeout(signOutTimerRef.current);
-      signOutTimerRef.current = null;
-    }
-  }, []);
 
   useEffect(() => {
     const init = async () => {
@@ -76,23 +68,13 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     const { data: { subscription } } = authService.onAuthStateChange(
       (event, session) => {
         if (event === 'SIGNED_IN' && session?.user) {
-          cancelPendingSignOut();
           setUser(session.user);
         } else if (event === 'SIGNED_OUT') {
-          if (reAuthRequiredRef.current) return;
-          // keycloak-js fires onAuthLogout synchronously when it clears tokens
-          // after a refresh failure, while the matching reAuthBus.emit runs in
-          // the updateToken catch microtask immediately afterwards. Defer the
-          // user-null commit by one tick so the emit can suppress it; otherwise
-          // ProtectedRoute would redirect to /login and hide the modal.
-          cancelPendingSignOut();
-          signOutTimerRef.current = setTimeout(() => {
-            signOutTimerRef.current = null;
-            if (reAuthRequiredRef.current) return;
-            setUser(null);
-          }, 0);
+          // No-op: authService no longer forwards Keycloak's onAuthLogout, so
+          // refresh failures cannot wipe the user behind our backs. Explicit
+          // signOut() triggers a full browser redirect via kc.logout(), so
+          // React state cleanup is unnecessary either way.
         } else if (event === 'TOKEN_REFRESHED' && session?.user) {
-          cancelPendingSignOut();
           setUser(session.user);
         }
       }
@@ -100,24 +82,20 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
     return () => {
       subscription.unsubscribe();
-      cancelPendingSignOut();
     };
-  }, [cancelPendingSignOut]);
+  }, []);
 
   // Subscribe to re-auth events from authService / apiInterceptors
   useEffect(() => {
     const unsubscribe = reAuthBus.subscribe((reason) => {
       // Suppress repeated emits while the modal is already up (avoids 401 loops)
       if (reAuthRequiredRef.current) return;
-      // Set ref synchronously so a pending setTimeout(0) signout sees the
-      // updated value before React commits the state.
       reAuthRequiredRef.current = true;
-      cancelPendingSignOut();
       setReAuthReason(reason);
       setReAuthRequired(true);
     });
     return unsubscribe;
-  }, [cancelPendingSignOut]);
+  }, []);
 
   const dismissReAuth = useCallback(() => {
     setReAuthRequired(false);

--- a/gui/workflow_frontend/src/auth/authContext.tsx
+++ b/gui/workflow_frontend/src/auth/authContext.tsx
@@ -43,10 +43,18 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
   const saveFlusherRef = useRef<(() => Promise<void>) | null>(null);
   const reAuthRequiredRef = useRef(false);
+  const signOutTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     reAuthRequiredRef.current = reAuthRequired;
   }, [reAuthRequired]);
+
+  const cancelPendingSignOut = useCallback(() => {
+    if (signOutTimerRef.current !== null) {
+      clearTimeout(signOutTimerRef.current);
+      signOutTimerRef.current = null;
+    }
+  }, []);
 
   useEffect(() => {
     const init = async () => {
@@ -68,10 +76,23 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
     const { data: { subscription } } = authService.onAuthStateChange(
       (event, session) => {
         if (event === 'SIGNED_IN' && session?.user) {
+          cancelPendingSignOut();
           setUser(session.user);
         } else if (event === 'SIGNED_OUT') {
-          setUser(null);
+          if (reAuthRequiredRef.current) return;
+          // keycloak-js fires onAuthLogout synchronously when it clears tokens
+          // after a refresh failure, while the matching reAuthBus.emit runs in
+          // the updateToken catch microtask immediately afterwards. Defer the
+          // user-null commit by one tick so the emit can suppress it; otherwise
+          // ProtectedRoute would redirect to /login and hide the modal.
+          cancelPendingSignOut();
+          signOutTimerRef.current = setTimeout(() => {
+            signOutTimerRef.current = null;
+            if (reAuthRequiredRef.current) return;
+            setUser(null);
+          }, 0);
         } else if (event === 'TOKEN_REFRESHED' && session?.user) {
+          cancelPendingSignOut();
           setUser(session.user);
         }
       }
@@ -79,19 +100,24 @@ export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
 
     return () => {
       subscription.unsubscribe();
+      cancelPendingSignOut();
     };
-  }, []);
+  }, [cancelPendingSignOut]);
 
   // Subscribe to re-auth events from authService / apiInterceptors
   useEffect(() => {
     const unsubscribe = reAuthBus.subscribe((reason) => {
       // Suppress repeated emits while the modal is already up (avoids 401 loops)
       if (reAuthRequiredRef.current) return;
+      // Set ref synchronously so a pending setTimeout(0) signout sees the
+      // updated value before React commits the state.
+      reAuthRequiredRef.current = true;
+      cancelPendingSignOut();
       setReAuthReason(reason);
       setReAuthRequired(true);
     });
     return unsubscribe;
-  }, []);
+  }, [cancelPendingSignOut]);
 
   const dismissReAuth = useCallback(() => {
     setReAuthRequired(false);

--- a/gui/workflow_frontend/src/auth/authService.ts
+++ b/gui/workflow_frontend/src/auth/authService.ts
@@ -8,8 +8,13 @@ class AuthService {
   async init(): Promise<boolean> {
     const kc = getKeycloak();
     try {
+      // Use "check-sso" rather than "login-required" so that a failed
+      // updateToken() (refresh-token invalidated server-side) does not cause
+      // keycloak-js to auto-redirect the browser to the Keycloak login page.
+      // Unauthenticated states are handled by ProtectedRoute -> LoginView, and
+      // refresh failures are surfaced through reAuthBus -> ReAuthGate.
       return await kc.init({
-        onLoad: "login-required",
+        onLoad: "check-sso",
         checkLoginIframe: false,
       });
     } catch (err) {

--- a/gui/workflow_frontend/src/auth/authService.ts
+++ b/gui/workflow_frontend/src/auth/authService.ts
@@ -71,7 +71,13 @@ class AuthService {
       const user = await this.getCurrentUser();
       callback("SIGNED_IN", user ? { user } : null);
     };
-    kc.onAuthLogout = () => callback("SIGNED_OUT", null);
+    // Intentionally do not forward onAuthLogout. keycloak-js fires it both for
+    // explicit kc.logout() calls (which navigate the browser via signOut() and
+    // don't need React state cleanup) and after a failed refresh when it
+    // internally clears tokens — in the latter case wiping the user would make
+    // ProtectedRoute redirect to /login before the re-auth modal can render.
+    // Refresh-failure recovery flows exclusively through reAuthBus.
+    kc.onAuthLogout = () => {};
     kc.onAuthRefreshSuccess = async () => {
       const user = await this.getCurrentUser();
       callback("TOKEN_REFRESHED", user ? { user } : null);

--- a/gui/workflow_frontend/src/auth/authService.ts
+++ b/gui/workflow_frontend/src/auth/authService.ts
@@ -1,4 +1,5 @@
 import { getKeycloak } from "./keycloak";
+import { reAuthBus } from "./reAuthBus";
 import { AuthResult, User } from "./types";
 
 export type { AuthResult } from "./types";
@@ -52,7 +53,7 @@ class AuthService {
     try {
       await kc.updateToken(30);
     } catch {
-      kc.login();
+      reAuthBus.emit("refresh-failed");
       return null;
     }
     return kc.token ?? null;
@@ -76,7 +77,7 @@ class AuthService {
       callback("TOKEN_REFRESHED", user ? { user } : null);
     };
     kc.onTokenExpired = () => {
-      kc.updateToken(30).catch(() => callback("SIGNED_OUT", null));
+      kc.updateToken(30).catch(() => reAuthBus.emit("refresh-failed"));
     };
     return {
       data: {

--- a/gui/workflow_frontend/src/auth/reAuthBus.ts
+++ b/gui/workflow_frontend/src/auth/reAuthBus.ts
@@ -1,0 +1,23 @@
+export type ReAuthReason = "refresh-failed" | "api-401";
+
+type Listener = (reason: ReAuthReason) => void;
+
+let listeners: Listener[] = [];
+
+export const reAuthBus = {
+  emit(reason: ReAuthReason) {
+    listeners.forEach((fn) => {
+      try {
+        fn(reason);
+      } catch (err) {
+        console.error("reAuthBus listener error:", err);
+      }
+    });
+  },
+  subscribe(fn: Listener): () => void {
+    listeners.push(fn);
+    return () => {
+      listeners = listeners.filter((l) => l !== fn);
+    };
+  },
+};

--- a/gui/workflow_frontend/src/router.tsx
+++ b/gui/workflow_frontend/src/router.tsx
@@ -4,11 +4,13 @@ import Header from './shared/header/header';
 import LoginView from './views/login/loginView';
 import ProtectedRoute from './protectedRoute';
 import { AuthProvider } from './auth/authContext';
+import ReAuthGate from './auth/ReAuthGate';
 import TabManager from './components/tabs/TabManager';
 
 function Router() {
   return (
     <AuthProvider>
+      <ReAuthGate />
       <BrowserRouter>
         <Routes>
           {/* Login page (no authentication required) */}

--- a/gui/workflow_frontend/src/views/home/components/projectSelector.tsx
+++ b/gui/workflow_frontend/src/views/home/components/projectSelector.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from 'react';
+import { useEffect, useState, useCallback, useRef } from 'react';
 import { HpcTarget, Project, Visibility } from '../type'
 import {
   HStack,
@@ -28,6 +28,7 @@ import {
 import { CheckIcon, WarningIcon, DeleteIcon, EditIcon } from '@chakra-ui/icons';
 import { FiMenu, FiPlay } from 'react-icons/fi';
 import { useTabContext } from '../../../components/tabs/TabManager';
+import { useAuth } from '../../../auth/authContext';
 import { createAuthHeaders } from '../../../api/authHeaders';
 import LogViewModal, { LogEntry } from "./logViewModal";
 import { runWorkflowStream } from '../../../api/workflowRunApi';
@@ -74,6 +75,20 @@ export const ProjectSelector = ({
   const [isRunning, setIsRunning] = useState<boolean>(false);
   const [runStatus, setRunStatus] = useState<"idle" | "running" | "ok" | "error">("idle");
   const abortControllerRef = useRef<AbortController | null>(null);
+  const { registerRunController } = useAuth();
+
+  useEffect(() => {
+    registerRunController({
+      isRunning,
+      abort: () => {
+        abortControllerRef.current?.abort();
+        abortControllerRef.current = null;
+        setIsRunning(false);
+        setRunStatus("idle");
+      },
+    });
+    return () => registerRunController(null);
+  }, [isRunning, registerRunController]);
 
   // Helper functions for API communication
   const createAuthHeadersLocal = async () => {

--- a/gui/workflow_frontend/src/views/home/homeView.tsx
+++ b/gui/workflow_frontend/src/views/home/homeView.tsx
@@ -51,7 +51,7 @@ import { convertToStrIncFloat } from '../../utils/typeConversion';
 
 const HomeView = () => {
   const toast = useToast();
-  const { user } = useAuth();
+  const { user, setHasPendingSaves, registerSaveFlusher } = useAuth();
   const currentUserId = user?.id ?? null;
   const prevUserIdRef = useRef<string | null | undefined>(undefined);
   const { data: uploadedNodes, isLoading: isNodesLoading, error, refetch: refetchNodes } = useUploadedNodes();
@@ -66,6 +66,7 @@ const HomeView = () => {
   const [isConnected, setIsConnected] = useState<boolean>(true);
   const [autoSaveEnabled, setAutoSaveEnabled] = useState<boolean>(true);
   const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+  const pendingActionRef = useRef<(() => Promise<void>) | null>(null);
   const refreshTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const updateNodeAPIRef = useRef<(nodeId: string, nodeData: Partial<Node<CalculationNodeData>>) => Promise<void>>();
 
@@ -198,10 +199,43 @@ const HomeView = () => {
       clearTimeout(saveTimeoutRef.current);
     }
 
+    pendingActionRef.current = action;
+    setHasPendingSaves(true);
+
     saveTimeoutRef.current = setTimeout(async () => {
-      await action();
+      saveTimeoutRef.current = null;
+      pendingActionRef.current = null;
+      try {
+        await action();
+      } finally {
+        setHasPendingSaves(false);
+      }
     }, 500);
-  }, []);
+  }, [setHasPendingSaves]);
+
+  // Flush any debounced save immediately. Called by the re-auth modal before redirecting.
+  const flushPendingSaves = useCallback(async () => {
+    if (saveTimeoutRef.current) {
+      clearTimeout(saveTimeoutRef.current);
+      saveTimeoutRef.current = null;
+    }
+    const action = pendingActionRef.current;
+    pendingActionRef.current = null;
+    if (action) {
+      try {
+        await action();
+      } finally {
+        setHasPendingSaves(false);
+      }
+    } else {
+      setHasPendingSaves(false);
+    }
+  }, [setHasPendingSaves]);
+
+  useEffect(() => {
+    registerSaveFlusher(flushPendingSaves);
+    return () => registerSaveFlusher(null);
+  }, [flushPendingSaves, registerSaveFlusher]);
 
   const handleNodeUpdate = useCallback((nodeId: string, updatedData: Partial<CalculationNodeData>) => {
     console.log('handleNodeUpdate called for node:', nodeId, 'with data:', updatedData);

--- a/gui/workflow_frontend/src/views/home/homeView.tsx
+++ b/gui/workflow_frontend/src/views/home/homeView.tsx
@@ -67,6 +67,7 @@ const HomeView = () => {
   const [autoSaveEnabled, setAutoSaveEnabled] = useState<boolean>(true);
   const saveTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const pendingActionRef = useRef<(() => Promise<void>) | null>(null);
+  const inFlightSaveRef = useRef<Promise<void> | null>(null);
   const refreshTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const updateNodeAPIRef = useRef<(nodeId: string, nodeData: Partial<Node<CalculationNodeData>>) => Promise<void>>();
 
@@ -188,6 +189,46 @@ const HomeView = () => {
     }
   }, [sharedNodes, onViewOpen, reactFlowInstance, toast]);
 
+  // Clear the dirty flag only when nothing is queued, scheduled, or in flight.
+  // Prevents an in-flight save's `finally` from clearing the flag while a newer
+  // debounced save is already queued behind it.
+  const maybeClearPendingState = useCallback(() => {
+    if (
+      saveTimeoutRef.current === null &&
+      pendingActionRef.current === null &&
+      inFlightSaveRef.current === null
+    ) {
+      setHasPendingSaves(false);
+    }
+  }, [setHasPendingSaves]);
+
+  // Consume whatever is in pendingActionRef and run it, tracking the promise so
+  // flushPendingSaves can await an already-running save.
+  const runPendingAction = useCallback(async () => {
+    const action = pendingActionRef.current;
+    pendingActionRef.current = null;
+    if (!action) {
+      maybeClearPendingState();
+      return;
+    }
+    const promise = (async () => {
+      try {
+        await action();
+      } catch (err) {
+        console.error("Pending save failed:", err);
+      }
+    })();
+    inFlightSaveRef.current = promise;
+    try {
+      await promise;
+    } finally {
+      if (inFlightSaveRef.current === promise) {
+        inFlightSaveRef.current = null;
+      }
+      maybeClearPendingState();
+    }
+  }, [maybeClearPendingState]);
+
   // Debounced Storage Function
   const debouncedSave = useCallback((action: () => Promise<void>) => {
     if (useFlowStore.getState().flowRefreshInProgress ||
@@ -202,35 +243,33 @@ const HomeView = () => {
     pendingActionRef.current = action;
     setHasPendingSaves(true);
 
-    saveTimeoutRef.current = setTimeout(async () => {
+    saveTimeoutRef.current = setTimeout(() => {
       saveTimeoutRef.current = null;
-      pendingActionRef.current = null;
-      try {
-        await action();
-      } finally {
-        setHasPendingSaves(false);
-      }
+      void runPendingAction();
     }, 500);
-  }, [setHasPendingSaves]);
+  }, [setHasPendingSaves, runPendingAction]);
 
-  // Flush any debounced save immediately. Called by the re-auth modal before redirecting.
+  // Flush any debounced or in-flight save immediately. Called by the re-auth
+  // modal before redirecting. Loops so a save queued during the wait is also
+  // drained before we return.
   const flushPendingSaves = useCallback(async () => {
     if (saveTimeoutRef.current) {
       clearTimeout(saveTimeoutRef.current);
       saveTimeoutRef.current = null;
     }
-    const action = pendingActionRef.current;
-    pendingActionRef.current = null;
-    if (action) {
-      try {
-        await action();
-      } finally {
-        setHasPendingSaves(false);
+    while (pendingActionRef.current || inFlightSaveRef.current) {
+      if (pendingActionRef.current) {
+        await runPendingAction();
+      } else if (inFlightSaveRef.current) {
+        try {
+          await inFlightSaveRef.current;
+        } catch {
+          // Already logged inside runPendingAction.
+        }
       }
-    } else {
-      setHasPendingSaves(false);
     }
-  }, [setHasPendingSaves]);
+    maybeClearPendingState();
+  }, [runPendingAction, maybeClearPendingState]);
 
   useEffect(() => {
     registerSaveFlusher(flushPendingSaves);

--- a/gui/workflow_frontend/src/views/home/homeView.tsx
+++ b/gui/workflow_frontend/src/views/home/homeView.tsx
@@ -203,7 +203,10 @@ const HomeView = () => {
   }, [setHasPendingSaves]);
 
   // Consume whatever is in pendingActionRef and run it, tracking the promise so
-  // flushPendingSaves can await an already-running save.
+  // flushPendingSaves can await an already-running save. The promise stored on
+  // inFlightSaveRef rejects when the action rejects, so callers (flush path)
+  // can surface the failure; we also log here so debounce-driven errors are
+  // not silently lost.
   const runPendingAction = useCallback(async () => {
     const action = pendingActionRef.current;
     pendingActionRef.current = null;
@@ -211,13 +214,7 @@ const HomeView = () => {
       maybeClearPendingState();
       return;
     }
-    const promise = (async () => {
-      try {
-        await action();
-      } catch (err) {
-        console.error("Pending save failed:", err);
-      }
-    })();
+    const promise = action();
     inFlightSaveRef.current = promise;
     try {
       await promise;
@@ -245,13 +242,18 @@ const HomeView = () => {
 
     saveTimeoutRef.current = setTimeout(() => {
       saveTimeoutRef.current = null;
-      void runPendingAction();
+      // Swallow errors on the debounce path so a transient save failure does
+      // not turn into an unhandled rejection. The flush path re-throws.
+      runPendingAction().catch((err) => {
+        console.error("Debounced save failed:", err);
+      });
     }, 500);
   }, [setHasPendingSaves, runPendingAction]);
 
   // Flush any debounced or in-flight save immediately. Called by the re-auth
   // modal before redirecting. Loops so a save queued during the wait is also
-  // drained before we return.
+  // drained before we return. Rejects if any save fails so the modal can show
+  // an error and keep the user from being redirected onto a lost write.
   const flushPendingSaves = useCallback(async () => {
     if (saveTimeoutRef.current) {
       clearTimeout(saveTimeoutRef.current);
@@ -261,20 +263,29 @@ const HomeView = () => {
       if (pendingActionRef.current) {
         await runPendingAction();
       } else if (inFlightSaveRef.current) {
-        try {
-          await inFlightSaveRef.current;
-        } catch {
-          // Already logged inside runPendingAction.
-        }
+        await inFlightSaveRef.current;
       }
     }
     maybeClearPendingState();
   }, [runPendingAction, maybeClearPendingState]);
 
+  // Register the flusher with AuthContext, and on unmount also reset any
+  // pending-save bookkeeping. Otherwise a stale hasPendingSaves=true could
+  // outlive HomeView and make ReAuthGate offer "Save & re-login" with no
+  // flusher available to actually save.
   useEffect(() => {
     registerSaveFlusher(flushPendingSaves);
-    return () => registerSaveFlusher(null);
-  }, [flushPendingSaves, registerSaveFlusher]);
+    return () => {
+      registerSaveFlusher(null);
+      if (saveTimeoutRef.current) {
+        clearTimeout(saveTimeoutRef.current);
+        saveTimeoutRef.current = null;
+      }
+      pendingActionRef.current = null;
+      inFlightSaveRef.current = null;
+      setHasPendingSaves(false);
+    };
+  }, [flushPendingSaves, registerSaveFlusher, setHasPendingSaves]);
 
   const handleNodeUpdate = useCallback((nodeId: string, updatedData: Partial<CalculationNodeData>) => {
     console.log('handleNodeUpdate called for node:', nodeId, 'with data:', updatedData);


### PR DESCRIPTION
## Summary

Closes #20.

- Previously, a failed Keycloak token refresh (`getAccessToken` or `onTokenExpired`) or a 401 API response triggered an immediate `kc.login()` redirect, discarding unsaved workflow state and aborting any in-flight simulation without warning.
- All three paths now emit through a small pub/sub bus (`reAuthBus`) to the `AuthContext`, which opens a blocking modal (`ReAuthGate`) letting the user save pending changes or abort a running workflow before re-logging in.
- `homeView` registers a flush function so the modal can immediately persist any debounced node/edge save; `projectSelector` registers an abort controller so the modal can cancel an SSE workflow run. Repeat emits are suppressed while the modal is open to avoid 401 loops.

## Test plan

- [ ] Trigger expiry via Keycloak Admin Console → Sessions → Logout user, then perform any UI action → modal opens
- [ ] dirty + idle: move a node, immediately invalidate the session → "Save & re-login" persists the change before redirect
- [ ] pristine + idle: no edits, invalidate session → "Re-login" button only
- [ ] running: start a workflow run, invalidate session → "Abort & re-login" cancels SSE and redirects
- [ ] Verify modal cannot be dismissed by Esc/overlay click

## Notes

- The 401 interceptor path only fires for aspida-routed requests (`apiManager.ts`). Direct `fetch()` callers still rely on the `getAccessToken` refresh-failure path to surface the modal — if refresh succeeds but the server still 401s, that case is not yet covered. Logged for follow-up if it becomes a problem in practice.
- JupyterHub kernel reconnect remains out of scope (per issue #20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)