### PR TITLE
Fix BMTK/TVB execution image: pandas, numpy, and HDF5 locking

### DIFF
--- a/gui/workflow_backend/django-project/codes/nodes/simulation/NW_SimConfig.py
+++ b/gui/workflow_backend/django-project/codes/nodes/simulation/NW_SimConfig.py
@@ -1,5 +1,16 @@
 from typing import Dict, Any
 
+import pandas as pd
+
+# BMTK 1.1.4 reads SONATA node-type tables via pandas. Under pandas >= 3.0 the
+# default string dtype became StringDtype(na_value=nan), which BMTK then hands to
+# np.empty() (sonata/group.py) and which NumPy cannot interpret as a dtype:
+#   "Cannot interpret '<StringDtype(...)>' as a data type"
+# Disabling the new string inference keeps those columns as object dtype, exactly
+# as pre-3.0. set_option is process-global, so setting it once at import — before
+# any BMTK SONATA read in workflow.execute() — covers the whole run.
+pd.set_option("future.infer_string", False)
+
 from neuroworkflow.core.node import Node
 from neuroworkflow.core.schema import (
     NodeDefinitionSchema, PortDefinition, ParameterDefinition, MethodDefinition,

--- a/gui/workflow_backend/django-project/neuroworkflow/Dockerfile.nest
+++ b/gui/workflow_backend/django-project/neuroworkflow/Dockerfile.nest
@@ -5,6 +5,12 @@ ARG NEST_VERSION=3.9
 
 ENV TZ=Asia/Tokyo DEBIAN_FRONTEND=noninteractive OMPI_ALLOW_RUN_AS_ROOT=1 OMPI_ALLOW_RUN_AS_ROOT_CONFIRM=1 PATH=/root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
 
+# Disable HDF5 advisory file locking — the container/overlay filesystem does not
+# support it, so BMTK's build->save->re-open of SONATA .h5 files fails with
+# "unable to lock file, errno = 11". Hits networks with edges (e.g. balanced E/I);
+# a no-edge single cell slips through. Covers all HDF5 users (BMTK + TVB).
+ENV HDF5_USE_FILE_LOCKING=FALSE
+
 RUN apt-get update && apt-get install -y --no-install-recommends \ 
 	ca-certificates locales tzdata \
 	python3 python3-venv python3-pip python3-dev \
@@ -89,7 +95,7 @@ RUN python3 -m venv /root/.env && \
 	echo "source /root/.env/bin/activate" >> /root/.bashrc && \
 	cd nest-simulator && \
 	pip install --upgrade pip wheel && \
-	pip install --no-cache-dir Cython numpy boost setuptools gsl meson-python ninja && \
+	pip install --no-cache-dir Cython "numpy<2.5" boost setuptools gsl meson-python ninja && \
 	pip install -v --no-cache-dir --no-build-isolation --force-reinstall --check-build-dependencies --no-binary pygsl pygsl && \
 	pip install --no-cache-dir -r requirements.txt
 
@@ -119,8 +125,8 @@ RUN . /root/.env/bin/activate && \
 	rm -rf ${SRC_PATH}/nest-build ${SRC_PATH}/nest-simulator
 
 RUN . /root/.env/bin/activate && \
-	pip install --no-cache-dir nestml nest-desktop pandas jupyterlab notebook \
-		jupyterhub tvb-library tvb-framework statsmodels hdf5storage bmtk \
+	pip install --no-cache-dir nestml nest-desktop "pandas>=2.2,<3.0" jupyterlab notebook \
+		jupyterhub tvb-library tvb-framework statsmodels hdf5storage bmtk "numpy<2.5" \
 		"siibra==1.0.1a15" "traitlets==5.14.3" && \
 	find /root/.cache -type f -delete
 
@@ -130,7 +136,7 @@ RUN . /root/.env/bin/activate && \
 # Use h5py >=3.13 (first version with HDF5 1.14.x support and Cython 3
 # compatibility) to ensure it builds in this environment.
 RUN . /root/.env/bin/activate && \
-	HDF5_DIR=${HDF5_DIR} pip install --no-cache-dir --no-binary=h5py --force-reinstall "h5py>=3.13" && \
+	HDF5_DIR=${HDF5_DIR} pip install --no-cache-dir --no-binary=h5py --force-reinstall "h5py>=3.13" "numpy<2.5" && \
 	find /root/.cache -type f -delete
 
 COPY entrypoint.sh /usr/local/bin/entrypoint.sh

--- a/src/neuroworkflow/nodes/simulation/NW_SimConfig.py
+++ b/src/neuroworkflow/nodes/simulation/NW_SimConfig.py
@@ -1,5 +1,16 @@
 from typing import Dict, Any
 
+import pandas as pd
+
+# BMTK 1.1.4 reads SONATA node-type tables via pandas. Under pandas >= 3.0 the
+# default string dtype became StringDtype(na_value=nan), which BMTK then hands to
+# np.empty() (sonata/group.py) and which NumPy cannot interpret as a dtype:
+#   "Cannot interpret '<StringDtype(...)>' as a data type"
+# Disabling the new string inference keeps those columns as object dtype, exactly
+# as pre-3.0. set_option is process-global, so setting it once at import — before
+# any BMTK SONATA read in workflow.execute() — covers the whole run.
+pd.set_option("future.infer_string", False)
+
 from neuroworkflow.core.node import Node
 from neuroworkflow.core.schema import (
     NodeDefinitionSchema, PortDefinition, ParameterDefinition, MethodDefinition,


### PR DESCRIPTION
Workflows failed at runtime in the nest-jupyterlab image (PR #58 only verified import + a minimal builder, not full sims):

1. pandas 3.0 StringDtype  -> BMTK SONATA read: 'Cannot interpret <StringDtype> as a data type' (single cell + balanced).
2. pandas 3.0 Copy-on-Write -> .values is read-only, BMTK passes it to nest.Connect: 'buffer source array is read-only' (edge networks).
3. HDF5 advisory locking unsupported on the container/overlay FS -> 'unable to lock file, errno = 11' on build->save->re-open of edges (balanced; no-edge single cell slips through).
4. numpy drifted to 2.5 -> 'Numba needs NumPy 2.4 or less' (TVB).

Fixes (Dockerfile.nest):
- Pin pandas>=2.2,<3.0  (keeps nilearn>=2.2; pandas 2.3 supports numpy 2 so it does NOT force numpy<2).
- ENV HDF5_USE_FILE_LOCKING=FALSE  (covers all HDF5 users: BMTK + TVB).
- Pin numpy<2.5 in all three pip steps, incl. the --force-reinstall h5py step that was re-bumping numpy after the earlier pins.

NW_SimConfig.py (src + GUI): defensive pd.set_option('future.infer_string', False) at import — redundant on the pinned image, protects the node if run under pandas 3.0 elsewhere.

Verified: single cell, balanced E/I network, and TVB workflows all run end-to-end in a freshly rebuilt image.