### PR TITLE
Add hackathon participant kit (agent node-building flow)

### DIFF
--- a/.claude/skills/create-node/SKILL.md
+++ b/.claude/skills/create-node/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: create-node
+description: Create a new NeuroWorkflow node (NEST / TVB / Brian2 / custom computation) following the NODE_CREATION_GUIDE.md conventions, then generate the file. Use when the user wants to build or add a workflow node.
+---
+
 # Create NeuroWorkflow Node
 
 Guide the user through creating a new node following the NODE_CREATION_GUIDE.md conventions, then generate the file.

--- a/hackathon/AGENTS.md
+++ b/hackathon/AGENTS.md
@@ -1,0 +1,255 @@
+# NeuroWorkflow Hackathon — Agent Instructions
+
+> **This file is the canonical participant instruction set. It is shipped as TWO identical files:**
+> **`CLAUDE.md`** (read automatically by Claude Code) and **`AGENTS.md`** (read automatically by Codex).
+> Each agent additionally auto-loads the `create-node` skill from its own path —
+> `.claude/skills/create-node/SKILL.md` for Claude Code, `.codex/skills/create-node/SKILL.md` for Codex —
+> which is the preferred path. This file is still written to be fully **self-contained** — an agent that
+> has only this file (even on a small model) can still succeed.
+> See `SETUP.md` for the exact per-agent environment setup and the prompt to give the agent.
+
+---
+
+## Who you are and what we are doing
+
+You are an AI coding agent helping a neuroscientist at a hackathon. The participant has **their
+own Python code** (a neuron/network model, a data-loading or analysis script — possibly messy and
+unstructured). They do **not** know NeuroWorkflow internals.
+
+**Your mission:** turn their Python code into one or more **NeuroWorkflow nodes**, wire those nodes
+into a **workflow**, and **prove it runs locally in a Jupyter notebook**. After that, the participant
+uploads the node files to the NeuroWorkflow web app and reproduces the workflow visually.
+
+This is NOT a task about developing the NeuroWorkflow platform itself (Django/React/Docker). Do not
+touch any platform code. You only author **node files** and **workflow files** from the participant's
+own code.
+
+### The hackathon has four steps (you handle steps 1–2; the GUI handles 3–4)
+
+1. **Local node building** — convert the participant's Python into NeuroWorkflow node classes. ← you
+2. **Local workflow & testing** — wire nodes into a workflow, run it in a Jupyter notebook, validate outputs. ← you
+3. **Upload & reproduce in the GUI** — participant uploads node `.py` files, rebuilds the graph (drag-drop or in-app AI agent).
+4. **Run on the server** — execute on the HPC backend, collect results.
+
+A node that works in step 2 is the deliverable that makes steps 3–4 possible. **Optimize for a clean,
+uploadable, well-described node.**
+
+---
+
+## What a NeuroWorkflow node IS (the contract you must produce)
+
+A node is a Python class that subclasses `Node` and declares a single `NODE_DEFINITION` schema. The
+framework reads that schema to auto-create input/output ports and parameters, and to let humans AND
+other AI agents connect it to nodes they have never seen. **The descriptions are part of the product.**
+
+```python
+from typing import Dict, Any
+
+# domain imports (e.g. import nest, import numpy as np) go here
+
+from neuroworkflow.core.node import Node
+from neuroworkflow.core.schema import (
+    NodeDefinitionSchema, PortDefinition, ParameterDefinition, MethodDefinition,
+)
+from neuroworkflow.core.port import PortType
+
+
+class MyModelNode(Node):
+    NODE_DEFINITION = NodeDefinitionSchema(
+        type="my_model",                 # globally UNIQUE snake_case id — never reuse an existing one
+        stage="simulation",              # see Stage list below
+        tool="NEST",                     # simulator/library, or "custom"
+        model_source="https://...",      # URL to the paper/repo/docs this implements
+        description="One scientifically specific sentence, written for an AI to read.",
+        parameters={
+            "duration_ms": ParameterDefinition(
+                default_value=1000.0,
+                description="Simulation duration in milliseconds.",
+                # constraints={"min": 1.0, "max": 100000.0},      # add when a valid range exists
+                # optimizable=True, optimization_range=[100.0, 5000.0],  # add for tunable params
+            ),
+        },
+        inputs={
+            "network": PortDefinition(
+                type=PortType.OBJECT,
+                description="Live NEST NodeCollection produced by the network node.",
+                # optional=True,   # only if the method works without it
+            ),
+        },
+        outputs={
+            "firing_rate_hz": PortDefinition(
+                type=PortType.DICT,
+                description="Mean firing rate per population in Hz, keyed by population name.",
+            ),
+        },
+        methods={
+            "run": MethodDefinition(
+                description="Simulate the network and compute per-population firing rates.",
+                inputs=["network"],
+                outputs=["firing_rate_hz"],
+            ),
+        },
+    )
+
+    def __init__(self, name: str):
+        super().__init__(name)
+        self._define_process_steps()
+
+    def _define_process_steps(self) -> None:
+        # one call per method, in execution order
+        self.add_process_step("run", self.run, method_key="run")
+
+    def run(self, network) -> Dict[str, Any]:
+        duration = float(self._parameters["duration_ms"])   # read params via self._parameters[...]
+        # ... the participant's actual code goes here ...
+        rates = {"exc": 8.3, "inh": 21.0}
+        # CRITICAL: dict keys MUST exactly match the output port names declared above.
+        return {"firing_rate_hz": rates}
+```
+
+### Hard rules the framework will not warn you loudly about
+
+- **Output key == port name.** If a method's return dict key does not match a declared output port,
+  the port is silently left as `None`. This is the #1 cause of "it ran but produced nothing."
+- **Errors are swallowed.** `Node.process()` catches exceptions, prints them, and returns `False`.
+  A workflow can "finish" while a node failed. **Always check that outputs are not `None`** (see smoke test).
+- **Read parameters with `self._parameters["key"]`.** There is no `get_parameter()`.
+- **Inter-step data flows by name.** A method's returned dict key becomes the next method's argument of
+  the same name. No instance variables needed for passing data between steps.
+- **`is_objective` / `objective_range` belong only on `ParameterDefinition`, never on `PortDefinition`**
+  (it raises `TypeError` at import).
+
+---
+
+## Choosing the right `PortType`
+
+Decision rule: *"Could this data be serialized to JSON without losing information?"*
+- **Yes** → `DICT`, `LIST`, `STR`, `FLOAT`, `BOOL`, `INT`
+- **No** (simulator object, model instance, NEST NodeCollection, TVB connectivity) → `OBJECT`
+
+Available: `ANY, INT, FLOAT, STR, BOOL, LIST, DICT, OBJECT, FILE_PATH, CSV_FILE, JSON_FILE, PICKLE_FILE, NUMPY_FILE, HDF5_FILE`.
+
+**Avoid `OBJECT` overuse.** `OBJECT` connects to anything, so it never errors — but it hides what the
+port carries. Prefer a `DICT` with well-named, unit-bearing keys (`firing_rate_hz`, `spike_times_ms`,
+`membrane_potential_mv`). A well-described `DICT` is far more composable than a simulator-specific object.
+
+---
+
+## Stage list (what role the node plays in the pipeline)
+
+`io` · `neuron` · `population` · `synapse` · `connectivity` · `stimulus` · `simulation` · `analysis` · `optimization`
+
+Pick the stage by reasoning about what the node **consumes** and **produces**, not by keyword matching.
+If nothing fits cleanly, propose a new short lowercase stage name and say why. (Full semantic guide:
+`NODE_CREATION_GUIDE.md`, if present in the working folder.)
+
+---
+
+## How to run the job (step by step)
+
+**If you are Claude Code:** invoke the `create-node` skill (run `/create-node`, or follow
+`.claude/skills/create-node/SKILL.md`) — it encodes everything below in detail. Then continue to the
+workflow + smoke test.
+
+**If you are Codex:** invoke the `create-node` skill via the `/skills` selector or a `$create-node`
+mention (it lives at `.codex/skills/create-node/SKILL.md`). There is no `/create-node` command. If the
+skill is not installed, follow the steps below directly — this file IS your skill.
+
+### 0. Confirm the environment
+- Ensure `neuroworkflow` is importable: `python -c "import neuroworkflow; print(neuroworkflow.__version__)"`.
+  If it fails, install it (see `SETUP.md`: `pip install git+https://github.com/oist/neuro-workflow.git`,
+  or `pip install -e ".[nest]"` from a clone).
+- Decide an **output folder** for the node files. Ask the user; default to `./my_nodes/`. Create it if missing.
+
+### 1. Read the participant's code and plan the nodes
+- Read every file / notebook cell they point you to (default source folder: `./source_code/`).
+- **One node = one scientific operation at one stage** — not one whole script, not one line.
+- Map the code to candidate nodes BEFORE writing. If several variants share the same inputs/outputs and
+  differ only by parameters, prefer **one configurable node** with a `model_type`-style parameter.
+- For a notebook: each coherent group of cells that yields a self-contained scientific object is a node;
+  the notebook's literal values become the `default_value`s.
+
+### 2. Ask the participant (in ONE message) only what you cannot infer
+Node name(s); the model source URL; and anything ambiguous about parameters or what each step produces.
+Infer stage, tool, port types, and `optional=True` from the code — do not interrogate.
+Mark a port `optional=True` only if the method has `=None` / an `if x is None:` guard for it.
+**Ask for confirmation of the proposed node breakdown before writing files.**
+
+### 3. Write each node file
+Use the template above. Put domain imports at the top. Keep the participant's real logic inside the
+method bodies. Write **specific** descriptions (units + meaning) on every port and parameter.
+
+If the node writes files to disk, read the output dir from context first:
+```python
+import os
+data_path = self._context.get("results_path", "results/")
+os.makedirs(data_path, exist_ok=True)   # create BEFORE the simulator initializes
+```
+
+**NEST only:** never call `nest.ResetKernel()` at import or in `__init__` — only inside a method.
+
+### 4. Smoke-test every node (do this; do not skip)
+```python
+import sys; sys.path.insert(0, "<output_folder>")     # standalone mode
+from MyModelNode import MyModelNode
+n = MyModelNode("test")
+print(n.get_info())     # must list the ports/params you declared
+```
+Fix any import or schema error before moving on.
+
+### 5. Build and test the workflow in a notebook
+Create a workflow `.py` AND `.ipynb` that wire the nodes and run end-to-end. Save both in the output
+folder (default `./my_nodes/`):
+```python
+import os
+from neuroworkflow import WorkflowBuilder
+# import nodes ...
+
+a = NodeA("NodeA"); b = NodeB("NodeB")
+a.configure(param=value); b.configure(param=value)
+
+wf = WorkflowBuilder("MyWorkflow")
+wf.add_node(a); wf.add_node(b)
+wf.connect("NodeA", "out_port", "NodeB", "in_port")    # names must match declared ports
+
+wf.context["results_path"] = os.path.join(os.getcwd(), "results")   # set BEFORE build()
+workflow = wf.build()
+ok = workflow.execute()
+assert ok, "workflow.execute() returned False — a node failed (check printed errors)"
+
+# VALIDATE: outputs must not be None
+for name, node in workflow.nodes.items():
+    for pname, port in node._output_ports.items():
+        print(name, pname, "OK" if port.value is not None else "*** None ***")
+```
+Re-run with different parameters by reconfiguring nodes and calling `execute()` again — do not rebuild.
+
+### 6. Report to the participant
+- The **absolute path of every file you created**.
+- Confirmation the smoke test and workflow run passed and outputs are non-`None`.
+- Which node file(s) to **upload to the web app** and under which **GUI category**. The GUI has exactly
+  six upload categories: `analysis`, `io`, `network`, `optimization`, `simulation`, `stimulus`. Map the
+  node's `stage` to one of these — the network-building stages (`neuron`, `population`, `synapse`,
+  `connectivity`) all upload under **`network`**; the rest map to the category of the same name.
+- A one-line summary of each node's inputs/outputs so they can reconnect the graph in the GUI.
+
+---
+
+## Handoff to the web app (so steps 3–4 work)
+
+The web app uploads **node `.py` files**, parses each `NODE_DEFINITION`, and shows the node in the
+palette. There is no "import workflow file" button — the participant rebuilds the graph by drag-drop or
+by asking the **in-app AI assistant** to add and connect the nodes. To make that easy, your node files
+must be **import-clean**: no machine-specific `sys.path` hacks inside the node file, imports limited to
+`neuroworkflow.core.*` + standard domain libraries. Keep any `sys.path.insert` only in the local
+*workflow* file, never in the node files that get uploaded.
+
+---
+
+## Behavioral guidelines (keep it simple and honest)
+
+- State assumptions; if a requirement is ambiguous and you cannot infer it from the code, ask once.
+- Minimum code that solves the problem. Preserve the participant's scientific logic; don't "improve" it.
+- Verify, don't assume: a node is done only when its smoke test passes and the workflow produces
+  non-`None` outputs.
+- Always end by reporting the absolute paths of the files you created and the exact upload instructions.

