### PR TITLE
PR-B: Unify frontend URL structure and make API timeout configurable

### DIFF
--- a/gui/docker-compose.yml
+++ b/gui/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       - OPENAI_MODEL=${OPENAI_MODEL:-gpt-4o}
       - MCP_SERVER_URL=http://mcp:8001
       - JUPYTERHUB_API_TOKEN=${JUPYTERHUB_API_TOKEN:-dev-token-change-in-production}
-      - JUPYTERHUB_BASE_URL=${JUPYTERHUB_BASE_URL:-/}
+      - JUPYTERHUB_BASE_URL=${JUPYTERHUB_BASE_URL:-/jupyter/}
       - JUPYTER_EXECUTION_USER=${JUPYTER_EXECUTION_USER:-user1}
     depends_on:
       - db
@@ -49,7 +49,7 @@ services:
     environment:
       - DOCKER_HOST=unix:///var/run/docker.sock
       - JUPYTERHUB_API_TOKEN=${JUPYTERHUB_API_TOKEN:-dev-token-change-in-production}
-      - JUPYTERHUB_BASE_URL=${JUPYTERHUB_BASE_URL:-/}
+      - JUPYTERHUB_BASE_URL=${JUPYTERHUB_BASE_URL:-/jupyter/}
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:rw
       - ./workflow_backend/django-project/neuroworkflow/jupyterhub_config.py:/srv/jupyterhub/jupyterhub_config.py:ro
@@ -69,10 +69,11 @@ services:
     env_file:
       - ./workflow_frontend/.env
     depends_on:
-      - backend 
+      - backend
     restart: unless-stopped
     networks:
       - workflow
+      - jupyterhub-network
 
   mcp:
     build: ./mcp_server

--- a/gui/workflow_frontend/env.template
+++ b/gui/workflow_frontend/env.template
@@ -1,11 +1,20 @@
 # Browser-facing base URLs.
-# Behind nginx these become relative paths; in local dev they use localhost:PORT.
+# These are always relative paths. In dev, the Vite proxy forwards each
+# prefix to the appropriate container; in prod, nginx does the same routing.
 VITE_API_BASE_URL=/api
-VITE_JUPYTER_BASE_URL=http://localhost:8000
+VITE_JUPYTER_BASE_URL=/jupyter
 VITE_MCP_BASE_URL=/mcp
 
-# Vite dev server proxy target (only used by vite.config.ts, not the browser)
+# Optional: override timeout (ms) for the frontend API client (default 30000).
+# VITE_API_TIMEOUT=30000
+
+# Vite dev server proxy targets (only used by vite.config.ts /
+# vite.config.docker.ts, not the browser). Defaults are appropriate for
+# `npm run dev` (localhost) and `npm run dev:docker` (container hostnames).
 # VITE_PROXY_BACKEND=http://localhost:3000
+# VITE_PROXY_JUPYTER=http://localhost:8000
+# VITE_PROXY_MCP=http://localhost:8001
+# VITE_PROXY_KEYCLOAK=http://localhost:8080
 
 # --- Authentication (Keycloak OIDC) ---
 VITE_KEYCLOAK_URL=/auth

--- a/gui/workflow_frontend/src/api/config.ts
+++ b/gui/workflow_frontend/src/api/config.ts
@@ -4,29 +4,22 @@ interface ApiConfig {
   timeout: number;
 }
 
