### PR TITLE
Add Project metadata (Key/Value)

### DIFF
--- a/gui/mcp_server/workflow_mcp.py
+++ b/gui/mcp_server/workflow_mcp.py
@@ -127,6 +127,8 @@ async def list_projects() -> dict[str, Any]:
     - name (str): Project name.
     - description (str): Project description.
     - workflow_context (dict): Arbitrary workflow metadata.
+    - metadata (dict[str, str]): User-defined key/value tags
+      (e.g. Affiliation, paper DOI, Funding).
     - owner (dict): Owner user object with id, username, email, first_name, last_name.
     - created_at / updated_at (datetime): Timestamps.
     - nodes_count (int): Number of nodes in the project.
@@ -144,10 +146,14 @@ async def create_project(payload: dict) -> dict[str, Any]:
     """Create a new workflow project.
 
     Args:
-        payload: Project fields. Required: {"name": str}. Optional: {"description": str, "workflow_context": dict}.
+        payload: Project fields. Required: {"name": str}.
+            Optional: {"description": str, "workflow_context": dict,
+            "metadata": dict[str, str]}.
+            "metadata" is a free-form Key/Value bag for user-defined tags
+            (e.g. {"Affiliation": "OIST", "paper DOI": "10.x/y"}).
 
     Returns the created project object with id, name, description, workflow_context,
-    owner, created_at, updated_at, nodes_count, and edges_count.
+    metadata, owner, created_at, updated_at, nodes_count, and edges_count.
     """
     url = f"{DJANGO_API_URL}/workflow/"
     data = await _make_post_request(url, payload)
@@ -164,7 +170,7 @@ async def get_project(workflow_id: str) -> dict[str, Any]:
         workflow_id: UUID of the project to fetch.
 
     Returns the full project object including id, name, description,
-    workflow_context, owner, timestamps, nodes_count, and edges_count.
+    workflow_context, metadata, owner, timestamps, nodes_count, and edges_count.
     """
     url = f"{DJANGO_API_URL}/workflow/{workflow_id}/"
     data = await _make_get_request(url)
@@ -179,7 +185,10 @@ async def update_project(workflow_id: str, payload: dict) -> dict[str, Any]:
 
     Args:
         workflow_id: UUID of the project to update.
-        payload: Fields to update. Accepted: {"name": str, "description": str, "workflow_context": dict}.
+        payload: Fields to update. Accepted: {"name": str, "description": str,
+            "workflow_context": dict, "metadata": dict[str, str]}.
+            "metadata" is replaced wholesale (no deep-merge). To update one key,
+            read-modify-write the full dict.
 
     Returns the updated project object.
     """

--- a/gui/workflow_backend/django-project/app/workflow/models.py
+++ b/gui/workflow_backend/django-project/app/workflow/models.py
@@ -16,6 +16,7 @@ class FlowProject(models.Model):
     name = models.CharField(max_length=255)
     description = models.TextField(blank=True, null=True)
     workflow_context = models.JSONField(default=dict, blank=True)
+    metadata = models.JSONField(default=dict, blank=True)
     owner = models.ForeignKey(
         User, on_delete=models.CASCADE, related_name="flow_projects"
     )

--- a/gui/workflow_backend/django-project/app/workflow/serializers.py
+++ b/gui/workflow_backend/django-project/app/workflow/serializers.py
@@ -32,6 +32,7 @@ class FlowProjectSerializer(serializers.ModelSerializer):
             "name",
             "description",
             "workflow_context",
+            "metadata",
             "owner",
             "visibility",
             "reference",

--- a/gui/workflow_backend/django-project/app/workflow/serializers.py
+++ b/gui/workflow_backend/django-project/app/workflow/serializers.py
@@ -88,6 +88,22 @@ class FlowProjectSerializer(serializers.ModelSerializer):
     def get_can_change_visibility(self, obj):
         return self.get_is_owned_by_me(obj)
 
+    def validate_metadata(self, value):
+        """Enforce the Key/Value contract: an object of string -> string."""
+        if not isinstance(value, dict):
+            raise serializers.ValidationError("metadata must be an object.")
+        for k, v in value.items():
+            if not isinstance(k, str):
+                raise serializers.ValidationError(
+                    "metadata keys must be strings."
+                )
+            if not isinstance(v, str):
+                raise serializers.ValidationError(
+                    f"metadata['{k}'] must be a string, "
+                    f"got {type(v).__name__}."
+                )
+        return value
+
 
 class FlowNodeSerializer(serializers.ModelSerializer):
     has_parameter_modifications = serializers.SerializerMethodField()

