### PR TITLE
Tighten auth profile branch review fixes

### DIFF
--- a/gui/DOCKER_SETUP.md
+++ b/gui/DOCKER_SETUP.md
@@ -23,7 +23,16 @@ Copy from the corresponding `env.template` in each folder and set:
 
 - **gui/.env**: `NODES_DIR` = path to `gui/workflow_backend/django-project/codes/nodes` on your host; `HOST_PROJECT_PATH` = path to `gui/workflow_backend/django-project`.
 - **workflow_backend/.env**: Set `KEYCLOAK_URL`, `KEYCLOAK_REALM`, `KEYCLOAK_CLIENT_ID` to match the Keycloak service in `docker-compose.yml`; set `HOST_PROJECT_PATH` and other `*_PATH` to your repo’s `gui/workflow_backend/django-project` (and subdirs).
-- **workflow_frontend/.env**: `VITE_API_BASE_URL="http://localhost:3000/api"`; set `VITE_KEYCLOAK_URL`, `VITE_KEYCLOAK_REALM`, `VITE_KEYCLOAK_CLIENT_ID` to point at the same Keycloak realm and client.
+- **workflow_frontend/.env**: use relative service prefixes for app traffic:
+  `VITE_API_BASE_URL=/api`, `VITE_JUPYTER_BASE_URL=/jupyter`, and
+  `VITE_MCP_BASE_URL=/mcp`. For local development, set
+  `VITE_KEYCLOAK_URL=http://localhost:8080/auth` so browser redirects use the
+  host-reachable Keycloak URL. Production builds override this value to `/auth`
+  behind nginx.
+
+The `.env` files are gitignored, so pulling a branch that changes an
+`env.template` does not update an existing local `.env`. Compare your local
+files with the templates after pulling configuration changes.
 
 ## 2. Create directory for nodes mount (if missing)
 
@@ -67,10 +76,35 @@ First run can take several minutes (building backend and frontend images). When 
 
 - **Workflow UI**: http://localhost:5173  
 - **Django API**: http://localhost:3000  
-- **JupyterHub** (if image built): http://localhost:8000  
+- **JupyterHub** (if image built): http://localhost:8000/jupyter/
 - **MCP proxy**: http://localhost:8001  
 
-## 5. Stop
+## 5. Routing smoke checks
+
+Run these checks after changing the frontend service URLs, Keycloak settings,
+or JupyterHub base path:
+
+1. Open http://localhost:5173 and log in with Keycloak.
+2. Confirm Keycloak browser requests use `http://localhost:8080/auth` in local
+   development, not the internal Docker hostname.
+3. Confirm app requests use the frontend origin with relative prefixes:
+   `/api`, `/jupyter`, and `/mcp`.
+4. Open the user profile page. It should render identity fields from the token
+   and the account-management link should open Keycloak.
+5. Open the custom database manager and test list/create/edit/test/delete
+   operations while authenticated.
+6. Click the Jupyter button from a workflow node and confirm JupyterLab opens
+   the expected project/file under `/jupyter/` without a 404.
+
+For the RIKEN production overlay, also confirm that published service ports are
+bound to localhost, as required by the server firewall policy:
+
+```bash
+cd gui
+docker compose -f docker-compose.yml -f docker-compose.prod.yml config
+```
+
+## 6. Stop
 
 In the same terminal where you ran `docker compose up`, press **Ctrl+C**. To remove containers and volumes:
 

--- a/gui/workflow_frontend/env.template
+++ b/gui/workflow_frontend/env.template
@@ -1,11 +1,11 @@
 # Browser-facing base URLs.
-# These are always relative paths. In dev, the Vite proxy forwards each
-# prefix to the appropriate container; in prod, nginx does the same routing.
+# API, JupyterHub, and MCP use relative paths. In dev, the Vite proxy forwards
+# these prefixes; in prod, nginx does the same routing.
 VITE_API_BASE_URL=/api
 VITE_JUPYTER_BASE_URL=/jupyter
 VITE_MCP_BASE_URL=/mcp
 