-export const getApiConfig = (): ApiConfig => {
-  const env = import.meta.env.MODE || "development";
+const DEFAULT_TIMEOUT_MS = 30000;
 
-  switch (env) {
-    case "production":
-      return {
-        baseURL: import.meta.env.VITE_API_BASE_URL,
-        internalSecret: import.meta.env.VITE_INTERNAL_SECRET || "",
-        timeout: 10000,
-      };
-    case "staging":
-      return {
-        baseURL: import.meta.env.VITE_API_BASE_URL,
-        internalSecret: import.meta.env.VITE_INTERNAL_SECRET || "",
-        timeout: 15000,
-      };
-    default: // development
-      return {
-        baseURL: import.meta.env.VITE_API_BASE_URL,
-        internalSecret: import.meta.env.VITE_INTERNAL_SECRET || "dev-secret",
-        timeout: 30000,
-      };
-  }
+const parseTimeout = (raw: string | undefined): number => {
+  if (!raw) return DEFAULT_TIMEOUT_MS;
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_TIMEOUT_MS;
+};
+
+export const getApiConfig = (): ApiConfig => {
+  const isDev = (import.meta.env.MODE || "development") === "development";
+  return {
+    baseURL: import.meta.env.VITE_API_BASE_URL,
+    internalSecret:
+      import.meta.env.VITE_INTERNAL_SECRET || (isDev ? "dev-secret" : ""),
+    timeout: parseTimeout(import.meta.env.VITE_API_TIMEOUT),
+  };
 };
 
 export interface ApiError {

--- a/gui/workflow_frontend/vite.config.docker.ts
+++ b/gui/workflow_frontend/vite.config.docker.ts
@@ -27,7 +27,23 @@ export default defineConfig({
     },
     proxy: {
       "/api": {
-        target: "http://backend:3000",
+        target: process.env.VITE_PROXY_BACKEND || "http://backend:3000",
+        changeOrigin: true,
+        secure: false,
+      },
+      "/jupyter": {
+        target: process.env.VITE_PROXY_JUPYTER || "http://jupyterhub:8000",
+        changeOrigin: true,
+        secure: false,
+        ws: true,
+      },
+      "/mcp": {
+        target: process.env.VITE_PROXY_MCP || "http://mcp:8001",
+        changeOrigin: true,
+        secure: false,
+      },
+      "/auth": {
+        target: process.env.VITE_PROXY_KEYCLOAK || "http://keycloak:8080",
         changeOrigin: true,
         secure: false,
       },

--- a/gui/workflow_frontend/vite.config.ts
+++ b/gui/workflow_frontend/vite.config.ts
@@ -31,6 +31,22 @@ export default defineConfig({
         changeOrigin: true,
         secure: false,
       },
+      "/jupyter": {
+        target: process.env.VITE_PROXY_JUPYTER || "http://localhost:8000",
+        changeOrigin: true,
+        secure: false,
+        ws: true,
+      },
+      "/mcp": {
+        target: process.env.VITE_PROXY_MCP || "http://localhost:8001",
+        changeOrigin: true,
+        secure: false,
+      },
+      "/auth": {
+        target: process.env.VITE_PROXY_KEYCLOAK || "http://localhost:8080",
+        changeOrigin: true,
+        secure: false,
+      },
     },
   },
   resolve: {


### PR DESCRIPTION
## Summary

Second slice of the Dev/Prod parity work tracked in #45 (PR-B: T3 + T4). Builds on PR-A (already merged into the feature branch).

- **T3**: Make the browser-facing URL prefixes (`/api`, `/jupyter`, `/mcp`, `/auth`) identical in Dev and Prod, so the same `VITE_*` configuration works in both environments. The Vite dev server now proxies all four prefixes (previously only `/api`), with targets that can be overridden via `VITE_PROXY_*` env vars. To make `/jupyter` reach JupyterHub correctly in Dev, the frontend container is added to `jupyterhub-network` and Dev's default `JUPYTERHUB_BASE_URL` is changed from `/` to `/jupyter/` so JupyterHub-generated redirects match the proxy path.
- **T4**: Replace the per-Vite-MODE timeout switch in `api/config.ts` (10s/15s/30s) with a single `VITE_API_TIMEOUT` env var (default 30000), so each deployment can pick its own value without a code change or rebuild.

## Changes

- `gui/workflow_frontend/env.template` — `VITE_JUPYTER_BASE_URL` becomes the relative `/jupyter`; document optional `VITE_API_TIMEOUT` and `VITE_PROXY_*` overrides
- `gui/workflow_frontend/vite.config.ts` / `vite.config.docker.ts` — add `/jupyter` (with `ws: true`), `/mcp`, and `/auth` proxies; all targets read from `VITE_PROXY_BACKEND` / `_JUPYTER` / `_MCP` / `_KEYCLOAK` with sensible defaults
- `gui/docker-compose.yml` — frontend joins `jupyterhub-network`; Dev default `JUPYTERHUB_BASE_URL` changes from `/` to `/jupyter/`
- `gui/workflow_frontend/src/api/config.ts` — single env-driven timeout

## Behavior change to flag

Dev users who used to open `http://localhost:8000/` directly to reach JupyterHub now need to use `http://localhost:8000/jupyter/`. Access through the frontend (`http://localhost:5173`) is unaffected.

## Test plan

- [x] `docker compose -f gui/docker-compose.yml config --quiet` — succeeds
- [x] `docker compose -f gui/docker-compose.yml -f gui/docker-compose.prod.yml config --quiet` — succeeds
- [x] Dev smoke: `cd gui && docker compose up --build`; in the browser at http://localhost:5173, verify Network tab shows `/api/*`, `/jupyter/*`, `/mcp/*`, and `/auth/*` all going through the dev origin (port 5173)
- [x] Direct JupyterHub access at `http://localhost:8000/jupyter/` returns the JupyterHub login page
- [ ] Prod-like local smoke (overlay with `.env` overriding cookie/secure flags for HTTP) still passes the PR-A smoke checks
- [ ] `VITE_API_TIMEOUT=5000` in `.env` is reflected in `getApiConfig().timeout`

## Notes

- Frontend is now a member of both the `workflow` and `jupyterhub-network` networks. This is the minimal change required for the Vite proxy to reach the `jupyterhub` service from the `frontend` container in Docker Dev.
- Targets `feature/45-…` (not `main`); merges after the rest of the issue's series is staged on the same branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)