--- a/gui/workflow_backend/django-project/tests/test_metadata.py
+++ b/gui/workflow_backend/django-project/tests/test_metadata.py
@@ -1,0 +1,67 @@
+"""Tests for FlowProject user-defined metadata (Issue #31)."""
+import pytest
+from django.urls import reverse
+
+from app.workflow.models import FlowProject
+
+pytestmark = pytest.mark.django_db
+
+
+def test_default_metadata_is_empty_dict(user_alice):
+    project = FlowProject.objects.create(name="X", owner=user_alice)
+    assert project.metadata == {}
+
+
+def test_create_with_metadata(auth_client, user_alice):
+    client = auth_client(user_alice)
+    list_url = reverse("workflow:workflow-list-create")
+    resp = client.post(
+        list_url,
+        {
+            "name": "WithMeta",
+            "metadata": {"Affiliation": "OIST", "paper DOI": "10.1234/x"},
+        },
+        format="json",
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["metadata"] == {"Affiliation": "OIST", "paper DOI": "10.1234/x"}
+
+    project = FlowProject.objects.get(id=body["id"])
+    assert project.metadata == {"Affiliation": "OIST", "paper DOI": "10.1234/x"}
+
+
+def test_patch_metadata(auth_client, user_alice):
+    project = FlowProject.objects.create(name="P", owner=user_alice)
+    client = auth_client(user_alice)
+    url = reverse("workflow:workflow-detail", args=[project.id])
+
+    resp = client.patch(
+        url, {"metadata": {"Funding": "Brain/MINDS 2.0"}}, format="json"
+    )
+    assert resp.status_code == 200
+    assert resp.json()["metadata"] == {"Funding": "Brain/MINDS 2.0"}
+
+    project.refresh_from_db()
+    assert project.metadata == {"Funding": "Brain/MINDS 2.0"}
+
+
+def test_metadata_replaces_on_patch(auth_client, user_alice):
+    """PATCH replaces the metadata dict wholesale (no deep-merge)."""
+    project = FlowProject.objects.create(
+        name="P",
+        owner=user_alice,
+        metadata={"Affiliation": "OIST", "Collaborators": "A, B"},
+    )
+    client = auth_client(user_alice)
+    url = reverse("workflow:workflow-detail", args=[project.id])
+
+    resp = client.patch(
+        url, {"metadata": {"paper DOI": "10.9999/z"}}, format="json"
+    )
+    assert resp.status_code == 200
+
+    project.refresh_from_db()
+    assert project.metadata == {"paper DOI": "10.9999/z"}
+    assert "Affiliation" not in project.metadata
+    assert "Collaborators" not in project.metadata

--- a/gui/workflow_backend/django-project/tests/test_metadata.py
+++ b/gui/workflow_backend/django-project/tests/test_metadata.py
@@ -65,3 +65,26 @@ def test_metadata_replaces_on_patch(auth_client, user_alice):
     assert project.metadata == {"paper DOI": "10.9999/z"}
     assert "Affiliation" not in project.metadata
     assert "Collaborators" not in project.metadata
+
+
+def test_metadata_rejects_non_object(auth_client, user_alice):
+    project = FlowProject.objects.create(name="P", owner=user_alice)
+    client = auth_client(user_alice)
+    url = reverse("workflow:workflow-detail", args=[project.id])
+
+    resp = client.patch(url, {"metadata": ["a", "b"]}, format="json")
+    assert resp.status_code == 400
+    assert "metadata" in resp.json()
+
+
+def test_metadata_rejects_non_string_value(auth_client, user_alice):
+    project = FlowProject.objects.create(name="P", owner=user_alice)
+    client = auth_client(user_alice)
+    url = reverse("workflow:workflow-detail", args=[project.id])
+
+    resp = client.patch(url, {"metadata": {"cpus": 4}}, format="json")
+    assert resp.status_code == 400
+    assert "metadata" in resp.json()
+
+    project.refresh_from_db()
+    assert project.metadata == {}

--- a/gui/workflow_frontend/src/components/MetadataEditor.tsx
+++ b/gui/workflow_frontend/src/components/MetadataEditor.tsx
@@ -1,0 +1,194 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import {
+  Box,
+  Button,
+  HStack,
+  IconButton,
+  Input,
+  Tag,
+  TagLabel,
+  Text,
+  VStack,
+  Wrap,
+  WrapItem,
+  useColorModeValue,
+} from '@chakra-ui/react';
+import { AddIcon, DeleteIcon } from '@chakra-ui/icons';
+
+interface MetadataRow {
+  id: string;
+  key: string;
+  value: string;
+}
+
+interface MetadataEditorProps {
+  initialMetadata?: Record<string, string>;
+  label?: string;
+  disabled?: boolean;
+  presetKeys?: string[];
+  onChange?: (metadata: Record<string, string>) => void;
+}
+
+const DEFAULT_PRESET_KEYS = [
+  'Affiliation',
+  'Affiliation URL',
+  'Collaborators',
+  'paper DOI',
+  'Funding',
+];
+
+const EMPTY_METADATA: Record<string, string> = {};
+
+const rowsToDict = (rows: MetadataRow[]): Record<string, string> => {
+  const dict: Record<string, string> = {};
+  for (const row of rows) {
+    const k = row.key.trim();
+    if (!k) continue;
+    dict[k] = row.value;
+  }
+  return dict;
+};
+
+const dictToRows = (dict: Record<string, string>, nextId: () => string): MetadataRow[] =>
+  Object.entries(dict).map(([key, value]) => ({
+    id: nextId(),
+    key,
+    value: typeof value === 'string' ? value : String(value),
+  }));
+
+export const MetadataEditor = ({
+  initialMetadata = EMPTY_METADATA,
+  label = 'Metadata (Optional)',
+  disabled = false,
+  presetKeys = DEFAULT_PRESET_KEYS,
+  onChange,
+}: MetadataEditorProps) => {
+  const counterRef = useRef(0);
+  const nextId = () => {
+    counterRef.current += 1;
+    return `meta-${counterRef.current}`;
+  };
+
+  const [rows, setRows] = useState<MetadataRow[]>(() => dictToRows(initialMetadata, nextId));
+
+  useEffect(() => {
+    setRows(dictToRows(initialMetadata, nextId));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [initialMetadata]);
+
+  useEffect(() => {
+    onChange?.(rowsToDict(rows));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [rows]);
+
+  const duplicateKeyWarning = useMemo(() => {
+    const seen = new Set<string>();
+    const dups = new Set<string>();
+    for (const row of rows) {
+      const k = row.key.trim();
+      if (!k) continue;
+      if (seen.has(k)) dups.add(k);
+      seen.add(k);
+    }
+    return dups.size > 0 ? Array.from(dups) : null;
+  }, [rows]);
+
+  const labelColor = useColorModeValue('gray.700', 'gray.200');
+  const helperColor = useColorModeValue('gray.500', 'gray.400');
+
+  const addRow = (key = '') => {
+    setRows(prev => [...prev, { id: nextId(), key, value: '' }]);
+  };
+
+  const removeRow = (id: string) => {
+    setRows(prev => prev.filter(r => r.id !== id));
+  };
+
+  const updateRow = (id: string, patch: Partial<Omit<MetadataRow, 'id'>>) => {
+    setRows(prev => prev.map(r => (r.id === id ? { ...r, ...patch } : r)));
+  };
+
+  return (
+    <Box>
+      <Text fontSize="sm" fontWeight="semibold" mb={2} color={labelColor}>
+        {label}
+      </Text>
+
+      {presetKeys.length > 0 && (
+        <Box mb={3}>
+          <Text fontSize="xs" color={helperColor} mb={1}>
+            Quick add:
+          </Text>
+          <Wrap spacing={2}>
+            {presetKeys.map(preset => (
+              <WrapItem key={preset}>
+                <Tag
+                  size="sm"
+                  colorScheme="blue"
+                  variant="subtle"
+                  cursor={disabled ? 'not-allowed' : 'pointer'}
+                  opacity={disabled ? 0.6 : 1}
+                  onClick={() => {
+                    if (!disabled) addRow(preset);
+                  }}
+                >
+                  <TagLabel>+ {preset}</TagLabel>
+                </Tag>
+              </WrapItem>
+            ))}
+          </Wrap>
+        </Box>
+      )}
+
+      <VStack spacing={2} align="stretch">
+        {rows.map(row => (
+          <HStack key={row.id} spacing={2}>
+            <Input
+              size="sm"
+              placeholder="Key"
+              value={row.key}
+              onChange={e => updateRow(row.id, { key: e.target.value })}
+              isDisabled={disabled}
+              flex="1"
+            />
+            <Input
+              size="sm"
+              placeholder="Value"
+              value={row.value}
+              onChange={e => updateRow(row.id, { value: e.target.value })}
+              isDisabled={disabled}
+              flex="2"
+            />
+            <IconButton
+              aria-label="Remove metadata row"
+              icon={<DeleteIcon />}
+              size="sm"
+              variant="ghost"
+              colorScheme="red"
+              onClick={() => removeRow(row.id)}
+              isDisabled={disabled}
+            />
+          </HStack>
+        ))}
+      </VStack>
+
+      <Button
+        leftIcon={<AddIcon />}
+        size="sm"
+        variant="outline"
+        mt={2}
+        onClick={() => addRow()}
+        isDisabled={disabled}
+      >
+        Add row
+      </Button>
+
+      {duplicateKeyWarning && (
+        <Text fontSize="xs" color="orange.500" mt={2}>
+          Duplicate key{duplicateKeyWarning.length > 1 ? 's' : ''}:{' '}
+          {duplicateKeyWarning.join(', ')}. The last row's value will be saved.
+        </Text>
+      )}
+    </Box>
+  );
+};

--- a/gui/workflow_frontend/src/components/MetadataEditor.tsx
+++ b/gui/workflow_frontend/src/components/MetadataEditor.tsx
@@ -123,14 +123,15 @@ export const MetadataEditor = ({
             {presetKeys.map(preset => (
               <WrapItem key={preset}>
                 <Tag
+                  as="button"
+                  type="button"
                   size="sm"
                   colorScheme="blue"
                   variant="subtle"
-                  cursor={disabled ? 'not-allowed' : 'pointer'}
-                  opacity={disabled ? 0.6 : 1}
-                  onClick={() => {
-                    if (!disabled) addRow(preset);
-                  }}
+                  disabled={disabled}
+                  aria-label={`Add metadata row for ${preset}`}
+                  onClick={() => addRow(preset)}
+                  _disabled={{ cursor: 'not-allowed', opacity: 0.6 }}
                 >
                   <TagLabel>+ {preset}</TagLabel>
                 </Tag>
@@ -141,35 +142,45 @@ export const MetadataEditor = ({
       )}
 
       <VStack spacing={2} align="stretch">
-        {rows.map(row => (
-          <HStack key={row.id} spacing={2}>
-            <Input
-              size="sm"
-              placeholder="Key"
-              value={row.key}
-              onChange={e => updateRow(row.id, { key: e.target.value })}
-              isDisabled={disabled}
-              flex="1"
-            />
-            <Input
-              size="sm"
-              placeholder="Value"
-              value={row.value}
-              onChange={e => updateRow(row.id, { value: e.target.value })}
-              isDisabled={disabled}
-              flex="2"
-            />
-            <IconButton
-              aria-label="Remove metadata row"
-              icon={<DeleteIcon />}
-              size="sm"
-              variant="ghost"
-              colorScheme="red"
-              onClick={() => removeRow(row.id)}
-              isDisabled={disabled}
-            />
-          </HStack>
-        ))}
+        {rows.map((row, index) => {
+          const trimmedKey = row.key.trim();
+          const rowLabel = trimmedKey || `row ${index + 1}`;
+          return (
+            <HStack key={row.id} spacing={2}>
+              <Input
+                size="sm"
+                placeholder="Key"
+                aria-label={`Metadata key (row ${index + 1})`}
+                value={row.key}
+                onChange={e => updateRow(row.id, { key: e.target.value })}
+                isDisabled={disabled}
+                flex="1"
+              />
+              <Input
+                size="sm"
+                placeholder="Value"
+                aria-label={
+                  trimmedKey
+                    ? `Metadata value for ${trimmedKey}`
+                    : `Metadata value (row ${index + 1})`
+                }
+                value={row.value}
+                onChange={e => updateRow(row.id, { value: e.target.value })}
+                isDisabled={disabled}
+                flex="2"
+              />
+              <IconButton
+                aria-label={`Remove metadata ${rowLabel}`}
+                icon={<DeleteIcon />}
+                size="sm"
+                variant="ghost"
+                colorScheme="red"
+                onClick={() => removeRow(row.id)}
+                isDisabled={disabled}
+              />
+            </HStack>
+          );
+        })}
       </VStack>
 
       <Button

--- a/gui/workflow_frontend/src/views/file/createView.tsx
+++ b/gui/workflow_frontend/src/views/file/createView.tsx
@@ -22,12 +22,14 @@ import {
 import { useNavigate } from 'react-router-dom';
 import { createAuthHeaders } from '../../api/authHeaders'; // for authentication header
 import { WorkflowContextEditor } from '../../components/WorkflowContextEditor';
+import { MetadataEditor } from '../../components/MetadataEditor';
 import type { HpcTarget, Visibility } from '../home/type';
 
 interface CreateFlowProjectRequest {
   name: string;
   description: string;
   workflow_context?: Record<string, any>;
+  metadata?: Record<string, string>;
   visibility: Visibility;
   reference: string;
   hpc_target: HpcTarget;
@@ -55,6 +57,7 @@ const CreateFlowPj: React.FC = () => {
   const [workflowContext, setWorkflowContext] = useState<Record<string, any> | null>(null);
   const [isContextValid, setIsContextValid] = useState<boolean>(true);
   const [contextResetKey, setContextResetKey] = useState<number>(0);
+  const [metadata, setMetadata] = useState<Record<string, string>>({});
   const [visibility, setVisibility] = useState<Visibility>('private');
   const [reference, setReference] = useState<string>('');
   const [hpcTarget, setHpcTarget] = useState<HpcTarget>('');
@@ -148,6 +151,7 @@ const CreateFlowPj: React.FC = () => {
         reference,
         hpc_target: hpcTarget,
         ...(workflowContextPayload ? { workflow_context: workflowContextPayload } : {}),
+        ...(Object.keys(metadata).length > 0 ? { metadata } : {}),
       };
 
       const response = await createFlowProject(requestData);
@@ -167,6 +171,7 @@ const CreateFlowPj: React.FC = () => {
       setWorkflowContext(null);
       setIsContextValid(true);
       setContextResetKey(prev => prev + 1);
+      setMetadata({});
       setVisibility('private');
       setReference('');
       setHpcTarget('');
@@ -213,6 +218,7 @@ const CreateFlowPj: React.FC = () => {
     setWorkflowContext(null);
     setIsContextValid(true);
     setContextResetKey(prev => prev + 1);
+    setMetadata({});
     setReference('');
     setHpcTarget('');
     navigate(-1);
@@ -328,6 +334,14 @@ const CreateFlowPj: React.FC = () => {
             <option value="riken">Riken</option>
             <option value="fugaku">Fugaku</option>
           </Select>
+        </FormControl>
+
+        <FormControl>
+          <MetadataEditor
+            key={`meta-${contextResetKey}`}
+            disabled={isLoading}
+            onChange={setMetadata}
+          />
         </FormControl>
 
         <FormControl>

--- a/gui/workflow_frontend/src/views/home/components/projectSelector.tsx
+++ b/gui/workflow_frontend/src/views/home/components/projectSelector.tsx
@@ -33,6 +33,7 @@ import { createAuthHeaders } from '../../../api/authHeaders';
 import LogViewModal, { LogEntry } from "./logViewModal";
 import { runWorkflowStream } from '../../../api/workflowRunApi';
 import { WorkflowContextEditor } from '../../../components/WorkflowContextEditor';
+import { MetadataEditor } from '../../../components/MetadataEditor';
 import { JUPYTER_BASE_URL } from '../../../config/urls';
 
 export const ProjectSelector = ({ 
@@ -58,6 +59,8 @@ export const ProjectSelector = ({
   const [contextDraft, setContextDraft] = useState<Record<string, any> | null>(null);
   const [isContextValid, setIsContextValid] = useState<boolean>(true);
   const [contextResetKey, setContextResetKey] = useState<number>(0);
+  const [metadataInitial, setMetadataInitial] = useState<Record<string, string>>({});
+  const [metadataDraft, setMetadataDraft] = useState<Record<string, string>>({});
   const [descriptionDraft, setDescriptionDraft] = useState<string>('');
   const [visibilityDraft, setVisibilityDraft] = useState<Visibility>('private');
   const [referenceDraft, setReferenceDraft] = useState<string>('');
@@ -121,6 +124,7 @@ export const ProjectSelector = ({
     const descriptionPayload = descriptionDraft.trim();
     const payload: Record<string, any> = {
       workflow_context: parsedContext,
+      metadata: metadataDraft,
       description: descriptionPayload,
       reference: referenceDraft,
       hpc_target: hpcTargetDraft,
@@ -157,6 +161,7 @@ export const ProjectSelector = ({
       });
       setContextInitial(parsedContext);
       setContextDraft(parsedContext);
+      setMetadataInitial(metadataDraft);
       if (updated.visibility) {
         setVisibilityDraft(updated.visibility);
       }
@@ -528,11 +533,14 @@ export const ProjectSelector = ({
                   onClick={() => {
                     const project = projects.find(p => p.id === selectedProject);
                     const context = project?.workflow_context ?? {};
+                    const meta = project?.metadata ?? {};
                     setDescriptionDraft(project?.description ?? '');
                     setContextInitial(context);
                     setContextDraft(context);
                     setIsContextValid(true);
                     setContextResetKey(prev => prev + 1);
+                    setMetadataInitial(meta);
+                    setMetadataDraft(meta);
                     setVisibilityDraft(project?.visibility ?? 'private');
                     setReferenceDraft(project?.reference ?? '');
                     setHpcTargetDraft(project?.hpc_target ?? '');
@@ -659,6 +667,13 @@ export const ProjectSelector = ({
                 <option value="riken">Riken</option>
                 <option value="fugaku">Fugaku</option>
               </Select>
+            </Box>
+            <Box mb={4}>
+              <MetadataEditor
+                key={`meta-${contextResetKey}`}
+                initialMetadata={metadataInitial}
+                onChange={setMetadataDraft}
+              />
             </Box>
             <WorkflowContextEditor
               key={contextResetKey}

--- a/gui/workflow_frontend/src/views/home/type.ts
+++ b/gui/workflow_frontend/src/views/home/type.ts
@@ -88,6 +88,7 @@ export interface Project {
   name: string;
   description?: string;
   workflow_context?: Record<string, any>;
+  metadata?: Record<string, string>;
   visibility: Visibility;
   reference?: string;
   hpc_target?: HpcTarget;


### PR DESCRIPTION
## Summary
- Add a free-form `metadata` JSONField on `FlowProject` so users can attach acknowledgments-style Key/Value information (Affiliation, paper DOI, Funding, etc.) without expanding the structured `workflow_context` schema
- Introduce a shared `MetadataEditor` React component used by both the Create and Edit Project modals, with preset chips for common keys and a soft duplicate-key warning
- Expose `metadata` through the MCP server (passthrough — docstring updates only) so AI tools can read/write the field

Closes #31.

## Changes
**Backend (Django)**
- `app/workflow/models.py`: add `metadata = models.JSONField(default=dict, blank=True)` to `FlowProject`
- `app/workflow/serializers.py`: include `metadata` in `FlowProjectSerializer.Meta.fields`
- `tests/test_metadata.py` (new): covers default-empty, create-with-metadata, patch, and patch-replaces-wholesale

**Frontend (React + Chakra UI)**
- `components/MetadataEditor.tsx` (new): row-based Key/Value editor with preset chips and duplicate-key warning
- `views/file/createView.tsx`: embed the editor and include `metadata` in the POST payload
- `views/home/components/projectSelector.tsx`: embed the editor in the Edit modal and include `metadata` in the PATCH payload
- `views/home/type.ts`: add `metadata?: Record<string, string>` to the `Project` interface

**MCP**
- `mcp_server/workflow_mcp.py`: document `metadata` in `list_projects` / `create_project` / `get_project` / `update_project` docstrings, including the full-replacement semantics of PATCH

## Test plan
- [ ] `python manage.py makemigrations workflow --name flowproject_metadata` regenerates `0007_flowproject_metadata.py` (migrations are gitignored in this repo)
- [ ] `python manage.py migrate workflow` applies cleanly
- [ ] `pytest tests/test_metadata.py -v` passes all 4 cases
- [ ] `pnpm exec tsc --noEmit` is clean (verified locally)
- [ ] Manual E2E with `docker-compose up`:
  - [ ] Create flow: new modal shows MetadataEditor; preset chip click adds a row; saved project has the metadata
  - [ ] Edit flow: existing metadata hydrates; add/edit/delete rows; Save persists
  - [ ] Duplicate keys: warning shown; last row wins on save
  - [ ] Empty keys: not sent on save
- [ ] MCP `get_project` returns `metadata` in the payload

🤖 Generated with [Claude Code](https://claude.com/claude-code)