--- a/hackathon/AGENTS.md
+++ b/hackathon/AGENTS.md
@@ -29,7 +29,7 @@ own code.
 1. **Local node building** — convert the participant's Python into NeuroWorkflow node classes. ← you
 2. **Local workflow & testing** — wire nodes into a workflow, run it in a Jupyter notebook, validate outputs. ← you
 3. **Upload & reproduce in the GUI** — participant uploads node `.py` files, rebuilds the graph (drag-drop or in-app AI agent).
-4. **Run on the server** — execute on the HPC backend, collect results.
+4. **Run on the server** — execute on the application server, collect results.
 
 A node that works in step 2 is the deliverable that makes steps 3–4 possible. **Optimize for a clean,
 uploadable, well-described node.**

--- a/hackathon/CLAUDE.md
+++ b/hackathon/CLAUDE.md
@@ -1,0 +1,255 @@
+# NeuroWorkflow Hackathon — Agent Instructions
+
+> **This file is the canonical participant instruction set. It is shipped as TWO identical files:**
+> **`CLAUDE.md`** (read automatically by Claude Code) and **`AGENTS.md`** (read automatically by Codex).
+> Each agent additionally auto-loads the `create-node` skill from its own path —
+> `.claude/skills/create-node/SKILL.md` for Claude Code, `.codex/skills/create-node/SKILL.md` for Codex —
+> which is the preferred path. This file is still written to be fully **self-contained** — an agent that
+> has only this file (even on a small model) can still succeed.
+> See `SETUP.md` for the exact per-agent environment setup and the prompt to give the agent.
+
+---
+
+## Who you are and what we are doing
+
+You are an AI coding agent helping a neuroscientist at a hackathon. The participant has **their
+own Python code** (a neuron/network model, a data-loading or analysis script — possibly messy and
+unstructured). They do **not** know NeuroWorkflow internals.
+
+**Your mission:** turn their Python code into one or more **NeuroWorkflow nodes**, wire those nodes
+into a **workflow**, and **prove it runs locally in a Jupyter notebook**. After that, the participant
+uploads the node files to the NeuroWorkflow web app and reproduces the workflow visually.
+
+This is NOT a task about developing the NeuroWorkflow platform itself (Django/React/Docker). Do not
+touch any platform code. You only author **node files** and **workflow files** from the participant's
+own code.
+
+### The hackathon has four steps (you handle steps 1–2; the GUI handles 3–4)
+
+1. **Local node building** — convert the participant's Python into NeuroWorkflow node classes. ← you
+2. **Local workflow & testing** — wire nodes into a workflow, run it in a Jupyter notebook, validate outputs. ← you
+3. **Upload & reproduce in the GUI** — participant uploads node `.py` files, rebuilds the graph (drag-drop or in-app AI agent).
+4. **Run on the server** — execute on the application server, collect results.
+
+A node that works in step 2 is the deliverable that makes steps 3–4 possible. **Optimize for a clean,
+uploadable, well-described node.**
+
+---
+
+## What a NeuroWorkflow node IS (the contract you must produce)
+
+A node is a Python class that subclasses `Node` and declares a single `NODE_DEFINITION` schema. The
+framework reads that schema to auto-create input/output ports and parameters, and to let humans AND
+other AI agents connect it to nodes they have never seen. **The descriptions are part of the product.**
+
+```python
+from typing import Dict, Any
+
+# domain imports (e.g. import nest, import numpy as np) go here
+
+from neuroworkflow.core.node import Node
+from neuroworkflow.core.schema import (
+    NodeDefinitionSchema, PortDefinition, ParameterDefinition, MethodDefinition,
+)
+from neuroworkflow.core.port import PortType
+
+
+class MyModelNode(Node):
+    NODE_DEFINITION = NodeDefinitionSchema(
+        type="my_model",                 # globally UNIQUE snake_case id — never reuse an existing one
+        stage="simulation",              # see Stage list below
+        tool="NEST",                     # simulator/library, or "custom"
+        model_source="https://...",      # URL to the paper/repo/docs this implements
+        description="One scientifically specific sentence, written for an AI to read.",
+        parameters={
+            "duration_ms": ParameterDefinition(
+                default_value=1000.0,
+                description="Simulation duration in milliseconds.",
+                # constraints={"min": 1.0, "max": 100000.0},      # add when a valid range exists
+                # optimizable=True, optimization_range=[100.0, 5000.0],  # add for tunable params
+            ),
+        },
+        inputs={
+            "network": PortDefinition(
+                type=PortType.OBJECT,
+                description="Live NEST NodeCollection produced by the network node.",
+                # optional=True,   # only if the method works without it
+            ),
+        },
+        outputs={
+            "firing_rate_hz": PortDefinition(
+                type=PortType.DICT,
+                description="Mean firing rate per population in Hz, keyed by population name.",
+            ),
+        },
+        methods={
+            "run": MethodDefinition(
+                description="Simulate the network and compute per-population firing rates.",
+                inputs=["network"],
+                outputs=["firing_rate_hz"],
+            ),
+        },
+    )
+
+    def __init__(self, name: str):
+        super().__init__(name)
+        self._define_process_steps()
+
+    def _define_process_steps(self) -> None:
+        # one call per method, in execution order
+        self.add_process_step("run", self.run, method_key="run")
+
+    def run(self, network) -> Dict[str, Any]:
+        duration = float(self._parameters["duration_ms"])   # read params via self._parameters[...]
+        # ... the participant's actual code goes here ...
+        rates = {"exc": 8.3, "inh": 21.0}
+        # CRITICAL: dict keys MUST exactly match the output port names declared above.
+        return {"firing_rate_hz": rates}
+```
+
+### Hard rules the framework will not warn you loudly about
+
+- **Output key == port name.** If a method's return dict key does not match a declared output port,
+  the port is silently left as `None`. This is the #1 cause of "it ran but produced nothing."
+- **Errors are swallowed.** `Node.process()` catches exceptions, prints them, and returns `False`.
+  A workflow can "finish" while a node failed. **Always check that outputs are not `None`** (see smoke test).
+- **Read parameters with `self._parameters["key"]`.** There is no `get_parameter()`.
+- **Inter-step data flows by name.** A method's returned dict key becomes the next method's argument of
+  the same name. No instance variables needed for passing data between steps.
+- **`is_objective` / `objective_range` belong only on `ParameterDefinition`, never on `PortDefinition`**
+  (it raises `TypeError` at import).
+
+---
+
+## Choosing the right `PortType`
+
+Decision rule: *"Could this data be serialized to JSON without losing information?"*
+- **Yes** → `DICT`, `LIST`, `STR`, `FLOAT`, `BOOL`, `INT`
+- **No** (simulator object, model instance, NEST NodeCollection, TVB connectivity) → `OBJECT`
+
+Available: `ANY, INT, FLOAT, STR, BOOL, LIST, DICT, OBJECT, FILE_PATH, CSV_FILE, JSON_FILE, PICKLE_FILE, NUMPY_FILE, HDF5_FILE`.
+
+**Avoid `OBJECT` overuse.** `OBJECT` connects to anything, so it never errors — but it hides what the
+port carries. Prefer a `DICT` with well-named, unit-bearing keys (`firing_rate_hz`, `spike_times_ms`,
+`membrane_potential_mv`). A well-described `DICT` is far more composable than a simulator-specific object.
+
+---
+
+## Stage list (what role the node plays in the pipeline)
+
+`io` · `neuron` · `population` · `synapse` · `connectivity` · `stimulus` · `simulation` · `analysis` · `optimization`
+
+Pick the stage by reasoning about what the node **consumes** and **produces**, not by keyword matching.
+If nothing fits cleanly, propose a new short lowercase stage name and say why. (Full semantic guide:
+`NODE_CREATION_GUIDE.md`, if present in the working folder.)
+
+---
+
+## How to run the job (step by step)
+
+**If you are Claude Code:** invoke the `create-node` skill (run `/create-node`, or follow
+`.claude/skills/create-node/SKILL.md`) — it encodes everything below in detail. Then continue to the
+workflow + smoke test.
+
+**If you are Codex:** invoke the `create-node` skill via the `/skills` selector or a `$create-node`
+mention (it lives at `.codex/skills/create-node/SKILL.md`). There is no `/create-node` command. If the
+skill is not installed, follow the steps below directly — this file IS your skill.
+
+### 0. Confirm the environment
+- Ensure `neuroworkflow` is importable: `python -c "import neuroworkflow; print(neuroworkflow.__version__)"`.
+  If it fails, install it (see `SETUP.md`: `pip install git+https://github.com/oist/neuro-workflow.git`,
+  or `pip install -e ".[nest]"` from a clone).
+- Decide an **output folder** for the node files. Ask the user; default to `./my_nodes/`. Create it if missing.
+
+### 1. Read the participant's code and plan the nodes
+- Read every file / notebook cell they point you to (default source folder: `./source_code/`).
+- **One node = one scientific operation at one stage** — not one whole script, not one line.
+- Map the code to candidate nodes BEFORE writing. If several variants share the same inputs/outputs and
+  differ only by parameters, prefer **one configurable node** with a `model_type`-style parameter.
+- For a notebook: each coherent group of cells that yields a self-contained scientific object is a node;
+  the notebook's literal values become the `default_value`s.
+
+### 2. Ask the participant (in ONE message) only what you cannot infer
+Node name(s); the model source URL; and anything ambiguous about parameters or what each step produces.
+Infer stage, tool, port types, and `optional=True` from the code — do not interrogate.
+Mark a port `optional=True` only if the method has `=None` / an `if x is None:` guard for it.
+**Ask for confirmation of the proposed node breakdown before writing files.**
+
+### 3. Write each node file
+Use the template above. Put domain imports at the top. Keep the participant's real logic inside the
+method bodies. Write **specific** descriptions (units + meaning) on every port and parameter.
+
+If the node writes files to disk, read the output dir from context first:
+```python
+import os
+data_path = self._context.get("results_path", "results/")
+os.makedirs(data_path, exist_ok=True)   # create BEFORE the simulator initializes
+```
+
+**NEST only:** never call `nest.ResetKernel()` at import or in `__init__` — only inside a method.
+
+### 4. Smoke-test every node (do this; do not skip)
+```python
+import sys; sys.path.insert(0, "<output_folder>")     # standalone mode
+from MyModelNode import MyModelNode
+n = MyModelNode("test")
+print(n.get_info())     # must list the ports/params you declared
+```
+Fix any import or schema error before moving on.
+
+### 5. Build and test the workflow in a notebook
+Create a workflow `.py` AND `.ipynb` that wire the nodes and run end-to-end. Save both in the output
+folder (default `./my_nodes/`):
+```python
+import os
+from neuroworkflow import WorkflowBuilder
+# import nodes ...
+
+a = NodeA("NodeA"); b = NodeB("NodeB")
+a.configure(param=value); b.configure(param=value)
+
+wf = WorkflowBuilder("MyWorkflow")
+wf.add_node(a); wf.add_node(b)
+wf.connect("NodeA", "out_port", "NodeB", "in_port")    # names must match declared ports
+
+wf.context["results_path"] = os.path.join(os.getcwd(), "results")   # set BEFORE build()
+workflow = wf.build()
+ok = workflow.execute()
+assert ok, "workflow.execute() returned False — a node failed (check printed errors)"
+
+# VALIDATE: outputs must not be None
+for name, node in workflow.nodes.items():
+    for pname, port in node._output_ports.items():
+        print(name, pname, "OK" if port.value is not None else "*** None ***")
+```
+Re-run with different parameters by reconfiguring nodes and calling `execute()` again — do not rebuild.
+
+### 6. Report to the participant
+- The **absolute path of every file you created**.
+- Confirmation the smoke test and workflow run passed and outputs are non-`None`.
+- Which node file(s) to **upload to the web app** and under which **GUI category**. The GUI has exactly
+  six upload categories: `analysis`, `io`, `network`, `optimization`, `simulation`, `stimulus`. Map the
+  node's `stage` to one of these — the network-building stages (`neuron`, `population`, `synapse`,
+  `connectivity`) all upload under **`network`**; the rest map to the category of the same name.
+- A one-line summary of each node's inputs/outputs so they can reconnect the graph in the GUI.
+
+---
+
+## Handoff to the web app (so steps 3–4 work)
+
+The web app uploads **node `.py` files**, parses each `NODE_DEFINITION`, and shows the node in the
+palette. There is no "import workflow file" button — the participant rebuilds the graph by drag-drop or
+by asking the **in-app AI assistant** to add and connect the nodes. To make that easy, your node files
+must be **import-clean**: no machine-specific `sys.path` hacks inside the node file, imports limited to
+`neuroworkflow.core.*` + standard domain libraries. Keep any `sys.path.insert` only in the local
+*workflow* file, never in the node files that get uploaded.
+
+---
+
+## Behavioral guidelines (keep it simple and honest)
+
+- State assumptions; if a requirement is ambiguous and you cannot infer it from the code, ask once.
+- Minimum code that solves the problem. Preserve the participant's scientific logic; don't "improve" it.
+- Verify, don't assume: a node is done only when its smoke test passes and the workflow produces
+  non-`None` outputs.
+- Always end by reporting the absolute paths of the files you created and the exact upload instructions.

