### PR TITLE
Serve the app on dbrain.jp domains (multi-host auth + Jupyter embed)

### DIFF
--- a/gui/docker-compose.prod.yml
+++ b/gui/docker-compose.prod.yml
@@ -65,5 +65,9 @@ services:
       - KC_PROXY_HEADERS=xforwarded
       - KC_HTTP_RELATIVE_PATH=/auth
       - KC_HTTP_ENABLED=true
-      - KC_HOSTNAME=${KEYCLOAK_HOSTNAME:-snnbuilder.riken.jp}
+      # No KC_HOSTNAME: with hostname-strict=false Keycloak derives the public
+      # hostname per-request (from the proxied Host/X-Forwarded-* headers), so
+      # login works on every domain it is served on (snnbuilder.riken.jp,
+      # neuro-workflow.dbrain.jp, www.dbrain.jp). Pinning it to one host makes
+      # the login form POST cross-host from the other domains and breaks auth.
       - KC_HOSTNAME_STRICT=false

--- a/gui/workflow_backend/django-project/app/auth/authentication.py
+++ b/gui/workflow_backend/django-project/app/auth/authentication.py
@@ -183,19 +183,33 @@ class KeycloakAuthentication(_BearerAuthentication):
         # explicit override. NOTE: KEYCLOAK_ISSUER must reference the same
         # realm as KEYCLOAK_URL/KEYCLOAK_REALM — a wrong-realm value will
         # cause all logins to fail at JWT verification. See env.template.
