### PR TITLE
Normalize MCP add_node category to match frontend nodeTypes (closes #30)

### DIFF
--- a/gui/mcp_server/workflow_mcp.py
+++ b/gui/mcp_server/workflow_mcp.py
@@ -334,11 +334,14 @@ async def add_node(
     if not file_name.endswith(".py"):
         file_name += ".py"
     category = node_def.get("category", "analysis")
+    # Normalize to match frontend WorkflowCanvas.tsx:260 (lowercase + remove '/')
+    # so node.type matches the keys registered in homeView's nodeTypes.
+    node_type = category.lower().replace("/", "")
     schema = copy.deepcopy(node_def.get("schema", {"inputs": {}, "outputs": {}, "parameters": {}, "methods": {}}))
     resolved_instance_name = instance_name or label
 
-    # 4. Resolve color from categories
-    cat_info = categories.get(category, {})
+    # 4. Resolve color from categories (cat_settings is keyed by DB value, i.e. normalized)
+    cat_info = categories.get(node_type, {})
     color = cat_info.get("color", "#6b46c1")
 
     # 5. Generate unique node ID (matching frontend format)
@@ -350,13 +353,13 @@ async def add_node(
     payload = {
         "id": node_id,
         "position": {"x": position_x, "y": position_y},
-        "type": category,
+        "type": node_type,
         "data": {
             "file_name": file_name,
             "label": label,
             "instanceName": resolved_instance_name,
             "schema": schema,
-            "nodeType": category,
+            "nodeType": node_type,
             "nodeParameters": {},
             "color": color,
         },


### PR DESCRIPTION
## Summary

- MCPツール `add_node` がノードの `type` / `data.nodeType` に `category` の display 値（`'I/O'`, `'Analysis'` など）をそのまま入れていたため、React Flow の `nodeTypes` ルックアップに失敗し、内蔵デフォルトノードにフォールバックしていた。これがノード左サイドの不要な線として可視化されていた（issue #30）。
- フロントエンド（`WorkflowCanvas.tsx:260` の手動 onDrop と `homeView.tsx:426` の `nodeTypes` 登録）と同じ正規化（`lower()` + `'/'` 除去）を MCP 側でも適用し、`UploadedNodesView` の `cat_settings` キーに合わせてカラー lookup も正規化値に変更。

## Root cause (短縮版)

- `app/box/models.py:107` が `get_category_display()` で `category` を返すため、`uploaded-nodes/` API のレスポンスは `'I/O'`, `'Analysis'` などの display 値。
- 手動追加 (`WorkflowCanvas.tsx:260`): `rawCategory.toLowerCase().replace('/', '')` で正規化 → `nodeTypes['io']` などにマッチ → `CalculationNode` 描画 ✅
- MCP 経由 (`workflow_mcp.py:336, 353, 359`): 正規化なし → `node.type = 'I/O'` のまま保存 → `nodeTypes` ミスマッチ → React Flow デフォルトノード → 左サイドにハンドルスタブ ❌

詳細は issue #30 のコメントを参照。

## Test plan

- [ ] **手動追加 regression**: サイドバーから `I/O` カテゴリを含む任意のノードをドラッグ&ドロップ。左サイドに余計な線が出ず、`CalculationNode` の青いハンドルで描画されること
- [ ] **MCP 追加（主検証）**: MCP 経由で `add_node(workflow_id=..., node_name="<I/Oカテゴリのノード>")` を実行。リフレッシュ後、手動追加と**ビジュアル上同一**で、左サイドの線が**消えている**ことを確認
- [ ] **複数カテゴリで確認**: `analysis`, `io`, `simulation`, `stimulus` の各カテゴリで上記2を実施
- [ ] **DBペイロード確認**: `/api/workflow/{id}/nodes/` を直接叩き、MCP 経由で追加されたノードの `node_type` および `data.nodeType` が lowercase（`'io'`, `'analysis'` 等）になっていること

## Notes

- 既存 DB 上の大文字 `type` ノードはこの PR では修復されない。必要なら別途データマイグレーションまたは読み出し時の正規化を検討。