### PR TITLE
Stop re-rendering HomeView tree on every node drag frame

### DIFF
--- a/gui/workflow_frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/gui/workflow_frontend/src/hooks/useKeyboardShortcuts.ts
@@ -1,8 +1,7 @@
 import { useEffect } from 'react';
-import { Node, Edge } from '@xyflow/react';
+import { Edge } from '@xyflow/react';
 import { useToast } from '@chakra-ui/react';
-import { CalculationNodeData } from '../views/home/type';
-import { useFlowStore, FlowStore } from '../stores/flowStore';
+import { useFlowStore } from '../stores/flowStore';
 
 interface UseKeyboardShortcutsParams {
   toast: ReturnType<typeof useToast>;
@@ -40,20 +39,20 @@ export const useKeyboardShortcuts = ({
       }
 
       if (event.key === 'Delete' || event.key === 'Backspace') {
-        const { sharedNodes, sharedEdges, setSharedEdges } = useFlowStore.getState() as FlowStore;
+        const { sharedNodes, sharedEdges, setSharedEdges } = useFlowStore.getState();
 
-        const selectedNodes = sharedNodes.filter((node: Node<CalculationNodeData>) => node.selected);
+        const selectedNodes = sharedNodes.filter(node => node.selected);
         if (selectedNodes.length > 0) {
           event.preventDefault();
-          onRequestDeleteNodes(selectedNodes.map((node: Node<CalculationNodeData>) => node.id));
+          onRequestDeleteNodes(selectedNodes.map(node => node.id));
           return;
         }
 
-        const selectedEdges = sharedEdges.filter((edge: Edge) => edge.selected);
+        const selectedEdges = sharedEdges.filter(edge => edge.selected);
         if (selectedEdges.length > 0) {
           event.preventDefault();
           if (autoSaveEnabled) {
-            selectedEdges.forEach((edge: Edge) => {
+            selectedEdges.forEach(edge => {
               deleteEdgeAPI(edge.id);
             });
           }

--- a/gui/workflow_frontend/src/hooks/useKeyboardShortcuts.ts
+++ b/gui/workflow_frontend/src/hooks/useKeyboardShortcuts.ts
@@ -2,12 +2,9 @@ import { useEffect } from 'react';
 import { Node, Edge } from '@xyflow/react';
 import { useToast } from '@chakra-ui/react';
 import { CalculationNodeData } from '../views/home/type';
+import { useFlowStore, FlowStore } from '../stores/flowStore';
 
 interface UseKeyboardShortcutsParams {
-  sharedNodes: Node<CalculationNodeData>[];
-  sharedEdges: Edge[];
-  setSharedNodes: (updater: Node<CalculationNodeData>[] | ((nds: Node<CalculationNodeData>[]) => Node<CalculationNodeData>[])) => void;
-  setSharedEdges: (updater: Edge[] | ((eds: Edge[]) => Edge[])) => void;
   toast: ReturnType<typeof useToast>;
   autoSaveEnabled: boolean;
   isViewOpen: boolean;
@@ -16,11 +13,11 @@ interface UseKeyboardShortcutsParams {
   deleteEdgeAPI: (edgeId: string) => Promise<void>;
 }
 
+// Reads the latest sharedNodes/sharedEdges from the Zustand store inside the
+// keydown handler so callers do not need to subscribe at their level. A
+// HomeView-level subscription would re-render the whole tree on every drag
+// frame.
 export const useKeyboardShortcuts = ({
-  sharedNodes,
-  sharedEdges,
-  setSharedNodes,
-  setSharedEdges,
   toast,
   autoSaveEnabled,
   isViewOpen,
@@ -43,18 +40,20 @@ export const useKeyboardShortcuts = ({
       }
 
       if (event.key === 'Delete' || event.key === 'Backspace') {
-        const selectedNodes = sharedNodes.filter(node => node.selected);
+        const { sharedNodes, sharedEdges, setSharedEdges } = useFlowStore.getState() as FlowStore;
+
+        const selectedNodes = sharedNodes.filter((node: Node<CalculationNodeData>) => node.selected);
         if (selectedNodes.length > 0) {
           event.preventDefault();
-          onRequestDeleteNodes(selectedNodes.map(node => node.id));
+          onRequestDeleteNodes(selectedNodes.map((node: Node<CalculationNodeData>) => node.id));
           return;
         }
 
-        const selectedEdges = sharedEdges.filter(edge => edge.selected);
+        const selectedEdges = sharedEdges.filter((edge: Edge) => edge.selected);
         if (selectedEdges.length > 0) {
           event.preventDefault();
           if (autoSaveEnabled) {
-            selectedEdges.forEach(edge => {
+            selectedEdges.forEach((edge: Edge) => {
               deleteEdgeAPI(edge.id);
             });
           }
@@ -75,7 +74,7 @@ export const useKeyboardShortcuts = ({
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
     };
-  }, [sharedNodes, sharedEdges, setSharedNodes, setSharedEdges, toast, autoSaveEnabled, isViewOpen, isCodeOpen, onRequestDeleteNodes, deleteEdgeAPI]);
+  }, [toast, autoSaveEnabled, isViewOpen, isCodeOpen, onRequestDeleteNodes, deleteEdgeAPI]);
 };
 
 export default useKeyboardShortcuts;

--- a/gui/workflow_frontend/src/views/home/WorkflowToolbar.tsx
+++ b/gui/workflow_frontend/src/views/home/WorkflowToolbar.tsx
@@ -10,7 +10,7 @@ import {
 import { ViewIcon } from '@chakra-ui/icons';
 import { FiMenu } from 'react-icons/fi';
 import { Project } from './type';
-import { useFlowStore, FlowStore } from '../../stores/flowStore';
+import { useFlowStore } from '../../stores/flowStore';
 
 interface WorkflowToolbarProps {
   isIslandCodeOpen: boolean;
@@ -40,7 +40,7 @@ export const WorkflowToolbar: React.FC<WorkflowToolbarProps> = ({
   // Subscribe only to the node count, not the full sharedNodes array, so the
   // toolbar does not re-render on every drag frame. Length changes only when
   // nodes are added or removed.
-  const nodesCount = useFlowStore((state: FlowStore) => state.sharedNodes.length);
+  const nodesCount = useFlowStore(state => state.sharedNodes.length);
   return (
     <>
       <IconButton

--- a/gui/workflow_frontend/src/views/home/WorkflowToolbar.tsx
+++ b/gui/workflow_frontend/src/views/home/WorkflowToolbar.tsx
@@ -9,8 +9,8 @@ import {
 } from '@chakra-ui/react';
 import { ViewIcon } from '@chakra-ui/icons';
 import { FiMenu } from 'react-icons/fi';
-import { Node } from '@xyflow/react';
-import { CalculationNodeData, Project } from './type';
+import { Project } from './type';
+import { useFlowStore, FlowStore } from '../../stores/flowStore';
 
 interface WorkflowToolbarProps {
   isIslandCodeOpen: boolean;
@@ -19,7 +19,6 @@ interface WorkflowToolbarProps {
   autoSaveEnabled: boolean;
   selectedProject: string | null;
   projects: Project[];
-  sharedNodes: Node<CalculationNodeData>[];
   isGeneratingCode: boolean;
   handleOpenJupyter: () => void;
   handleGenerateCode: () => void;
@@ -33,12 +32,15 @@ export const WorkflowToolbar: React.FC<WorkflowToolbarProps> = ({
   autoSaveEnabled,
   selectedProject,
   projects,
-  sharedNodes,
   isGeneratingCode,
   handleOpenJupyter,
   handleGenerateCode,
   handleExportFlowJSON,
 }) => {
+  // Subscribe only to the node count, not the full sharedNodes array, so the
+  // toolbar does not re-render on every drag frame. Length changes only when
+  // nodes are added or removed.
+  const nodesCount = useFlowStore((state: FlowStore) => state.sharedNodes.length);
   return (
     <>
       <IconButton
@@ -129,7 +131,7 @@ export const WorkflowToolbar: React.FC<WorkflowToolbarProps> = ({
               variant="solid"
               size="sm"
               onClick={handleGenerateCode}
-              isDisabled={!selectedProject || sharedNodes.length === 0}
+              isDisabled={!selectedProject || nodesCount === 0}
               isLoading={isGeneratingCode}
               loadingText="Generating..."
               _hover={{ bg: "blue.600", transform: "translateY(-1px)" }}
@@ -140,7 +142,7 @@ export const WorkflowToolbar: React.FC<WorkflowToolbarProps> = ({
               transition="all 0.2s"
             >
               {!selectedProject ? "Select Project First" :
-              sharedNodes.length === 0 ? "Add Nodes to Generate" :
+              nodesCount === 0 ? "Add Nodes to Generate" :
               "📝 Generate Code"}
             </Button>
 
@@ -149,7 +151,7 @@ export const WorkflowToolbar: React.FC<WorkflowToolbarProps> = ({
               variant="outline"
               size="sm"
               onClick={handleExportFlowJSON}
-              isDisabled={!selectedProject || sharedNodes.length === 0}
+              isDisabled={!selectedProject || nodesCount === 0}
               _hover={{ bg: "green.50", transform: "translateY(-1px)" }}
               _disabled={{
                 opacity: 0.4,
@@ -157,7 +159,7 @@ export const WorkflowToolbar: React.FC<WorkflowToolbarProps> = ({
               }}
               transition="all 0.2s"
             >
-              {sharedNodes.length === 0 ? "No Flow to Export" : "📋 Export Flow JSON"}
+              {nodesCount === 0 ? "No Flow to Export" : "📋 Export Flow JSON"}
             </Button>
 
             {selectedProject && (

--- a/gui/workflow_frontend/src/views/home/homeView.tsx
+++ b/gui/workflow_frontend/src/views/home/homeView.tsx
@@ -95,9 +95,13 @@ const HomeView = () => {
   const nodeDeleteCancelRef = useRef<HTMLButtonElement>(null);
 
   // Comon Selector
-  const sharedNodes = useFlowStore(state => state.sharedNodes);
+  // Note: sharedNodes / sharedEdges are intentionally NOT subscribed at the
+  // HomeView top level. During a node drag React Flow fires onNodesChange
+  // ~60×/sec; subscribing here would re-render the whole HomeView tree
+  // (toolbar, chatbot, modals) every frame and remount the React Flow nodes
+  // via nodeTypes (see handleNodeJupyter/handleNodeInfo). Callbacks below
+  // read fresh state with useFlowStore.getState() instead.
   const setSharedNodes = useFlowStore(state => state.setSharedNodes);
-  const sharedEdges = useFlowStore(state => state.sharedEdges);
   const setSharedEdges = useFlowStore(state => state.setSharedEdges);
   const flowRefreshRequestedAt = useFlowStore(state => state.flowRefreshRequestedAt);
   const setFlowRefreshInProgress = useFlowStore(state => state.setFlowRefreshInProgress);
@@ -154,26 +158,30 @@ const HomeView = () => {
     }
   }, [selectedProject, projects, addJupyterTab, toast]);
 
-  // Node callback functions
+  // Node callback functions.
+  // Read sharedNodes via useFlowStore.getState() — keeping it out of the deps
+  // array is what makes these callbacks stable across drag frames, which in
+  // turn keeps the `nodeTypes` useMemo from being recreated and remounting
+  // every React Flow node on every drag event.
   const handleNodeJupyter = useCallback((nodeId: string) => {
-    const node = sharedNodes.find(n => n.id === nodeId);
+    const node = useFlowStore.getState().sharedNodes.find(n => n.id === nodeId);
     if (node) {
       setSelectedNode(node);
       onCodeOpen();
     }
-  }, [sharedNodes, onCodeOpen]);
+  }, [onCodeOpen]);
 
 
   const handleNodeInfo = useCallback((nodeId: string) => {
     // Try to find node in sharedNodes first
-    let node = sharedNodes.find(n => n.id === nodeId);
-    
+    let node = useFlowStore.getState().sharedNodes.find(n => n.id === nodeId);
+
     // If not found, try to get it from ReactFlow instance (for newly added nodes)
     if (!node && reactFlowInstance.current) {
       const flowNodes = reactFlowInstance.current.getNodes();
       node = flowNodes.find(n => n.id === nodeId) as Node<CalculationNodeData> | undefined;
     }
-    
+
     if (node) {
       setSelectedNode(node);
       onViewOpen();
@@ -187,7 +195,7 @@ const HomeView = () => {
         isClosable: true,
       });
     }
-  }, [sharedNodes, onViewOpen, reactFlowInstance, toast]);
+  }, [onViewOpen, reactFlowInstance, toast]);
 
   // Clear the dirty flag only when nothing is queued, scheduled, or in flight.
   // Prevents an in-flight save's `finally` from clearing the flag while a newer
@@ -377,14 +385,14 @@ const HomeView = () => {
       return;
     }
 
-    const pendingNodes = sharedNodes.filter((node) => nodeIds.includes(node.id));
+    const pendingNodes = useFlowStore.getState().sharedNodes.filter((node) => nodeIds.includes(node.id));
     if (pendingNodes.length === 0) {
       return;
     }
 
     setNodesPendingDelete(pendingNodes);
     onNodeDeleteOpen();
-  }, [sharedNodes, onNodeDeleteOpen]);
+  }, [onNodeDeleteOpen]);
 
   const handleNodeDelete = useCallback((nodeId: string) => {
     requestNodeDelete([nodeId]);
@@ -710,12 +718,10 @@ const HomeView = () => {
     }
   };
 
-  // Keyboard shortcuts (Delete/Backspace for selected nodes/edges)
+  // Keyboard shortcuts (Delete/Backspace for selected nodes/edges).
+  // The hook reads nodes/edges from useFlowStore internally so HomeView does
+  // not need to subscribe to them at the top level.
   useKeyboardShortcuts({
-    sharedNodes,
-    sharedEdges,
-    setSharedNodes,
-    setSharedEdges,
     toast,
     autoSaveEnabled,
     isViewOpen,
@@ -941,7 +947,8 @@ const HomeView = () => {
       return;
     }
 
-    if (sharedNodes.length === 0) {
+    const currentSharedNodes = useFlowStore.getState().sharedNodes;
+    if (currentSharedNodes.length === 0) {
       toast({
         title: "Empty Flow",
         description: "Please add nodes to the flow before generating code",
@@ -964,7 +971,7 @@ const HomeView = () => {
 
     // Save all nodes that haven't been saved yet
     // Get current nodes from ReactFlow instance (includes newly added ones)
-    const currentNodes = reactFlowInstance.current?.getNodes() || sharedNodes;
+    const currentNodes = reactFlowInstance.current?.getNodes() || currentSharedNodes;
     
     for (const node of currentNodes) {
       try {
@@ -1052,7 +1059,7 @@ const HomeView = () => {
     } finally {
       setIsGeneratingCode(false);
     }
-  }, [selectedProject, reactFlowInstance, sharedNodes, createNodeAPI, updateNodeAPI, toast]);
+  }, [selectedProject, reactFlowInstance, createNodeAPI, updateNodeAPI, toast]);
 
   // Clean up
   useEffect(() => {
@@ -1206,7 +1213,6 @@ const HomeView = () => {
           autoSaveEnabled={autoSaveEnabled}
           selectedProject={selectedProject}
           projects={projects}
-          sharedNodes={sharedNodes}
           isGeneratingCode={isGeneratingCode}
           handleOpenJupyter={handleOpenJupyter}
           handleGenerateCode={handleGenerateCode}


### PR DESCRIPTION
## Summary

GUI上のWorkflowキャンバスでノードをドラッグした際にスムーズに追従せず「飛び飛び」に動く問題を修正。原因は React Flow の controlled モード × Zustand 構成における 2 つの再レンダリングアンチパターン:

- **`nodeTypes` がドラッグの全フレームで再生成され、全ノードが remount されていた（致命的）**
  `homeView.tsx` で `sharedNodes` を購読していたため、`handleNodeJupyter` / `handleNodeInfo` の useCallback deps が毎フレーム変化 → それらを deps に持つ `nodeTypes` useMemo も毎フレーム再生成 → React Flow が `nodeTypes` の中身を新しいコンポーネント型と認識し全ノードを unmount → mount し直していた。
- **HomeView 全体が再レンダリング**
  1200 行超の HomeView（ProjectSelector / WorkflowToolbar / ChatbotView / モーダル群を内包）がドラッグの全フレームで再レンダリングされていた。

### 変更点
- `homeView.tsx`: トップレベルの `sharedNodes` / `sharedEdges` 購読を削除。コールバック内では `useFlowStore.getState().sharedNodes` で都度取得。`handleNodeJupyter` / `handleNodeInfo` / `requestNodeDelete` / `handleGenerateCode` の deps から `sharedNodes` を除去。
- `WorkflowToolbar.tsx`: `sharedNodes` prop を廃止し、必要な `nodesCount` だけを `useFlowStore` から直接購読。
- `useKeyboardShortcuts.ts`: フック内部で `useFlowStore.getState()` から取得する形に変更。signature から `sharedNodes` / `sharedEdges` / `setSharedNodes` / `setSharedEdges` を削除。

保存挙動 (`debouncedSave`)、zundo `temporal` の undo 履歴、API 契約には触れていない（描画パフォーマンスのみの最小修正）。

## Test plan
- [ ] `cd gui && docker-compose up` でアプリ起動 → ノード複数配置 → マウスドラッグでスムーズに追従することを確認
- [ ] React DevTools Profiler でドラッグ中の再レンダリングを記録し、HomeView / WorkflowToolbar が再レンダリングされず、`WorkflowCanvas` 配下のみが更新されることを確認
- [ ] ノード追加・削除（個別/複数）が正常に動作
- [ ] エッジ作成・削除が正常に動作
- [ ] ノードドラッグ後の自動保存（500ms debounce → API 呼び出し）が走る
- [ ] `onNodeDragStop` 後のフルノード保存が走る
- [ ] Delete / Backspace で選択ノード・エッジが削除できる
- [ ] WorkflowToolbar の Generate Code / Export ボタンの活性化（nodesCount === 0 判定）が正しい
- [ ] ノード設定パネルからのデータ更新がノードに反映される
- [ ] チャット経由のフロー更新 (`requestFlowRefresh`) が動作
- [ ] Undo/Redo が今までどおり動作

🤖 Generated with [Claude Code](https://claude.com/claude-code)