--- a/hackathon/README.md
+++ b/hackathon/README.md
@@ -78,6 +78,11 @@ You drive **steps 1–2** locally with your agent. Steps **3–4** happen in the
   Tweak a parameter or a connection and re-run to get a feel for the structure.
 - **What you get:** a working workflow you have run end-to-end locally, with validated outputs — the proof
   that your nodes are correct and uploadable.
+- **If your nodes need NEST/TVB and you can't install the simulator locally:** that's fine — local
+  running is **optional**. The agent can still write the node files from your code, but you won't be able
+  to *execute* them or run `check_node.py` on them locally (importing the node imports the simulator).
+  In that case, do the real run **on the server (Step 4)**, where NEST and TVB are preinstalled. Pure
+  Python / NumPy nodes (like `hello_node`) always run locally with no extra setup.
 
 ### Step 3 — Upload & reproduce in the GUI
 - **What you do:** log in to the NeuroWorkflow web app and **upload each node `.py` file** under its

--- a/hackathon/README.md
+++ b/hackathon/README.md
@@ -1,0 +1,113 @@
+# NeuroWorkflow Hackathon — Participant Guide
+
+Welcome! In this hackathon you will turn **your own Python code** into reusable **NeuroWorkflow nodes**
+and a **workflow**, with an AI coding agent doing most of the heavy lifting. You then run it locally,
+upload it to the NeuroWorkflow web app, and execute it on the server.
+
+**No prior NeuroWorkflow experience is required.** The agent + the `create-node` skill guide every step.
+
+---
+
+## What is a node / a workflow?
+
+- A **node** is a Python class wrapping one scientific operation (e.g. "build network", "run simulation",
+  "compute firing rates"). It declares its inputs, outputs, and parameters so it can be connected to other
+  nodes — even ones written by other teams or other simulators.
+- A **workflow** is a graph of connected nodes. Running it executes the nodes in order and passes data
+  along the connections.
+
+The 5-minute example in `examples/hello_node/` shows both, with no simulator needed.
+
+---
+
+## Before you come
+
+| Item | Detail |
+|------|--------|
+| **Register** | Send your name, affiliation, and email. We create your NeuroWorkflow account in advance. |
+| **Bring your code** | Any Python you have — a model, preprocessing, analysis, or simulation. **Unstructured is fine** — that is the starting point. |
+| **AI agent** | Bring your own **Claude Code** (preferred) or **Codex** subscription. If you don't have one, OpenAI API keys are provided — install **Codex** in that case. |
+| **Laptop** | Python 3 + pip. If your code needs **NEST / TVB** (or another simulator), pre-install it (conda recommended for NEST). |
+
+---
+
+## Setup (once, at the start)
+
+Run the one-command script for your agent from a fresh working folder
+(full details and a manual fallback are in [`SETUP.md`](./SETUP.md)):
+
+```bash
+# Claude Code:
+bash examples/hackathon_202607/setup_claude.sh
+# Codex:
+bash examples/hackathon_202607/setup_codex.sh
+```
+
+This creates a Python virtual environment, installs NeuroWorkflow + JupyterLab + matplotlib, makes a
+`source_code/` folder (drop your code here) and a `my_nodes/` folder (the agent writes here), and installs
+the `create-node` skill for your agent.
+
+**Sanity check — get a green run first.** Before using your own code, run the tiny example so you know the
+toolchain works and you can see what a finished node looks like:
+
+```bash
+cd hackathon/examples/hello_node
+python workflow.py        # compare the printed numbers with EXPECTED_OUTPUT.md
+```
+
+---
+
+## The agenda — four steps
+
+You drive **steps 1–2** locally with your agent. Steps **3–4** happen in the web app.
+
+### Step 1 — Local node building
+- **No code to bring?** Use [`examples/sample_target/lif_network.py`](./examples/sample_target/) — a
+  realistic, unstructured LIF-network script meant as a stand-in for your own code. Copy it into
+  `source_code/` and proceed exactly as below.
+- **What you do:** put your script in `source_code/`, start your agent, and run the `create-node` skill
+  (Claude Code: `/create-node`; Codex: the `/skills` selector or `$create-node`). The agent reads your
+  code, proposes a breakdown into nodes, **asks you to confirm**, then writes node files into `my_nodes/`.
+- **What you get:** one or more NeuroWorkflow node `.py` files in `my_nodes/`, each with a clear schema
+  (inputs, outputs, parameters) and your scientific logic inside.
+
+### Step 2 — Local workflow & testing
+- **What you do:** the agent wires your nodes into a workflow (`.py` + a Jupyter `.ipynb`) and runs it.
+  Validate it: confirm the run succeeds and **no output is `None`**. Run
+  `python check_node.py my_nodes/<NodeName>.py` on each node — it should print `ALL NODES PASSED`.
+  Tweak a parameter or a connection and re-run to get a feel for the structure.
+- **What you get:** a working workflow you have run end-to-end locally, with validated outputs — the proof
+  that your nodes are correct and uploadable.
+
+### Step 3 — Upload & reproduce in the GUI
+- **What you do:** log in to the NeuroWorkflow web app and **upload each node `.py` file** under its
+  category (`analysis`, `io`, `network`, `optimization`, `simulation`, `stimulus`). Rebuild your graph by
+  dragging nodes from the palette and connecting them — or ask the **built-in AI assistant** to add and
+  connect them (paste the node/edge summary your local agent printed).
+- **What you get:** your workflow recreated visually in the platform, ready to run.
+
+### Step 4 — Run on the server
+- **What you do:** generate the workflow code in the GUI and execute it on the compute backend.
+- **What you get:** results from a full run on shared compute, collected in the app.
+
+---
+
+## Support
+
+A built-in AI assistant is available inside the platform for participants who prefer not to use Claude
+Code or Codex directly. **Working locally with a coding agent is the recommended path** — it gives you
+full control over node development. If a simulator install fails or anything blocks you, ask an organizer
+rather than burning session time.
+
+---
+
+## What's in this folder
+
+| File | Purpose |
+|------|---------|
+| [`README.md`](./README.md) | This guide. |
+| [`SETUP.md`](./SETUP.md) | Exact setup steps (scripts + manual fallback) for both agents. |
+| [`CLAUDE.md`](./CLAUDE.md) / [`AGENTS.md`](./AGENTS.md) | The agent's instructions (identical; Claude Code reads `CLAUDE.md`, Codex reads `AGENTS.md`). |
+| [`check_node.py`](./check_node.py) | Deterministic node validator (`ALL NODES PASSED` / failures). |
+| [`examples/hello_node/`](./examples/hello_node/) | The dependency-free 5-minute green-run example. |
+| [`examples/sample_target/`](./examples/sample_target/) | A realistic unstructured script to use as input if you didn't bring your own code. |