-# Optional: override timeout (ms) for the frontend API client (default 30000).
+# Optional: override timeout (ms) for the typed frontend API client (default 30000).
 # VITE_API_TIMEOUT=30000
 
 # Vite dev server proxy targets (only used by vite.config.ts /
@@ -17,6 +17,9 @@ VITE_MCP_BASE_URL=/mcp
 # VITE_PROXY_KEYCLOAK=http://localhost:8080
 
 # --- Authentication (Keycloak OIDC) ---
-VITE_KEYCLOAK_URL=/auth
+# Local dev must use the browser-reachable Keycloak URL directly. Using /auth
+# through the Vite proxy can make Keycloak redirects expose internal Docker
+# hostnames. Production builds override this to /auth behind nginx.
+VITE_KEYCLOAK_URL=http://localhost:8080/auth
 VITE_KEYCLOAK_REALM=neuroworkflow
 VITE_KEYCLOAK_CLIENT_ID=neuroworkflow-app

--- a/gui/workflow_frontend/src/api/apiManager.ts
+++ b/gui/workflow_frontend/src/api/apiManager.ts
@@ -3,13 +3,50 @@ import api from "@/api/$api";
 import { getApiConfig } from "./config";
 import { createAuthHeaders } from "./authHeaders";
 
+const createTimeoutFetch = (timeoutMs: number): typeof fetch => {
+  return async (input: RequestInfo | URL, init?: RequestInit) => {
+    const controller = new AbortController();
+    const upstreamSignal = init?.signal;
+    let didTimeout = false;
+
+    const timeoutId = setTimeout(() => {
+      didTimeout = true;
+      controller.abort();
+    }, timeoutMs);
+
+    const abortFromUpstream = () => controller.abort();
+    if (upstreamSignal) {
+      if (upstreamSignal.aborted) {
+        controller.abort();
+      } else {
+        upstreamSignal.addEventListener("abort", abortFromUpstream, { once: true });
+      }
+    }
+
+    try {
+      return await fetch(input, {
+        ...init,
+        signal: controller.signal,
+      });
+    } catch (error) {
+      if (didTimeout) {
+        throw new Error(`Request timed out after ${timeoutMs}ms`);
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeoutId);
+      upstreamSignal?.removeEventListener("abort", abortFromUpstream);
+    }
+  };
+};
+
 // Creating an API client
 const createApiClient = async () => {
   const config = getApiConfig();
   const headers = await createAuthHeaders();
 
   return api(
-    aspida(fetch, {
+    aspida(createTimeoutFetch(config.timeout), {
       baseURL: config.baseURL,
       headers,
     })


### PR DESCRIPTION
This is the PR regarding the merge of https://github.com/oist/neuro-workflow/tree/fix/auth-headers-and-profile
## Summary
- Clarify the local Keycloak URL exception so dev uses the browser-reachable `http://localhost:8080/auth` while production still overrides to `/auth` behind nginx.
- Enforce `VITE_API_TIMEOUT` in the typed frontend API client with an AbortController-backed fetch wrapper.
- Document the required `.env` update behavior and smoke checks for Keycloak, custom databases, JupyterHub, and RIKEN localhost port binding.

## Test plan
- [x] `git diff --check`
- [x] Cursor lints for `gui/workflow_frontend/src/api/apiManager.ts`
- [x] `docker compose -f docker-compose.yml config --quiet`
- [x] `docker compose -f docker-compose.yml -f docker-compose.prod.yml config --quiet`
- [ ] Frontend build not run locally because host `gui/workflow_frontend/node_modules` is absent; the running deployment uses the built Docker image.
- [ ] Manual smoke: Keycloak login, profile page, custom database CRUD/test connection, and Jupyter node launch under `/jupyter/`. 

@carlosengutierrez please, let me know, if there are any issues. 