### PR TITLE
Make JupyterHub base_url and cookie Secure env-driven for dev/prod split

### DIFF
--- a/gui/docker-compose.prod.yml
+++ b/gui/docker-compose.prod.yml
@@ -12,10 +12,16 @@ services:
   backend:
     environment:
       - ALLOWED_HOSTS_ALL=false
+      - JUPYTERHUB_API_URL=http://jupyterhub:8000/jupyter
       # Set these in .env for your domain:
       # - CORS_ALLOWED_ORIGINS_EXTRA=https://your-server.riken.jp
       # - CSRF_TRUSTED_ORIGINS_EXTRA=https://your-server.riken.jp
       # - ALLOWED_HOSTS_EXTRA=your-server.riken.jp
+
+  jupyterhub:
+    environment:
+      - JUPYTERHUB_BASE_URL=/jupyter/
+      - JUPYTERHUB_COOKIE_SECURE=true
 
   frontend:
     command: npm run dev:docker

--- a/gui/docker-compose.yml
+++ b/gui/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - OPENAI_MODEL=${OPENAI_MODEL:-gpt-4o}
       - MCP_SERVER_URL=http://mcp:8001
       - JUPYTERHUB_API_TOKEN=${JUPYTERHUB_API_TOKEN:-dev-token-change-in-production}
-      - JUPYTERHUB_API_URL=http://jupyterhub:8000/jupyter
+      - JUPYTERHUB_API_URL=http://jupyterhub:8000
       - JUPYTER_EXECUTION_USER=${JUPYTER_EXECUTION_USER:-user1}
     depends_on:
       - db

--- a/gui/workflow_backend/django-project/neuroworkflow/jupyterhub_config.py
+++ b/gui/workflow_backend/django-project/neuroworkflow/jupyterhub_config.py
@@ -11,7 +11,7 @@ c = get_config()
 # Network configuration
 c.JupyterHub.hub_ip = "0.0.0.0"
 c.JupyterHub.port = 8000
-c.JupyterHub.base_url = "/jupyter/"
+c.JupyterHub.base_url = os.environ.get("JUPYTERHUB_BASE_URL", "/")
 
 # Use Docker spawner
 c.JupyterHub.spawner_class = DockerSpawner
@@ -107,7 +107,7 @@ c.JupyterHub.extra_handlers = [
 # Cookie settings for iframe embedding
 c.JupyterHub.cookie_options = {
     'SameSite': 'None',
-    'Secure': True,
+    'Secure': os.environ.get("JUPYTERHUB_COOKIE_SECURE", "false").lower() == "true",
 }
 
 # =============== SERVICE TOKEN FOR BACKEND ===============


### PR DESCRIPTION
## Summary
- `66af096d` hard-coded `base_url=/jupyter/` and `Secure=True` cookies on JupyterHub for the RIKEN nginx+HTTPS deployment, which broke plain HTTP `docker compose up` dev: the frontend constructs JupyterLab URLs without a `/jupyter` prefix (hitting 404), and browsers drop `Secure` cookies over HTTP (login session lost).
- Make both settings env-driven (`JUPYTERHUB_BASE_URL`, `JUPYTERHUB_COOKIE_SECURE`) so dev defaults to root + non-Secure while `docker-compose.prod.yml` reinstates the `/jupyter` prefix and `Secure=true` for the nginx-fronted RIKEN deployment.
- Also revert backend `JUPYTERHUB_API_URL` to `http://jupyterhub:8000` in the dev compose file and add the `/jupyter` variant as a prod override, keeping backend↔JupyterHub API calls aligned with the active base_url.

## Test plan
- [ ] Dev: `cd gui && docker compose up -d --build jupyterhub backend frontend`, sign in via `http://localhost:5173`, click **Open JupyterLab** on a project — new tab loads JupyterLab over HTTP.
- [ ] Dev: trigger workflow **Run** from the frontend — backend reaches JupyterHub API at root and code executes through to completion.
- [ ] Prod: `cd gui && docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build jupyterhub backend frontend` behind nginx + HTTPS — same two scenarios (Open JupyterLab tab + Run workflow) still work with `/jupyter` prefix and Secure cookies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)