--- a/hackathon/README.md
+++ b/hackathon/README.md
@@ -27,7 +27,7 @@ The 5-minute example in `examples/hello_node/` shows both, with no simulator nee
 | **Register** | Send your name, affiliation, and email. We create your NeuroWorkflow account in advance. |
 | **Bring your code** | Any Python you have — a model, preprocessing, analysis, or simulation. **Unstructured is fine** — that is the starting point. |
 | **AI agent** | Bring your own **Claude Code** (preferred) or **Codex** subscription. If you don't have one, OpenAI API keys are provided — install **Codex** in that case. |
-| **Laptop** | Python 3 + pip. If your code needs **NEST / TVB** (or another simulator), pre-install it (conda recommended for NEST). |
+| **Laptop** | Python 3 + pip. If your code needs **NEST / TVB** (or another simulator), install it locally if you can (conda recommended for NEST) so you can test. The organizers will make sure the simulators your run needs are available on the server — ask if your local install fails. |
 
 ---
 
@@ -87,8 +87,11 @@ You drive **steps 1–2** locally with your agent. Steps **3–4** happen in the
 - **What you get:** your workflow recreated visually in the platform, ready to run.
 
 ### Step 4 — Run on the server
-- **What you do:** generate the workflow code in the GUI and execute it on the compute backend.
-- **What you get:** results from a full run on shared compute, collected in the app.
+- **What you do:** generate the workflow code in the GUI and run it.
+- **What you get:** results collected in the app.
+- **For this hackathon:** workflows run **directly on the application server**, so please keep example
+  runs **lightweight** (short simulations, modest network sizes). A dedicated HPC compute backend is not
+  used in this round.
 
 ---
 

