### PR TITLE
fix(frontend): add fan_in to InputField type so the prod build passes

### DIFF
--- a/gui/workflow_frontend/src/views/home/type.ts
+++ b/gui/workflow_frontend/src/views/home/type.ts
@@ -7,6 +7,7 @@ export interface InputField {
   default_value?: any;
   constraints?: any;
   optional?: boolean;
+  fan_in?: boolean;
 }
 
 export interface OutputField {


### PR DESCRIPTION
## Summary
`main`'s frontend currently **fails to build**. PR #55 (BMTK nodes / fan-in support) added code that reads `fan_in` on port schemas, but never added the field to the `InputField` type:

- `src/views/home/WorkflowCanvas.tsx:485` — `targetPortSchema?.fan_in`
- `src/views/home/components/calculationNode.tsx:54,425,432` — `data.fan_in`

The production build runs `tsc -b && vite build`, so `tsc` rejects these with `TS2339: Property 'fan_in' does not exist on type 'InputField'` and the build exits non-zero. (The PR-time CI evidently didn't run the strict prod build, so it slipped into `main`.)

This adds the missing optional field:

```ts
export interface InputField {
  ...
  optional?: boolean;
  fan_in?: boolean;   // added
}
```

## Test plan
- [x] `docker build -f Dockerfile.prod` (which runs `tsc -b && vite build`) now succeeds end-to-end (previously failed with the 4 TS2339 errors).

## Why
The production frontend is a static `vite build` image; without this fix the frontend image cannot be rebuilt, blocking deployment of all post-June-4 UI changes (#55, #60 built-in DB sources, #62 sidebar auth fix).