### PR TITLE
PR-A: Unify MCP env var and JupyterHub URL source

### DIFF
--- a/gui/docker-compose.prod.yml
+++ b/gui/docker-compose.prod.yml
@@ -19,7 +19,7 @@ services:
       - CORS_ALLOWED_ORIGINS_EXTRA=${CORS_ALLOWED_ORIGINS_EXTRA:-https://snnbuilder.riken.jp}
       - CSRF_TRUSTED_ORIGINS_EXTRA=${CSRF_TRUSTED_ORIGINS_EXTRA:-https://snnbuilder.riken.jp}
       - DJANGO_DEBUG=${DJANGO_DEBUG:-false}
-      - JUPYTERHUB_API_URL=http://jupyterhub:8000/jupyter
+      - JUPYTERHUB_BASE_URL=${JUPYTERHUB_BASE_URL:-/jupyter/}
 
   jupyterhub:
     environment:
@@ -27,7 +27,7 @@ services:
       - JUPYTERHUB_API_TOKEN=${JUPYTERHUB_API_TOKEN:-dev-token-change-in-production}
       - JUPYTERHUB_ALLOWED_USERS=${JUPYTERHUB_ALLOWED_USERS:-user1}
       - JUPYTERHUB_AUTHENTICATOR=firstuse
-      - JUPYTERHUB_BASE_URL=/jupyter/
+      - JUPYTERHUB_BASE_URL=${JUPYTERHUB_BASE_URL:-/jupyter/}
       - JUPYTERHUB_COOKIE_SECURE=true
       - JUPYTERHUB_COOKIE_SAMESITE=None
       - JUPYTERHUB_FRAME_ORIGIN=${JUPYTERHUB_FRAME_ORIGIN:-https://snnbuilder.riken.jp}

--- a/gui/docker-compose.yml
+++ b/gui/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - OPENAI_MODEL=${OPENAI_MODEL:-gpt-4o}
       - MCP_SERVER_URL=http://mcp:8001
       - JUPYTERHUB_API_TOKEN=${JUPYTERHUB_API_TOKEN:-dev-token-change-in-production}
-      - JUPYTERHUB_API_URL=http://jupyterhub:8000
+      - JUPYTERHUB_BASE_URL=${JUPYTERHUB_BASE_URL:-/}
       - JUPYTER_EXECUTION_USER=${JUPYTER_EXECUTION_USER:-user1}
     depends_on:
       - db
@@ -49,6 +49,7 @@ services:
     environment:
       - DOCKER_HOST=unix:///var/run/docker.sock
       - JUPYTERHUB_API_TOKEN=${JUPYTERHUB_API_TOKEN:-dev-token-change-in-production}
+      - JUPYTERHUB_BASE_URL=${JUPYTERHUB_BASE_URL:-/}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:rw
       - ./workflow_backend/django-project/neuroworkflow/jupyterhub_config.py:/srv/jupyterhub/jupyterhub_config.py:ro

--- a/gui/workflow_backend/django-project/app/chat/services/mcp_client.py
+++ b/gui/workflow_backend/django-project/app/chat/services/mcp_client.py
@@ -5,10 +5,7 @@ import os
 
 logger = logging.getLogger(__name__)
 
-MCP_SERVER_URL = (
-    os.environ.get("MCP_SERVER_URL")
-    or os.environ.get("MCP_PROXY_URL", "http://mcp:8001")
-)
+MCP_SERVER_URL = os.environ.get("MCP_SERVER_URL", "http://mcp:8001")
 MCP_ENDPOINT = f"{MCP_SERVER_URL}/mcp"
 
 

--- a/gui/workflow_backend/django-project/app/workflow/jupyter_execution_service.py
+++ b/gui/workflow_backend/django-project/app/workflow/jupyter_execution_service.py
@@ -9,8 +9,17 @@ import websockets
 
 logger = logging.getLogger(__name__)
 
-# JupyterHub / Jupyter Server connection settings
-JUPYTERHUB_API_URL = os.environ.get("JUPYTERHUB_API_URL", "http://jupyterhub:8000")
+# JupyterHub / Jupyter Server connection settings.
+#
+# ``JUPYTERHUB_BASE_URL`` is the single source of truth for the JupyterHub
+# subpath: the same value is consumed by the JupyterHub container itself
+# (``jupyterhub_config.py``) and by this backend. Combining it with
+# ``JUPYTERHUB_INTERNAL_HOST`` yields the fully-qualified API base URL.
+JUPYTERHUB_INTERNAL_HOST = os.environ.get(
+    "JUPYTERHUB_INTERNAL_HOST", "http://jupyterhub:8000"
+)
+_base_url = os.environ.get("JUPYTERHUB_BASE_URL", "/").rstrip("/")
+JUPYTERHUB_API_URL = f"{JUPYTERHUB_INTERNAL_HOST}{_base_url}"
 JUPYTERHUB_API_TOKEN = os.environ.get("JUPYTERHUB_API_TOKEN") or None
 JUPYTER_USER = os.environ.get("JUPYTER_EXECUTION_USER", "user1")
 

--- a/gui/workflow_backend/django-project/app/workflow/jupyter_execution_service.py
+++ b/gui/workflow_backend/django-project/app/workflow/jupyter_execution_service.py
@@ -17,9 +17,13 @@ logger = logging.getLogger(__name__)
 # ``JUPYTERHUB_INTERNAL_HOST`` yields the fully-qualified API base URL.
 JUPYTERHUB_INTERNAL_HOST = os.environ.get(
     "JUPYTERHUB_INTERNAL_HOST", "http://jupyterhub:8000"
+).rstrip("/")
+_base_url = os.environ.get("JUPYTERHUB_BASE_URL", "/").strip("/")
+JUPYTERHUB_API_URL = (
+    f"{JUPYTERHUB_INTERNAL_HOST}/{_base_url}"
+    if _base_url
+    else JUPYTERHUB_INTERNAL_HOST
 )
-_base_url = os.environ.get("JUPYTERHUB_BASE_URL", "/").rstrip("/")
-JUPYTERHUB_API_URL = f"{JUPYTERHUB_INTERNAL_HOST}{_base_url}"
 JUPYTERHUB_API_TOKEN = os.environ.get("JUPYTERHUB_API_TOKEN") or None
 JUPYTER_USER = os.environ.get("JUPYTER_EXECUTION_USER", "user1")
 


### PR DESCRIPTION
## Summary

First slice of the Dev/Prod parity work tracked in #45 (PR-A: T1 + T2).

- **T1**: Drop the legacy `MCP_PROXY_URL` fallback in `mcp_client.py`. Both compose files already standardize on `MCP_SERVER_URL`, so the fallback is dead code that only hides env-var drift.
- **T2**: Make `JUPYTERHUB_BASE_URL` the single source of truth for the JupyterHub subpath. The backend now derives its API URL from `JUPYTERHUB_INTERNAL_HOST` + `JUPYTERHUB_BASE_URL` instead of relying on a hand-synced `JUPYTERHUB_API_URL`. Both compose files now pass the same `JUPYTERHUB_BASE_URL` value to the `backend` and `jupyterhub` services, so changing the subpath only requires editing one variable.

## Changes

- `gui/workflow_backend/django-project/app/chat/services/mcp_client.py` — read `MCP_SERVER_URL` only
- `gui/workflow_backend/django-project/app/workflow/jupyter_execution_service.py` — derive `JUPYTERHUB_API_URL` from `JUPYTERHUB_INTERNAL_HOST` + `JUPYTERHUB_BASE_URL`
- `gui/docker-compose.yml` — replace `JUPYTERHUB_API_URL` on `backend` with `JUPYTERHUB_BASE_URL=\${JUPYTERHUB_BASE_URL:-/}`; add the same to `jupyterhub`
- `gui/docker-compose.prod.yml` — replace `JUPYTERHUB_API_URL` on `backend` with `JUPYTERHUB_BASE_URL=\${JUPYTERHUB_BASE_URL:-/jupyter/}`; align the existing `jupyterhub` entry with the same form

## Test plan

- [x] `grep -rn 'MCP_PROXY_URL' gui/ src/` → 0 matches
- [x] `grep -n 'JUPYTERHUB_API_URL' gui/docker-compose.yml gui/docker-compose.prod.yml` → 0 matches
- [x] `docker compose -f gui/docker-compose.yml config --quiet` succeeds
- [x] `docker compose -f gui/docker-compose.yml -f gui/docker-compose.prod.yml config --quiet` succeeds
- [x] Dev smoke: `cd gui && docker compose up --build`, log in, create a workflow, generate code, execute via Jupyter end-to-end
- [x] Prod-like local smoke (overlay with `.env` overriding cookie/secure flags to HTTP)

## Notes

- Default behavior is preserved: with `JUPYTERHUB_BASE_URL` unset, Dev resolves to `http://jupyterhub:8000` (root) and Prod resolves to `http://jupyterhub:8000/jupyter` exactly as before.
- Developers with a stale local `.env` that hardcodes `MCP_PROXY_URL` will need to rename it to `MCP_SERVER_URL`.
- Targets the `feature/45-…` integration branch, not `main` directly; this is the first of a planned series of small PRs against that branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)