--- a/hackathon/SETUP.md
+++ b/hackathon/SETUP.md
@@ -44,6 +44,9 @@ pip install jupyterlab matplotlib
 > **Simulators (NEST/TVB) are NOT installed by the line above.** If your code needs them, install them
 > separately and ideally via conda (NEST rarely installs cleanly through pip). Ask an organizer if your
 > install fails — do not burn time fighting it. A pure-Python / NumPy / Brian2 example always works.
+> **Local execution of NEST/TVB nodes is optional:** the authoritative run happens in the GUI on the
+> server, where NEST and TVB are preinstalled. If you can't install them locally, build the nodes anyway
+> and run them on the server.
 
 ## C. Verify the install and make the working folders
 

--- a/hackathon/SETUP.md
+++ b/hackathon/SETUP.md
@@ -1,0 +1,158 @@
+# NeuroWorkflow Hackathon — Participant Setup
+
+> **Fastest path — use the official one-command script for your agent** (in this repo):
+>
+> ```bash
+> # Claude Code:
+> bash examples/hackathon_202607/setup_claude.sh
+> # Codex:
+> bash examples/hackathon_202607/setup_codex.sh
+> ```
+>
+> Each script is idempotent and does everything below automatically: creates the venv, installs a
+> **pinned** neuroworkflow + JupyterLab + matplotlib, makes `source_code/` and `my_nodes/`, installs the
+> `create-node` skill into the right path for your agent (`.claude/skills/` or `.codex/skills/`) **with
+> frontmatter**, and writes a starter `CLAUDE.md` / `AGENTS.md`.
+>
+> The manual steps below are the **explanation / fallback** if you are not using the scripts.
+
+---
+
+Two tracks: **Claude Code** and **Codex**. Steps A–C are identical for both; step D differs.
+
+> The `curl` commands below pull from the raw-GitHub base
+> `https://raw.githubusercontent.com/oist/neuro-workflow/main`. (Organizers may give you a specific commit
+> SHA in place of `main` so everyone runs the exact same version.)
+
+---
+
+## A. Create an isolated environment
+
+```bash
+python3 -m venv neuro-env
+source neuro-env/bin/activate          # Windows: neuro-env\Scripts\activate
+```
+
+## B. Install NeuroWorkflow + notebook tools
+
+```bash
+pip install --upgrade pip
+pip install "git+https://github.com/oist/neuro-workflow.git"
+pip install jupyterlab matplotlib
+```
+
+> **Simulators (NEST/TVB) are NOT installed by the line above.** If your code needs them, install them
+> separately and ideally via conda (NEST rarely installs cleanly through pip). Ask an organizer if your
+> install fails — do not burn time fighting it. A pure-Python / NumPy / Brian2 example always works.
+
+## C. Verify the install and make the working folders
+
+```bash
+python3 -c "from neuroworkflow.core.node import Node; print('OK')"
+
+mkdir -p source_code      # put your existing (unstructured) Python code here
+mkdir -p my_nodes         # the agent will write nodes + workflows here
+```
+
+## C-2. Get a green run first (recommended)
+
+Before pointing an agent at your own code, confirm the toolchain works with a tiny, dependency-free
+example (no NEST/TVB). This also gives the agent a correct pattern to imitate.
+
+```bash
+mkdir -p hello_node
+base=https://raw.githubusercontent.com/oist/neuro-workflow/main/hackathon
+curl -fsSL $base/check_node.py                          -o check_node.py
+curl -fsSL $base/examples/hello_node/signal_generator.py  -o hello_node/signal_generator.py
+curl -fsSL $base/examples/hello_node/signal_statistics.py -o hello_node/signal_statistics.py
+curl -fsSL $base/examples/hello_node/workflow.py          -o hello_node/workflow.py
+curl -fsSL $base/examples/hello_node/EXPECTED_OUTPUT.md   -o hello_node/EXPECTED_OUTPUT.md
+
+cd hello_node && python workflow.py        # compare the numbers to EXPECTED_OUTPUT.md
+cd .. && python check_node.py hello_node/signal_generator.py   # should end with ALL NODES PASSED
+```
+
+`check_node.py` is a deterministic validator: it instantiates a node, checks that every method output
+maps to a declared port, and (when the node has no required inputs) runs one step and confirms no output
+came back `None`. Use it on the agent's nodes too — it catches the silent-failure traps the engine hides.
+
+---
+
+## D-1. Claude Code track (preferred)
+
+Download the skill (folder form with `SKILL.md`), the node guide, and the canonical instruction file:
+
+```bash
+mkdir -p .claude/skills/create-node
+curl -fsSL https://raw.githubusercontent.com/oist/neuro-workflow/main/.claude/skills/create-node/SKILL.md -o .claude/skills/create-node/SKILL.md
+curl -fsSL https://raw.githubusercontent.com/oist/neuro-workflow/main/NODE_CREATION_GUIDE.md             -o NODE_CREATION_GUIDE.md
+curl -fsSL https://raw.githubusercontent.com/oist/neuro-workflow/main/hackathon/CLAUDE.md                -o CLAUDE.md
+```
+
+Start Claude Code in this folder, then give it this prompt:
+
+```
+Use the /create-node skill. Look in the source_code/ folder, find the main Python file(s),
+analyze the code, and propose the nodes to build. Ask me to confirm the breakdown before you
+write anything. Save the nodes AND two workflow files (.py and .ipynb) in the my_nodes/ folder.
+Then smoke-test each node and run the workflow so we can see the outputs.
+```
+
+(`claude init` is optional — it only generates a thin starter `CLAUDE.md`. The curled `CLAUDE.md` and the
+skill already contain the real instructions, so you can skip `init` or let it run; it won't hurt.)
+
+---
+
+## D-2. Codex track
+
+Codex scans `.codex/skills/` (not `.claude/skills/`) and reads `AGENTS.md` as its project instruction
+file. It has **no `/create-node` command** — a skill is triggered via the `/skills` selector or a
+`$create-node` mention. Install the skill under the Codex path, the canonical `AGENTS.md`, and the guide:
+
+```bash
+mkdir -p .codex/skills/create-node
+curl -fsSL https://raw.githubusercontent.com/oist/neuro-workflow/main/.claude/skills/create-node/SKILL.md -o .codex/skills/create-node/SKILL.md
+curl -fsSL https://raw.githubusercontent.com/oist/neuro-workflow/main/hackathon/AGENTS.md                 -o AGENTS.md
+curl -fsSL https://raw.githubusercontent.com/oist/neuro-workflow/main/NODE_CREATION_GUIDE.md              -o NODE_CREATION_GUIDE.md
+```
+
+> **Codex requires YAML frontmatter** (`name` + `description`) at the top of `SKILL.md`. The repo
+> `SKILL.md` now ships with this block, so the `curl` above is enough. Only if you pull an older ref that
+> lacks it, prepend (the official `setup_codex.sh` also does this automatically):
+>
+> ```
+> ---
+> name: create-node
+> description: Create a new NeuroWorkflow node (NEST / TVB / Brian2 / custom computation) following the NODE_CREATION_GUIDE.md conventions, then generate the file. Use when the user wants to build or add a workflow node.
+> ---
+> ```
+
+If you don't have a Codex/OpenAI subscription, set the API key the organizers gave you:
+
+```bash
+export OPENAI_API_KEY=sk-...     # organizer-provided; suggested model: gpt-4o-mini or better
+```
+
+Start Codex in this folder, then give it this prompt (trigger the skill via `/skills` or `$create-node`;
+`AGENTS.md` also carries the rules as a fallback):
+
+```
+Use the create-node skill ($create-node). Look in the source_code/ folder, find the main Python
+file(s), analyze the code, and propose the nodes to build. Ask me to confirm the breakdown before
+you write anything. Save the nodes AND two workflow files (.py and .ipynb) in the my_nodes/ folder.
+Then smoke-test each node and run the workflow so we can see the outputs.
+```
+
+---
+
+## After the agent finishes (both tracks)
+
+1. Open `my_nodes/` and run the generated `.ipynb` in JupyterLab (`jupyter lab`) to confirm it works
+   locally and the outputs are not `None`. Also run `python check_node.py my_nodes/<NodeName>.py` on each
+   generated node — it should end with `ALL NODES PASSED`.
+2. Tweak a parameter or a connection and re-run to get a feel for the node structure.
+3. Log in to the NeuroWorkflow web app and **upload each node `.py` file** under its category
+   (`analysis`, `io`, `network`, `optimization`, `simulation`, `stimulus`).
+4. Rebuild the graph: drag the nodes from the palette and connect them, OR ask the in-app AI assistant to
+   add and connect them (paste the node/edge summary the agent printed).
+5. Generate code and run on the server.

--- a/hackathon/check_node.py
+++ b/hackathon/check_node.py
@@ -1,0 +1,180 @@
+#!/usr/bin/env python3
+"""Deterministic validator for NeuroWorkflow node files.
+
+Why this exists
+---------------
+The engine in `Node.process()` *swallows* exceptions (it prints and returns
+False) and leaves an output port as `None` when a method's return-dict key does
+not match the declared output port name. A node can therefore "look fine" and
+silently emit nothing. A small-model agent has no way to notice this by reading
+the code. This script gives a deterministic PASS/FAIL signal so an agent (or a
+participant) can loop a node to correctness without human judgement.
+
+Usage
+-----
+    python check_node.py my_nodes/MyNode.py            # check every node in the file
+    python check_node.py my_nodes/MyNode.py MyNodeName # check one class
+
+Exit code is 0 only if every checked node passes. Non-zero on any failure, so
+this is safe to use in a verify loop.
+"""
+
+import argparse
+import importlib.util
+import inspect
+import os
+import sys
+from typing import List, Type
+
+try:
+    from neuroworkflow.core.node import Node
+    from neuroworkflow.core.schema import MethodDefinition
+except ImportError:
+    sys.exit(
+        "ERROR: cannot import neuroworkflow. Activate the venv first "
+        "(e.g. `source venv/bin/activate`) so the package is on the path."
+    )
+
+
+def _load_module(path: str):
+    """Import a .py file by path, with its own directory on sys.path."""
+    path = os.path.abspath(path)
+    if not os.path.isfile(path):
+        sys.exit(f"ERROR: file not found: {path}")
+    folder = os.path.dirname(path)
+    if folder not in sys.path:
+        sys.path.insert(0, folder)
+    mod_name = "nw_check_target_" + os.path.splitext(os.path.basename(path))[0]
+    spec = importlib.util.spec_from_file_location(mod_name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[mod_name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _find_node_classes(mod, only: str = None) -> List[Type[Node]]:
+    classes = [
+        obj
+        for _, obj in inspect.getmembers(mod, inspect.isclass)
+        if issubclass(obj, Node) and obj is not Node and obj.__module__ == mod.__name__
+    ]
+    if only:
+        classes = [c for c in classes if c.__name__ == only]
+        if not classes:
+            sys.exit(f"ERROR: class '{only}' not found in the file.")
+    return classes
+
+
+def _check_class(cls: Type[Node]) -> bool:
+    """Run all checks for one node class. Return True if it passes."""
+    fails: List[str] = []
+    warns: List[str] = []
+    nd = getattr(cls, "NODE_DEFINITION", None)
+
+    print(f"\n=== {cls.__name__} ===")
+
+    if nd is None or nd.type == "base_node":
+        print("  [FAIL] NODE_DEFINITION is missing (class did not set its own schema).")
+        return False
+
+    # ---- Metadata expected by NODE_CREATION_GUIDE.md (warnings, not hard fails)
+    for field_name in ("stage", "tool", "model_source"):
+        if not getattr(nd, field_name, None):
+            warns.append(f"NODE_DEFINITION.{field_name} is not set.")
+    if not nd.description or len(nd.description.split()) < 3:
+        warns.append("description is empty or too short for an agent to use.")
+
+    out_ports = set(nd.outputs.keys())
+    in_ports = set(nd.inputs.keys())
+    produced = set()
+
+    # ---- Method/port wiring (static) ----------------------------------------
+    for mname, mdef in nd.methods.items():
+        outs = mdef.outputs if isinstance(mdef, MethodDefinition) else mdef.get("outputs", [])
+        ins = mdef.inputs if isinstance(mdef, MethodDefinition) else mdef.get("inputs", [])
+        for o in outs:
+            produced.add(o)
+            if o not in out_ports:
+                fails.append(
+                    f"method '{mname}' declares output '{o}' that is not an output port."
+                )
+        for i in ins:
+            if i not in in_ports and i not in produced and i not in nd.parameters:
+                warns.append(
+                    f"method '{mname}' input '{i}' is neither an input port, an "
+                    f"earlier method output, nor a parameter."
+                )
+
+    for o in out_ports - produced:
+        warns.append(
+            f"output port '{o}' is never produced by any method "
+            f"(it will stay None — a silent-failure trap)."
+        )
+
+    # ---- Instantiation -------------------------------------------------------
+    try:
+        node = cls("check")
+    except Exception as e:  # noqa: BLE001
+        fails.append(f"instantiation failed: {e!r}")
+        _report(fails, warns)
+        return not fails
+
+    if not node._process_steps:
+        warns.append("no process steps registered (did _define_process_steps run?).")
+
+    # ---- Runtime smoke test (only when we can run without fabricating inputs)-
+    required_inputs = [
+        n for n, p in node._input_ports.items() if not p.optional
+    ]
+    if not required_inputs:
+        try:
+            ok = node.process()
+        except Exception as e:  # noqa: BLE001
+            ok = False
+            fails.append(f"process() raised: {e!r}")
+        if ok is False:
+            fails.append("process() returned False (a step errored — see output above).")
+        else:
+            for name in out_ports:
+                if node.get_output(name) is None:
+                    fails.append(
+                        f"after run, output '{name}' is None "
+                        f"(return-dict key likely does not match the port name)."
+                    )
+    else:
+        print(
+            f"  [NOTE] has required inputs {required_inputs}; ran static checks only. "
+            f"Validate end-to-end inside a workflow."
+        )
+
+    _report(fails, warns)
+    return not fails
+
+
+def _report(fails: List[str], warns: List[str]) -> None:
+    for w in warns:
+        print(f"  [WARN] {w}")
+    for f in fails:
+        print(f"  [FAIL] {f}")
+    if not fails:
+        print("  [PASS] node checks passed.")
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(description="Validate a NeuroWorkflow node file.")
+    ap.add_argument("node_file", help="path to the node .py file")
+    ap.add_argument("class_name", nargs="?", help="optional: check only this class")
+    args = ap.parse_args()
+
+    mod = _load_module(args.node_file)
+    classes = _find_node_classes(mod, args.class_name)
+    if not classes:
+        sys.exit("ERROR: no Node subclasses defined in this file.")
+
+    all_ok = all(_check_class(c) for c in classes)
+    print("\n" + ("ALL NODES PASSED" if all_ok else "SOME NODES FAILED"))
+    sys.exit(0 if all_ok else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/hackathon/examples/hello_node/EXPECTED_OUTPUT.md
+++ b/hackathon/examples/hello_node/EXPECTED_OUTPUT.md
@@ -1,0 +1,41 @@
+# Expected output — hello_node green run
+
+`Node.process()` hides failures (it prints and returns False, and leaves a
+mismatched output port as `None`). So "did it work?" must be checked against
+known-good numbers, not just "no traceback". Run:
+
+```bash
+python workflow.py
+```
+
+With the default parameters (`length=100, amplitude=1.0, cycles=2.0`) you should
+see exactly:
+
+```
+Executing node: Generator
+Executing node: Stats
+
+--- results ---
+workflow success: True
+mean:       -4.501274070443074e-17
+std:        0.7071067811865476
+n_samples:  100
+```
+
+What to confirm:
+
+- `workflow success: True` — every node's `process()` returned True.
+- `mean` ≈ `0` (the tiny `-4.5e-17` is floating-point round-off; a full sine
+  period averages to zero).
+- `std` ≈ `0.7071` (= `1/sqrt(2)`, the RMS of a unit-amplitude sine).
+- `n_samples: 100` — and **not `None`**. A `None` here would mean a return-dict
+  key did not match the output port name.
+
+Then validate each node on its own with the checker:
+
+```bash
+python ../../check_node.py signal_generator.py
+python ../../check_node.py signal_statistics.py
+```
+
+Both should end with `ALL NODES PASSED`.

--- a/hackathon/examples/hello_node/README.md
+++ b/hackathon/examples/hello_node/README.md
@@ -1,0 +1,39 @@
+# hello_node — the 5-minute green run
+
+A minimal, **dependency-free** NeuroWorkflow example (no NEST, no TVB — Python
+stdlib only). Use it to confirm your environment works before pointing an agent
+at your own code, and as a correct pattern for the agent to imitate.
+
+## Files
+
+| File | Role |
+|------|------|
+| `signal_generator.py` | A **source** node: generates a sine wave (no inputs). |
+| `signal_statistics.py` | An **analysis** node: mean / std / count of a signal. |
+| `workflow.py` | Wires the two nodes and runs them. |
+| `EXPECTED_OUTPUT.md` | Golden numbers so you know the run actually worked. |
+
+## Run it
+
+```bash
+# from this folder, with the venv active
+python workflow.py
+```
+
+Compare the printed numbers to `EXPECTED_OUTPUT.md`.
+
+## Then read the two nodes
+
+They are the smallest complete examples of the node contract:
+
+- the `NODE_DEFINITION` schema (`type`, `stage`, `tool`, `model_source`,
+  `description`, `parameters`, `inputs`, `outputs`, `methods`);
+- `add_process_step(...)` registering a method;
+- a method returning a dict whose **keys equal the output port names** (the #1
+  silent-failure trap — see the comment in `signal_generator.py`).
+
+## Suggested session sequence (matches the team's onboarding plan)
+
+1. Run `workflow.py` as-is → green run.
+2. Change one parameter (e.g. `cycles=4.0` in `workflow.py`) and re-run.
+3. Only then ask your agent to convert your own code in `source_code/`.

--- a/hackathon/examples/hello_node/hello_workflow.ipynb
+++ b/hackathon/examples/hello_node/hello_workflow.ipynb
@@ -1,0 +1,76 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# hello_node — green run (notebook)\n",
+        "\n",
+        "A dependency-free NeuroWorkflow example. **Run all cells**, then compare the\n",
+        "printed numbers with `EXPECTED_OUTPUT.md`. Run this notebook from the\n",
+        "`hello_node/` folder so the node files are importable."
+      ],
+      "id": "3dd8e5ca"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "import os, sys\n",
+        "\n",
+        "_HERE = os.getcwd()  # run this notebook from the hello_node/ folder\n",
+        "if _HERE not in sys.path:\n",
+        "    sys.path.insert(0, _HERE)\n",
+        "\n",
+        "from neuroworkflow import WorkflowBuilder\n",
+        "from signal_generator import SignalGeneratorNode\n",
+        "from signal_statistics import SignalStatisticsNode\n",
+        "\n",
+        "generator = SignalGeneratorNode(\"Generator\")\n",
+        "statistics = SignalStatisticsNode(\"Stats\")\n",
+        "generator.configure(length=100, amplitude=1.0, cycles=2.0)\n",
+        "\n",
+        "wf = WorkflowBuilder(\"HelloNodeWorkflow\")\n",
+        "wf.add_node(generator)\n",
+        "wf.add_node(statistics)\n",
+        "wf.connect(\"Generator\", \"signal\", \"Stats\", \"signal\")\n",
+        "workflow = wf.build()\n",
+        "\n",
+        "success = workflow.execute()\n",
+        "print(\"workflow success:\", success)"
+      ],
+      "execution_count": null,
+      "outputs": [],
+      "id": "3ad19353"
+    },
+    {
+      "cell_type": "code",
+      "metadata": {},
+      "source": [
+        "mean = statistics.get_output(\"mean\")\n",
+        "std = statistics.get_output(\"std\")\n",
+        "n = statistics.get_output(\"n_samples\")\n",
+        "print(\"mean:\", mean)\n",
+        "print(\"std:\", std)\n",
+        "print(\"n_samples:\", n)\n",
+        "\n",
+        "# Golden checks — these fail loudly if a port silently came back None / wrong.\n",
+        "assert success is True\n",
+        "assert n == 100\n",
+        "assert abs(mean) < 1e-9          # full sine period averages to ~0\n",
+        "assert abs(std - 0.7071067811865476) < 1e-9\n",
+        "print(\"\\nOK — matches EXPECTED_OUTPUT.md\")"
+      ],
+      "id": "0649e113",
+      "execution_count": null,
+      "outputs": []
+    }
+  ],
+  "metadata": {
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 5
+}