-        issuer = (
+        default_issuer = (
             getattr(settings, "KEYCLOAK_ISSUER", None)
             or f"{kc_url}/realms/{kc_realm}"
         )
+        # Multi-domain deployments: Keycloak stamps the token issuer with the
+        # hostname the user logged in through (e.g. snnbuilder.riken.jp AND
+        # neuro-workflow.dbrain.jp), so accept any configured public issuer.
+        # The signature (RS256 via the realm JWKS) and the client (azp/aud)
+        # checks below are what actually authenticate the token; the issuer is
+        # restricted to a known allow-list rather than verified as a single value.
+        allowed_issuers = {default_issuer}
+        for iss in (getattr(settings, "KEYCLOAK_ISSUERS", "") or "").split(","):
+            if iss.strip():
+                allowed_issuers.add(iss.strip())
+
         kc_client = getattr(settings, "KEYCLOAK_CLIENT_ID", None)
 
         decode_kwargs: dict = {
-            "issuer": issuer,
             "options": {"verify_aud": False},
         }
 
         try:
             payload = _verify_rs256(token, jwks_url, **decode_kwargs)
+            if payload.get("iss") not in allowed_issuers:
+                raise jwt.InvalidTokenError(
+                    f"Untrusted token issuer: {payload.get('iss')}"
+                )
             _verify_keycloak_client(payload, kc_client)
         except jwt.ExpiredSignatureError:
             raise exceptions.AuthenticationFailed("Token has expired.")

--- a/gui/workflow_backend/django-project/config/config.py
+++ b/gui/workflow_backend/django-project/config/config.py
@@ -16,5 +16,9 @@ KEYCLOAK_CLIENT_ID = os.getenv("KEYCLOAK_CLIENT_ID", "neuroworkflow-app")
 # differs from KEYCLOAK_URL (used for JWKS fetch). Leave unset for single-host
 # setups.
 KEYCLOAK_ISSUER = os.getenv("KEYCLOAK_ISSUER")
+# Optional. Comma-separated list of additional accepted `iss` values. Needed in
+# multi-domain deployments where Keycloak issues tokens with the hostname the
+# user logged in through (e.g. snnbuilder.riken.jp AND neuro-workflow.dbrain.jp).
+KEYCLOAK_ISSUERS = os.getenv("KEYCLOAK_ISSUERS", "")
 
 SECRET_KEY = os.getenv("DJANGO_SECRET_KEY")

--- a/gui/workflow_backend/django-project/config/settings.py
+++ b/gui/workflow_backend/django-project/config/settings.py
@@ -10,6 +10,7 @@ from .config import (
     KEYCLOAK_REALM,
     KEYCLOAK_CLIENT_ID,
     KEYCLOAK_ISSUER,
+    KEYCLOAK_ISSUERS,
     SECRET_KEY,
 )
 
@@ -24,8 +25,12 @@ SECRET_KEY = SECRET_KEY
 DEBUG = os.getenv("DJANGO_DEBUG", "false").lower() in ("1", "true", "yes")
 
 _extra_hosts = [h.strip() for h in os.getenv("ALLOWED_HOSTS_EXTRA", "").split(",") if h.strip()]
+# Internal Docker service name used for service-to-service calls (e.g. the MCP
+# server reaches Django via http://backend:3000). This host is not externally
+# routable, so it is always allowed; per-user JWT auth is still enforced.
+_internal_hosts = ["backend"]
 if os.getenv("ALLOWED_HOSTS_ALL", "").lower() in ("0", "false", "no"):
-    ALLOWED_HOSTS = ["localhost", "127.0.0.1"] + _extra_hosts
+    ALLOWED_HOSTS = ["localhost", "127.0.0.1"] + _internal_hosts + _extra_hosts
 else:
     ALLOWED_HOSTS = ["*"]
 
@@ -136,6 +141,7 @@ KEYCLOAK_URL = KEYCLOAK_URL
 KEYCLOAK_REALM = KEYCLOAK_REALM
 KEYCLOAK_CLIENT_ID = KEYCLOAK_CLIENT_ID
 KEYCLOAK_ISSUER = KEYCLOAK_ISSUER
+KEYCLOAK_ISSUERS = KEYCLOAK_ISSUERS
 
 # ==============================================================================
 # CORS CONFIGURATION

--- a/gui/workflow_backend/django-project/neuroworkflow/jupyterhub_config.py
+++ b/gui/workflow_backend/django-project/neuroworkflow/jupyterhub_config.py
@@ -57,10 +57,22 @@ c.DockerSpawner.environment = {
 c.DockerSpawner.notebook_dir = "/home/jovyan"
 c.DockerSpawner.default_url = "/lab"
 
-# JupyterLab CSP settings for iframe embedding
-_frame_origin = os.environ.get("JUPYTERHUB_FRAME_ORIGIN", "http://localhost:5173")
+# JupyterLab CSP settings for iframe embedding. JUPYTERHUB_FRAME_ORIGIN may list
+# several space/comma-separated origins; CSP frame-ancestors accepts a list, so
+# the Jupyter iframe can be embedded from more than one public hostname.
+_frame_origins = [
+    o.strip()
+    for o in os.environ.get("JUPYTERHUB_FRAME_ORIGIN", "http://localhost:5173")
+    .replace(",", " ")
+    .split()
+    if o.strip()
+]
+_frame_ancestors = " ".join(_frame_origins) or "http://localhost:5173"
+# Access-Control-Allow-Origin accepts a single value. Jupyter is reached through
+# the same-origin nginx /jupyter proxy, so the primary origin is sufficient.
+_frame_origin = _frame_origins[0] if _frame_origins else "http://localhost:5173"
 c.DockerSpawner.args = [
-    f"--ServerApp.tornado_settings={{'headers':{{'Content-Security-Policy':\"frame-ancestors {_frame_origin}\"}}}}",
+    f"--ServerApp.tornado_settings={{'headers':{{'Content-Security-Policy':\"frame-ancestors {_frame_ancestors}\"}}}}",
     f"--ServerApp.allow_origin={_frame_origin}",
 ]
 if os.environ.get("JUPYTERHUB_DISABLE_XSRF", "false").lower() == "true":
@@ -100,7 +112,7 @@ c.DockerSpawner.http_timeout = 120
 # Allow embedding in iframes by removing X-Frame-Options restrictions
 c.JupyterHub.tornado_settings = {
     "headers": {
-        "Content-Security-Policy": f"frame-ancestors {_frame_origin}",
+        "Content-Security-Policy": f"frame-ancestors {_frame_ancestors}",
         "Access-Control-Allow-Origin": _frame_origin,
         "Access-Control-Allow-Methods": "GET, POST, OPTIONS, PUT, DELETE",
         "Access-Control-Allow-Headers": "Content-Type, Authorization, X-Requested-With, X-CSRFToken",


### PR DESCRIPTION
## Summary

Enables the NeuroWorkflow app on the new **dbrain.jp** domain alongside the existing **snnbuilder.riken.jp** host (additive — no cutover required).

Final public routing (configured on the server):

| Host | Serves |
|------|--------|
| `neuro-workflow.dbrain.jp` | the app |
| `dbrain.jp` | a static "Under Construction" portal page that links to the app |
| `www.dbrain.jp` | `301` redirect → `dbrain.jp` |
| `snnbuilder.riken.jp` | the app (unchanged) |

These code/compose changes are what the app needs to function on more than one hostname. Without them the Keycloak login form POSTed cross-host and the backend rejected the resulting tokens.

## Changes

- **`docker-compose.prod.yml`** — drop the pinned `KC_HOSTNAME`. With `KC_HOSTNAME_STRICT=false` + `KC_PROXY_HEADERS=xforwarded`, Keycloak derives its public hostname per request from the proxied `Host`/`X-Forwarded-*` headers, so the login form action matches whichever domain the user came in on. Pinning one host was what broke login on the other domains.
- **`app/auth/authentication.py`** — accept an allow-list of token issuers (`KEYCLOAK_ISSUERS`) instead of verifying a single `iss`. Keycloak stamps the token issuer with the host the user logged in through. Authentication is still enforced by the RS256 signature (realm JWKS) and the client (`azp`/`aud`) check; the issuer is just restricted to a known allow-list.
- **`config/config.py`, `config/settings.py`** — read/expose `KEYCLOAK_ISSUERS`. Also always allow the internal `backend` host in `ALLOWED_HOSTS` (used for service-to-service calls, e.g. MCP → Django) when `ALLOWED_HOSTS` is enforced; per-user JWT auth is unchanged.
- **`jupyterhub_config.py`** — parse `JUPYTERHUB_FRAME_ORIGIN` as a space/comma-separated list and feed all origins into the CSP `frame-ancestors`, so the Jupyter iframe can be embedded from more than one public hostname.

## Deployment notes (not in this PR)

Configured on the server, intentionally **not** committed here:
- `gui/.env`: `ALLOWED_HOSTS_EXTRA`, `CORS_ALLOWED_ORIGINS_EXTRA`, `CSRF_TRUSTED_ORIGINS_EXTRA`, `JUPYTERHUB_FRAME_ORIGIN` extended with the dbrain hosts.
- `gui/workflow_backend/.env`: `KEYCLOAK_ISSUERS` listing the realm issuers.
- Keycloak client redirect URIs / web origins extended with the dbrain hosts (via admin API).
- nginx (admin-managed, adapted from the repo's reference `gui/nginx/neuro-workflow.conf`): `neuro-workflow.dbrain.jp` → app; `www.dbrain.jp` → 301 to `dbrain.jp`; `dbrain.jp` → static portal landing page.

## Test plan

- [x] Login on `neuro-workflow.dbrain.jp` succeeds; backend accepts the dbrain-issued token (`/api` returns 200).
- [x] `dbrain.jp` serves the portal page; `www.dbrain.jp` returns `301` → `dbrain.jp`.
- [x] Existing `snnbuilder.riken.jp` login + Jupyter still work.
- [ ] Colleagues verify the new pages before retiring the snnbuilder domain.
