### PR TITLE
Install bmtk in the nest-jupyterlab execution image

### DIFF
--- a/gui/workflow_backend/django-project/neuroworkflow/Dockerfile.nest
+++ b/gui/workflow_backend/django-project/neuroworkflow/Dockerfile.nest
@@ -120,7 +120,7 @@ RUN . /root/.env/bin/activate && \
 
 RUN . /root/.env/bin/activate && \
 	pip install --no-cache-dir nestml nest-desktop pandas jupyterlab notebook \
-		jupyterhub tvb-library tvb-framework statsmodels hdf5storage \
+		jupyterhub tvb-library tvb-framework statsmodels hdf5storage bmtk \
 		"siibra==1.0.1a15" "traitlets==5.14.3" && \
 	find /root/.cache -type f -delete
 


### PR DESCRIPTION
## Summary
- Add `bmtk` to the `nest-jupyterlab` image pip block (`Dockerfile.nest`) so it is available to generated workflows.

## Why
Workflows execute inside ephemeral single-user kernel containers spawned by JupyterHub (`c.DockerSpawner.remove = True`), so a manual `pip install` in a running container is wiped on restart. The package must be baked into the image and the image rebuilt.

## Verification (in the currently built `nest-jupyterlab:latest`)
- `bmtk 1.1.4` installs on top of the current **numpy 2.4.6 / pandas 3.0.2** with **no downgrades**.
- `pip check` is clean (nilearn / imagecodecs remain satisfied).
- NEST 3.9 import + small sim OK; TVB import + small sim OK; bmtk network builder writes `nodes.h5` + `node_types.csv`.
- A `pandas<2.2` pin was intentionally avoided: it would force numpy `<2`, breaking `imagecodecs` (numpy>=2.1) and `nilearn` (pandas>=2.2). No pin is needed.

## Follow-up
- Rebuild `nest-jupyterlab:latest` on the server for this to take effect.

## Test plan
- [ ] Rebuild the image and confirm `python -c "import bmtk, nest, tvb"` succeeds.
- [ ] Confirm `pip check` is clean in the rebuilt image.