--- a/hackathon/examples/hello_node/signal_generator.py
+++ b/hackathon/examples/hello_node/signal_generator.py
@@ -1,0 +1,80 @@
+"""A dependency-free example *source* node.
+
+Generates a deterministic sine wave as a list of float samples. It needs no
+simulator and no inputs, so it always runs — the ideal first node for a green
+run and a correct pattern for an agent to imitate.
+"""
+
+import math
+from typing import Dict, Any
+
+from neuroworkflow.core.node import Node
+from neuroworkflow.core.schema import (
+    NodeDefinitionSchema,
+    PortDefinition,
+    ParameterDefinition,
+    MethodDefinition,
+)
+from neuroworkflow.core.port import PortType
+
+
+class SignalGeneratorNode(Node):
+    NODE_DEFINITION = NodeDefinitionSchema(
+        type="hello_signal_generator",
+        stage="stimulus",
+        tool="custom",
+        model_source="https://github.com/oist/neuro-workflow (hackathon hello example)",
+        description="Generate a deterministic sine wave as a list of float samples; a dependency-free source node used as the hackathon green-run example.",
+        parameters={
+            "length": ParameterDefinition(
+                default_value=100,
+                description="Number of samples to generate.",
+                constraints={"min": 1},
+            ),
+            "amplitude": ParameterDefinition(
+                default_value=1.0,
+                description="Peak amplitude of the sine wave (dimensionless).",
+            ),
+            "cycles": ParameterDefinition(
+                default_value=2.0,
+                description="Number of full sine cycles spanning the generated signal.",
+            ),
+        },
+        inputs={},
+        outputs={
+            "signal": PortDefinition(
+                type=PortType.LIST,
+                description="Sine wave as a list of float samples, length == 'length'.",
+            ),
+            "n_samples": PortDefinition(
+                type=PortType.INT,
+                description="Number of samples in the generated signal.",
+            ),
+        },
+        methods={
+            "generate": MethodDefinition(
+                description="Generate the sine wave signal.",
+                inputs=[],
+                outputs=["signal", "n_samples"],
+            ),
+        },
+    )
+
+    def __init__(self, name: str):
+        super().__init__(name)
+        self._define_process_steps()
+
+    def _define_process_steps(self) -> None:
+        self.add_process_step("generate", self.generate, method_key="generate")
+
+    def generate(self) -> Dict[str, Any]:
+        length = int(self._parameters["length"])
+        amplitude = float(self._parameters["amplitude"])
+        cycles = float(self._parameters["cycles"])
+        signal = [
+            amplitude * math.sin(2.0 * math.pi * cycles * i / length)
+            for i in range(length)
+        ]
+        # The return-dict keys MUST match the output port names exactly,
+        # otherwise the port silently stays None.
+        return {"signal": signal, "n_samples": length}

