### PR TITLE
Surface built-in database sources in the Custom Database Manager

### DIFF
--- a/gui/workflow_backend/django-project/app/metadata/urls.py
+++ b/gui/workflow_backend/django-project/app/metadata/urls.py
@@ -2,6 +2,7 @@ from django.urls import path
 from .views import (
     ParameterSuggestionView,
     SpeciesSpecificParametersView,
+    BuiltinDatabaseListView,
     CustomDatabaseListView,
     CustomDatabaseDetailView,
     DatabaseConnectionTestView,
@@ -21,6 +22,12 @@ urlpatterns = [
         "parameters/species-specific/",
         SpeciesSpecificParametersView.as_view(),
         name="species-specific-parameters"
+    ),
+    # Built-in (always-on) database sources, read-only
+    path(
+        "builtin-databases/",
+        BuiltinDatabaseListView.as_view(),
+        name="builtin-database-list"
     ),
     # Custom database management endpoints
     path(

--- a/gui/workflow_backend/django-project/app/metadata/views.py
+++ b/gui/workflow_backend/django-project/app/metadata/views.py
@@ -359,6 +359,79 @@ class SpeciesSpecificParametersView(APIView):
             )
 
 
+# Built-in database sources that the parameter metadata service always
+# initializes (see neuroworkflow.utils.parameter_metadata_service). They are
+# configured in code rather than stored as CustomDatabase records, so the UI
+# shows them as read-only entries alongside user-added databases.
+BUILTIN_DATABASE_SOURCES = [
+    {
+        "source": "allen_brain",
+        "name": "Allen Brain Atlas",
+        "description": "Cell Types Database (electrophysiology & morphology) via allensdk.",
+        "base_url": "https://api.brain-map.org/api/v2",
+        "requires_api_key": False,
+    },
+    {
+        "source": "neuromorpho",
+        "name": "NeuroMorpho.org",
+        "description": "Digitally reconstructed neuron morphologies.",
+        "base_url": "https://neuromorpho.org/api",
+        "requires_api_key": False,
+    },
+    {
+        "source": "pubmed",
+        "name": "PubMed / NCBI",
+        "description": "Parameter values extracted from research abstracts (NCBI E-utilities).",
+        "base_url": "https://eutils.ncbi.nlm.nih.gov/entrez/eutils",
+        "requires_api_key": False,
+    },
+    {
+        "source": "neuroml_db",
+        "name": "NeuroML-DB",
+        "description": "Curated NeuroML model database.",
+        "base_url": "https://neuroml-db.org/api",
+        "requires_api_key": False,
+    },
+]
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class BuiltinDatabaseListView(APIView):
+    """List the built-in, always-on database sources used for parameter
+    suggestions.
+
+    These are managed in code (not the CustomDatabase table), so they are
+    returned as read-only entries. Local RAG is included only when a base URL
+    is configured, mirroring get_metadata_service_instance().
+
+    GET /api/metadata/builtin-databases/
+    """
+    authentication_classes = [KeycloakAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        sources = [
+            dict(source, is_active=True, is_builtin=True)
+            for source in BUILTIN_DATABASE_SOURCES
+        ]
+
+        # Local RAG is only registered when a base URL is configured.
+        local_rag_url = os.getenv("LOCAL_RAG_BASE_URL", "").strip()
+        if local_rag_url:
+            local_rag_enabled = os.getenv("LOCAL_RAG_ENABLED", "true").lower() in ("true", "1", "yes")
+            sources.append({
+                "source": "local_rag",
+                "name": os.getenv("LOCAL_RAG_SOURCE_NAME", "Local RAG").strip() or "Local RAG",
+                "description": "Local semantic search over your own documents (RAG).",
+                "base_url": local_rag_url,
+                "requires_api_key": False,
+                "is_active": local_rag_enabled,
+                "is_builtin": True,
+            })
+
+        return Response(sources, status=status.HTTP_200_OK)
+
+
 @method_decorator(csrf_exempt, name="dispatch")
 class CustomDatabaseListView(APIView):
     """

--- a/gui/workflow_frontend/src/views/home/components/CustomDatabaseManager.tsx
+++ b/gui/workflow_frontend/src/views/home/components/CustomDatabaseManager.tsx
@@ -41,8 +41,19 @@ interface CustomDatabase {
   updated_at: string;
 }
 
+interface BuiltinDatabase {
+  source: string;
+  name: string;
+  description?: string;
+  base_url?: string;
+  requires_api_key?: boolean;
+  is_active: boolean;
+  is_builtin: boolean;
+}
+
 const CustomDatabaseManager: React.FC = () => {
   const [databases, setDatabases] = useState<CustomDatabase[]>([]);
+  const [builtins, setBuiltins] = useState<BuiltinDatabase[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [selectedDatabase, setSelectedDatabase] = useState<CustomDatabase | null>(null);
@@ -79,8 +90,27 @@ const CustomDatabaseManager: React.FC = () => {
     }
   };
 
+  const fetchBuiltins = async () => {
+    try {
+      const response = await fetch('/api/metadata/builtin-databases/', {
+        headers: await createAuthHeaders(),
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP error! status: ${response.status}`);
+      }
+
+      const data = await response.json();
+      setBuiltins(Array.isArray(data) ? data : []);
+    } catch (err) {
+      // Non-fatal: built-in sources are informational only.
+      console.warn('Failed to fetch built-in databases', err);
+    }
+  };
+
   useEffect(() => {
     fetchDatabases();
+    fetchBuiltins();
   }, []);
 
   const handleAdd = () => {
@@ -145,7 +175,60 @@ const CustomDatabaseManager: React.FC = () => {
 
   return (
     <Box p={4}>
-      <VStack spacing={4} align="stretch">
+      <VStack spacing={6} align="stretch">
+        {builtins.length > 0 && (
+          <Box>
+            <Text fontSize="xl" fontWeight="bold" mb={1}>
+              Built-in sources
+            </Text>
+            <Text fontSize="sm" color="gray.500" mb={3}>
+              These neuroscience databases are always available for parameter
+              suggestions. They are managed by NeuroWorkflow and cannot be edited
+              or removed.
+            </Text>
+            <TableContainer>
+              <Table variant="simple" size="sm">
+                <Thead>
+                  <Tr>
+                    <Th>Name</Th>
+                    <Th>Base URL</Th>
+                    <Th>Status</Th>
+                  </Tr>
+                </Thead>
+                <Tbody>
+                  {builtins.map((db) => (
+                    <Tr key={db.source}>
+                      <Td>
+                        <VStack align="start" spacing={0}>
+                          <HStack spacing={2}>
+                            <Text fontWeight="medium">{db.name}</Text>
+                            <Badge colorScheme="purple">Built-in</Badge>
+                          </HStack>
+                          {db.description && (
+                            <Text fontSize="sm" color="gray.500">
+                              {db.description}
+                            </Text>
+                          )}
+                        </VStack>
+                      </Td>
+                      <Td>
+                        <Text fontSize="sm" fontFamily="mono">
+                          {db.base_url}
+                        </Text>
+                      </Td>
+                      <Td>
+                        <Badge colorScheme={db.is_active ? 'green' : 'gray'}>
+                          {db.is_active ? 'Active' : 'Inactive'}
+                        </Badge>
+                      </Td>
+                    </Tr>
+                  ))}
+                </Tbody>
+              </Table>
+            </TableContainer>
+          </Box>
+        )}
+
         <HStack justify="space-between">
           <Text fontSize="xl" fontWeight="bold">
             Custom Databases


### PR DESCRIPTION
## Summary
- The default parameter-suggestion sources (Allen Brain Atlas, NeuroMorpho, PubMed, NeuroML-DB, and Local RAG when configured) are always-on adapters defined in code, so they never showed up in the **Custom Database Manager** — that panel only lists user-added `CustomDatabase` records.
- Add a read-only `GET /api/metadata/builtin-databases/` endpoint returning the built-in catalog (name, description, base URL, active status).
- Render those entries as a non-editable **"Built-in sources"** section above the custom databases table (no edit/delete; a "Built-in" badge + Active/Inactive status).

## Why
Users (and the team) couldn't see which default endpoints were active, even though they run on every `/api/metadata/parameters/suggest/` request. This makes them visible without changing how they're configured.

## Notes
- Built-ins remain managed in code; the endpoint is informational/read-only.
- Local RAG is listed only when `LOCAL_RAG_BASE_URL` is set, mirroring `get_metadata_service_instance()`.
- No new dependencies; backend byte-compiles and the frontend file passes lint.

## Test plan
- [ ] `GET /api/metadata/builtin-databases/` returns the 4 free sources (+ Local RAG when configured).
- [ ] Custom Database Manager shows a read-only "Built-in sources" table above custom databases.
- [ ] Adding/removing a custom database still works and doesn't affect the built-in section.