### PR TITLE
Send auth header on sidebar-node parameter save

### DIFF
--- a/gui/workflow_frontend/src/views/home/components/nodeDetailModal.tsx
+++ b/gui/workflow_frontend/src/views/home/components/nodeDetailModal.tsx
@@ -220,10 +220,12 @@ const NodeDetailsContent: React.FC<NodeDetailsContentProps> = ({ nodeData, onNod
         };
         console.log('Request body for sidebar node:', JSON.stringify(requestBody, null, 2));
 
+        const authHeaders = await createAuthHeaders();
         response = await fetch(endpoint, {
           method: 'PUT',
           headers: {
             'Content-Type': 'application/json',
+            ...authHeaders,
           },
           body: JSON.stringify(requestBody),
         });


### PR DESCRIPTION
## Summary

In `NodeDetailsContent` there are three parameter-save paths, each doing a `PUT`. Two of them (workflow-node instance name, workflow-node parameter) already attach the Keycloak auth headers via `createAuthHeaders()`. The **sidebar-node** parameter save was the odd one out — it sent only `Content-Type: application/json` and **no `Authorization` header**, so that request reached the backend unauthenticated and would be rejected (401) under `KeycloakAuthentication`.

This adds `createAuthHeaders()` to that one path, matching the other two.

## Why now

This fix already exists as an uncommitted local change on the app server. We're about to sync the server to `main`, so we're landing the fix on `main` first (rather than carrying it as a server-local diff) — then the server pull picks it up cleanly.

## Changes

- `nodeDetailModal.tsx` — call `createAuthHeaders()` and spread it into the sidebar-node `PUT` headers (2-line change).

## Test plan

- [ ] Edit a parameter on a **sidebar** node and save → request includes `Authorization`, returns 2xx (no 401).
- [x] Workflow-node name/parameter saves unchanged (already authed).