--- a/hackathon/examples/hello_node/signal_statistics.py
+++ b/hackathon/examples/hello_node/signal_statistics.py
@@ -1,0 +1,69 @@
+"""A dependency-free example *analysis* node.
+
+Consumes a list of float samples and reports summary statistics. Pairs with
+SignalGeneratorNode to form a minimal two-node workflow.
+"""
+
+import statistics as stats
+from typing import Dict, Any
+
+from neuroworkflow.core.node import Node
+from neuroworkflow.core.schema import (
+    NodeDefinitionSchema,
+    PortDefinition,
+    MethodDefinition,
+)
+from neuroworkflow.core.port import PortType
+
+
+class SignalStatisticsNode(Node):
+    NODE_DEFINITION = NodeDefinitionSchema(
+        type="hello_signal_statistics",
+        stage="analysis",
+        tool="custom",
+        model_source="https://github.com/oist/neuro-workflow (hackathon hello example)",
+        description="Compute summary statistics (mean, population standard deviation, sample count) of a list of float samples.",
+        parameters={},
+        inputs={
+            "signal": PortDefinition(
+                type=PortType.LIST,
+                description="List of float samples to summarize.",
+            ),
+        },
+        outputs={
+            "mean": PortDefinition(
+                type=PortType.FLOAT,
+                description="Arithmetic mean of the input samples.",
+            ),
+            "std": PortDefinition(
+                type=PortType.FLOAT,
+                description="Population standard deviation of the input samples.",
+            ),
+            "n_samples": PortDefinition(
+                type=PortType.INT,
+                description="Number of samples summarized.",
+            ),
+        },
+        methods={
+            "compute": MethodDefinition(
+                description="Compute mean, population standard deviation, and sample count.",
+                inputs=["signal"],
+                outputs=["mean", "std", "n_samples"],
+            ),
+        },
+    )
+
+    def __init__(self, name: str):
+        super().__init__(name)
+        self._define_process_steps()
+
+    def _define_process_steps(self) -> None:
+        self.add_process_step("compute", self.compute, method_key="compute")
+
+    def compute(self, signal) -> Dict[str, Any]:
+        values = [float(v) for v in signal]
+        return {
+            "mean": stats.fmean(values),
+            "std": stats.pstdev(values),
+            "n_samples": len(values),
+        }

