### PR TITLE
Allow owners to manage inactive custom databases

### DIFF
--- a/gui/workflow_backend/django-project/app/metadata/tests.py
+++ b/gui/workflow_backend/django-project/app/metadata/tests.py
@@ -1,0 +1,58 @@
+from django.contrib.auth import get_user_model
+from django.test import TestCase
+from rest_framework import status
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from .models import CustomDatabase
+from .views import CustomDatabaseDetailView, CustomDatabaseListView
+
+
+class CustomDatabaseAccessTests(TestCase):
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        User = get_user_model()
+        self.owner = User.objects.create_user(username="owner")
+        self.other_user = User.objects.create_user(username="other")
+
+    def _database(self, **overrides):
+        data = {
+            "name": "Test custom database",
+            "base_url": "https://example.com",
+            "adapter_type": "rest_api",
+            "is_active": True,
+            "created_by": self.owner,
+        }
+        data.update(overrides)
+        return CustomDatabase.objects.create(**data)
+
+    def test_list_only_returns_active_databases(self):
+        active = self._database(name="Active database")
+        self._database(name="Inactive database", is_active=False)
+
+        request = self.factory.get("/api/metadata/custom-databases/")
+        force_authenticate(request, user=self.owner)
+
+        response = CustomDatabaseListView.as_view()(request)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual([item["id"] for item in response.data], [str(active.id)])
+
+    def test_owner_can_delete_inactive_database(self):
+        database = self._database(is_active=False)
+
+        request = self.factory.delete(f"/api/metadata/custom-databases/{database.id}/")
+        force_authenticate(request, user=self.owner)
+
+        response = CustomDatabaseDetailView.as_view()(request, db_id=database.id)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_other_user_cannot_manage_database(self):
+        database = self._database()
+
+        request = self.factory.get(f"/api/metadata/custom-databases/{database.id}/")
+        force_authenticate(request, user=self.other_user)
+
+        response = CustomDatabaseDetailView.as_view()(request, db_id=database.id)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/gui/workflow_backend/django-project/app/metadata/views.py
+++ b/gui/workflow_backend/django-project/app/metadata/views.py
@@ -39,6 +39,19 @@ def _visible_custom_databases(user):
     )
 
 
+def _manageable_custom_databases(user):
+    """Return records a user may inspect for management actions.
+
+    Listing and suggestion use should stay active-only, but owners need to be
+    able to update/reactivate/delete their inactive databases.
+    """
+    if not user or not user.is_authenticated:
+        return CustomDatabase.objects.none()
+    if user and user.is_staff:
+        return CustomDatabase.objects.all()
+    return CustomDatabase.objects.filter(created_by=user)
+
+
 def _can_modify_custom_database(user, database):
     if not user or not user.is_authenticated:
         return False
@@ -463,7 +476,7 @@ class CustomDatabaseDetailView(APIView):
     def get(self, request, db_id):
         """Get custom database details."""
         try:
-            database = _visible_custom_databases(request.user).get(id=db_id)
+            database = _manageable_custom_databases(request.user).get(id=db_id)
             serializer = CustomDatabaseSerializer(database)
             return Response(serializer.data, status=status.HTTP_200_OK)
         except CustomDatabase.DoesNotExist:
@@ -481,7 +494,7 @@ class CustomDatabaseDetailView(APIView):
     def put(self, request, db_id):
         """Update custom database."""
         try:
-            database = _visible_custom_databases(request.user).get(id=db_id)
+            database = _manageable_custom_databases(request.user).get(id=db_id)
             if not _can_modify_custom_database(request.user, database):
                 return Response(
                     {"error": "You don't have permission to update this database"},
@@ -524,7 +537,7 @@ class CustomDatabaseDetailView(APIView):
     def delete(self, request, db_id):
         """Delete custom database (soft delete by setting is_active=False)."""
         try:
-            database = _visible_custom_databases(request.user).get(id=db_id)
+            database = _manageable_custom_databases(request.user).get(id=db_id)
             if not _can_modify_custom_database(request.user, database):
                 return Response(
                     {"error": "You don't have permission to delete this database"},


### PR DESCRIPTION
## Summary
- Keep custom database list/suggestion discovery active-only.
- Add a separate owner/admin management query so users can inspect, update, reactivate, or delete inactive custom databases they own.
- Add regression tests for active-only listing, owner deletion of inactive databases, and cross-user isolation.

## Test plan
- [x] `git diff --check`
- [x] Cursor lints for `app/metadata/views.py` and `app/metadata/tests.py`
- [x] `docker exec neuro-workflow-backend-1 python3 django-project/manage.py check`
- [x] `docker exec neuro-workflow-backend-1 python3 django-project/manage.py test app.metadata.tests`
- [x] Restarted backend and verified custom database smoke flow: list, test connection, create, update to inactive, delete after inactive.
- [x] Rebuilt frontend container from this branch and verified Custom Databases page no longer shows the stale unauthenticated 401.
- [x] Post-smoke cleanup verified no temporary smoke users or database rows remain.