### PR TITLE
Add .dockerignore to fix frontend Docker build failure

### DIFF
--- a/gui/workflow_frontend/.dockerignore
+++ b/gui/workflow_frontend/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.env
+.env.*
+*.log
+.DS_Store


### PR DESCRIPTION
## Summary

- Add `gui/workflow_frontend/.dockerignore` so the local `node_modules` (and other build artifacts) are excluded from the Docker build context.

## Background

`docker compose build` was failing on the `frontend` target with:

```
cannot replace to directory /var/lib/.../frontend/node_modules/@aspida/axios with file
```

This happened because the local `node_modules` was created by `pnpm install` (where `@aspida/axios` is a symlink into `.pnpm/`), and `COPY . /frontend` was copying that on top of the npm-style `node_modules` produced by `npm ci` inside the container, causing a directory vs. symlink conflict.

Adding `.dockerignore` keeps the local `node_modules` out of the context entirely, which is what we want anyway.

Related: #39 (lockfile duplication risk surfaced during this investigation).

## Test plan

- [ ] `cd gui && docker compose build` succeeds
- [ ] `docker compose up` starts the frontend container and the app is reachable at http://localhost:5173

🤖 Generated with [Claude Code](https://claude.com/claude-code)