--- a/hackathon/examples/hello_node/workflow.py
+++ b/hackathon/examples/hello_node/workflow.py
@@ -1,0 +1,48 @@
+"""Minimal two-node workflow: SignalGenerator -> SignalStatistics.
+
+Run it to get a guaranteed green run (no simulator required):
+
+    python workflow.py
+
+Then compare the printed values to EXPECTED_OUTPUT.md.
+"""
+
+import os
+import sys
+
+try:
+    _HERE = os.path.dirname(os.path.abspath(__file__))
+except NameError:
+    _HERE = os.getcwd()  # Jupyter: CWD is typically the script's directory
+
+# Make the node files importable in standalone mode (mirrors how participants
+# keep their nodes next to the workflow in my_nodes/).
+if _HERE not in sys.path:
+    sys.path.insert(0, _HERE)
+
+from neuroworkflow import WorkflowBuilder
+from signal_generator import SignalGeneratorNode
+from signal_statistics import SignalStatisticsNode
+
+# 1. Instantiate nodes (the constructor name is the key used in connect()).
+generator = SignalGeneratorNode("Generator")
+statistics = SignalStatisticsNode("Stats")
+
+# 2. Configure parameters.
+generator.configure(length=100, amplitude=1.0, cycles=2.0)
+
+# 3. Build the topology once.
+wf = WorkflowBuilder("HelloNodeWorkflow")
+wf.add_node(generator)
+wf.add_node(statistics)
+wf.connect("Generator", "signal", "Stats", "signal")
+workflow = wf.build()
+
+# 4. Execute.
+success = workflow.execute()
+
+print("\n--- results ---")
+print("workflow success:", success)
+print("mean:      ", statistics.get_output("mean"))
+print("std:       ", statistics.get_output("std"))
+print("n_samples: ", statistics.get_output("n_samples"))

--- a/hackathon/examples/sample_target/README.md
+++ b/hackathon/examples/sample_target/README.md
@@ -1,0 +1,32 @@
+# sample_target — a stand-in for "your own code"
+
+If you arrive without a suitable Python script (or just want a realistic warm-up),
+use this. `lif_network.py` is an intentionally **unstructured** single-file script
+— a leaky integrate-and-fire recurrent network with its parameters, simulation,
+and analysis all mixed together — exactly the kind of code this hackathon converts
+into nodes.
+
+## Use it as your input
+
+```bash
+mkdir -p source_code
+curl -fsSL https://raw.githubusercontent.com/oist/neuro-workflow/main/hackathon/examples/sample_target/lif_network.py \
+  -o source_code/lif_network.py
+python source_code/lif_network.py        # confirm it runs (prints a mean firing rate)
+```
+
+Then start your agent and run the `create-node` skill pointed at `source_code/`.
+
+## What the agent should produce
+
+A reasonable breakdown (the agent will propose its own and ask you to confirm):
+
+- a **network** node — neuron count, connectivity, weights → a connectivity object;
+- a **simulation** node — runs the LIF dynamics, records spike times;
+- an **analysis** node — computes mean firing rate and a raster plot.
+
+Wire them into a workflow and run it locally — the end-to-end result should match
+the standalone script's printed firing rate.
+
+> Requires only `numpy` (a core neuroworkflow dependency); the raster plot also uses
+> `matplotlib`, which the hackathon setup installs.

--- a/hackathon/examples/sample_target/lif_network.py
+++ b/hackathon/examples/sample_target/lif_network.py
@@ -1,0 +1,85 @@
+"""
+Leaky integrate-and-fire (LIF) recurrent network: quick simulation + analysis.
+
+This is an intentionally UNSTRUCTURED example script — the kind of single-file,
+top-to-bottom code a researcher might bring to the hackathon (parameters,
+network construction, simulation, and analysis all mixed together). Use it as a
+stand-in for "your own code":
+
+    1. copy it into your working folder as  source_code/lif_network.py
+    2. start your agent and run the create-node skill, pointing it at source_code/
+
+A reasonable node breakdown the agent might propose:
+    - a parameters / network-construction node  (stage: network)
+    - a simulation node that runs the LIF dynamics and records spikes  (stage: simulation)
+    - an analysis node that computes firing rate and a raster  (stage: analysis)
+
+Runs with numpy alone (a core neuroworkflow dependency). The raster plot is saved
+only if matplotlib is installed.
+"""
+
+import numpy as np
+
+rng = np.random.default_rng(0)
+
+# --- parameters -------------------------------------------------------------
+N = 200            # number of neurons
+p_conn = 0.1       # recurrent connection probability
+w_exc = 0.5        # excitatory synaptic weight (mV per presynaptic spike)
+tau_m = 20.0       # membrane time constant (ms)
+v_rest = 0.0       # resting potential (mV)
+v_thresh = 20.0    # spike threshold (mV)
+v_reset = 0.0      # reset potential (mV)
+t_ref = 2.0        # refractory period (ms)
+i_ext = 22.0       # external drive (mV-equivalent; above threshold => regular firing)
+dt = 0.1           # integration step (ms)
+T = 1000.0         # total simulated time (ms)
+
+# --- build a random recurrent connectivity matrix ---------------------------
+W = (rng.random((N, N)) < p_conn).astype(float) * w_exc
+np.fill_diagonal(W, 0.0)   # no self-connections
+
+# --- simulate (forward Euler) -----------------------------------------------
+n_steps = int(T / dt)
+v = np.full(N, v_rest, dtype=float)
+ref = np.zeros(N)          # remaining refractory time per neuron (ms)
+spike_t = []               # spike times (ms)
+spike_i = []               # spiking neuron indices
+
+for step in range(n_steps):
+    t = step * dt
+    can_update = ref <= 0.0
+    v[can_update] += (-(v[can_update] - v_rest) + i_ext) / tau_m * dt
+
+    fired = np.where(can_update & (v >= v_thresh))[0]
+    if fired.size:
+        spike_t.extend([t] * fired.size)
+        spike_i.extend(fired.tolist())
+        v[fired] = v_reset
+        ref[fired] = t_ref
+        v += W[:, fired].sum(axis=1)   # deliver recurrent input
+
+    ref -= dt
+
+# --- analysis ---------------------------------------------------------------
+n_spikes = len(spike_t)
+mean_rate_hz = n_spikes / N / (T / 1000.0)
+print(f"neurons={N}  total_spikes={n_spikes}  mean_firing_rate={mean_rate_hz:.2f} Hz")
+
+# optional raster plot (saved to file if matplotlib is available)
+try:
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    if spike_t:
+        plt.figure(figsize=(8, 4))
+        plt.scatter(spike_t, spike_i, s=2)
+        plt.xlabel("time (ms)")
+        plt.ylabel("neuron index")
+        plt.title(f"LIF network raster (mean rate {mean_rate_hz:.1f} Hz)")
+        plt.tight_layout()
+        plt.savefig("lif_raster.png", dpi=100)
+        print("saved lif_raster.png")
+except ImportError:
+    print("(matplotlib not installed — skipping raster plot)")


### PR DESCRIPTION
## Summary
- Adds a self-contained participant kit under `hackathon/` for the AI-agent node-building flow (Claude Code + Codex):
  - `README.md` — step-by-step agenda (4 steps, what-you-do / what-you-get)
  - `SETUP.md` — per-agent setup (official scripts + manual fallback)
  - `CLAUDE.md` / `AGENTS.md` — byte-identical agent instructions
  - `check_node.py` — deterministic node validator
  - `examples/hello_node/` — dependency-free green-run example (verified)
  - `examples/sample_target/lif_network.py` — realistic unstructured LIF script as a bring-your-own-code stand-in
- Commits `name`/`description` YAML frontmatter into `.claude/skills/create-node/SKILL.md` so the skill auto-discovers for hand-curl users (the official `setup_*.sh` already detect and skip re-adding it).
- For this hackathon, workflows run **directly on the application server (snnbuilder)**; docs ask for lightweight example runs and note the dedicated HPC compute backend is not used this round.

## Verified
- `hello_node/workflow.py` runs green; `check_node.py` passes both example nodes; the notebook asserts pass.
- `sample_target` LIF dynamics validated (sane, bounded firing rate).

## Notes
- `hackathon/CLAUDE.md` is force-added (root `.gitignore` ignores `CLAUDE.md`); byte-identical to `hackathon/AGENTS.md`.
- Internal planning docs are intentionally excluded.