### PR TITLE
Unify hackathon participant kit into a single entry point

### DIFF
--- a/hackathon/PARTICIPANT_GUIDE.md
+++ b/hackathon/PARTICIPANT_GUIDE.md
@@ -1,167 +1,190 @@
-NeuroWorkflow Hackathon — Participant Guide
+# NeuroWorkflow Hackathon — Participant Guide
 
+Welcome! **NeuroWorkflow** is a node-based model builder for computational neuroscience. This
+guide is your **entry point**: it explains the core ideas, lays out the two hackathon themes,
+and links to the detailed file for each step. You can do **one or both** themes.
 
-1. Introduction to Neuro-Workflow and the NW Model Builder
+---
 
-Neuro-Workflow is a node-based model builder for computational neuroscience. A model is
-expressed as a graph of reusable components:
+## What is a node / a workflow?
 
-  - A node is a Python class that wraps one scientific operation (build a population, add
-    connectivity, run a simulation, compute firing rates). Each node declares its inputs,
-    outputs, and parameters through a schema, so it can be connected to other nodes — even
-    nodes written by other teams or for other simulators.
-  - A workflow is a graph of connected nodes. Running it executes the nodes in order and
-    passes data along the connections.
+- A **node** is a Python class that wraps one scientific operation (build a population, add
+  connectivity, run a simulation, compute firing rates). Each node declares its inputs,
+  outputs, and parameters through a schema, so it can be connected to other nodes — even nodes
+  written by other teams or for other simulators.
+- A **workflow** is a graph of connected nodes. Running it executes the nodes in order and
+  passes data along the connections.
 
-The same model can be built and run in two places: locally through the Neuro-Workflow Python
-API (in a Jupyter notebook), and visually in the web application (GUI) on the server.
+The same model can be built and run in two places: **locally** through the NeuroWorkflow
+Python API (in a Jupyter notebook), and **visually** in the web application (GUI) on the
+server.
 
-In this theme you will learn Neuro-Workflow using a set of example workflows built with the
-NW Model Builder nodes (population, connectivity, stimulus, simulation, analysis).
+---
 
-Setup — prepare your environment before the hackathon
+## The two themes
 
-  Do these steps beforehand so you arrive ready to run. The three example workflows use the
-  NEST simulator (with BMTK), so they go in the same virtual environment as Neuro-Workflow.
-  This uses a plain Python venv, the same kind the Theme 2 setup scripts create.
+| Theme | What you do | Details |
+|-------|-------------|---------|
+| **Theme 1 — Learn with example workflows** | Run three ready-made point-neuron (NEST/BMTK) notebooks locally to learn the Python API, then reproduce one visually in the GUI. | [Theme 1](#theme-1--learn-neuroworkflow-with-example-workflows) + [`pointneuron_env_setup/`](./pointneuron_env_setup/) |
+| **Theme 2 — Build nodes from your own code** | Bring your own Python; an AI coding agent + the `create-node` skill turns it into nodes and a workflow; you validate locally, upload, and run in the GUI. | [Theme 2](#theme-2--build-nodes-from-your-own-code-with-ai-agents) + [`README.md`](./README.md) + [`SETUP.md`](./SETUP.md) |
 
-    1) Create a folder for this theme and move into it:
+Both themes set up with **one script that you run from your own working folder** and that
+creates a Python virtual environment for you. Keep this hackathon kit as **read-only**
+reference material, and run the scripts from a separate folder of your own (examples below).
 
-         mkdir nw_notebooks
-         cd nw_notebooks
+---
 
-    2) Create and activate a virtual environment:
+## Before you come
 
-         python3 -m venv venv
-         source venv/bin/activate          # Windows: venv\Scripts\activate
+| Item | Detail |
+|------|--------|
+| **Register** | Send your name, affiliation, and email. We create your NeuroWorkflow account in advance. |
+| **Laptop** | Python 3 + pip. Theme 1 needs **NEST** (the setup script installs it via a pip wheel on macOS 15+/Linux x86_64, Python 3.9–3.11; conda fallback otherwise). If a simulator won't install locally, you can still run on the server, where NEST/TVB are preinstalled. |
+| **Bring your code** *(Theme 2)* | Any Python you have — a model, preprocessing, analysis, or simulation. **Unstructured is fine** — that is the starting point. |
+| **AI agent** *(Theme 2)* | Bring your own **Claude Code** (preferred) or **Codex** subscription. If you don't have one, OpenAI API keys are provided — install **Codex** in that case. |
 
-    3) Install NEST into this virtual environment. NEST (version 3.7 or newer) must be
-       available in the same venv. NEST can be difficult to install and the procedure depends
-       on your system, so follow the official NEST installation instructions; conda is often
-       the most reliable route (conda install -c conda-forge nest-simulator). If it does not
-       install locally, you can still do Activity 2 on the server, where NEST is preinstalled.
+---
 
-    4) Install Neuro-Workflow, BMTK, and JupyterLab:
+## Theme 1 — Learn NeuroWorkflow with example workflows
 
-         pip install --upgrade pip
-         pip install "git+https://github.com/oist/neuro-workflow.git"
-         pip install bmtk jupyterlab matplotlib
+You learn NeuroWorkflow using a set of example workflows built with the NW Model Builder nodes
+(population, connectivity, stimulus, simulation, analysis).
 
-    5) Verify the installation (NEST should report version 3.7 or newer):
+### Setup (do this before the hackathon)
 
-         python -c "import nest, bmtk; from neuroworkflow.core.node import Node; print('NEST', nest.__version__)"
+The three example workflows use the **NEST** simulator (with **BMTK**), installed into the
+same virtual environment as NeuroWorkflow. NEST now ships a PyPI wheel, so the one-command
+path is simply:
 
-    6) Download the three example notebooks from the repository:
+```bash
+# from your own working folder (keep the hackathon kit read-only):
+bash /path/to/hackathon/pointneuron_env_setup/setup_pointneuron.sh
+```
 
-         base=https://raw.githubusercontent.com/oist/neuro-workflow/main/notebooks
-         curl -fsSL $base/NW_SingleCell_PointNeuron.ipynb     -o NW_SingleCell_PointNeuron.ipynb
-         curl -fsSL $base/NW_BalancedNetwork_PointNeuron.ipynb -o NW_BalancedNetwork_PointNeuron.ipynb
-         curl -fsSL $base/NW_Ring_PointNeuron.ipynb           -o NW_Ring_PointNeuron.ipynb
+This creates a venv, installs NeuroWorkflow + NEST + BMTK + JupyterLab, and downloads the
+three notebooks into `./notebooks`. It requires **CPython 3.9–3.11** on macOS 15+ or
+Linux x86_64. On other platforms/versions (older macOS, Linux aarch64, Windows), use the
+**conda** path instead — both paths are documented in
+[`pointneuron_env_setup/README.md`](./pointneuron_env_setup/README.md). If NEST won't install
+locally at all, that's fine: do **Activity 2** on the server, where NEST is preinstalled.
 
-    7) Launch JupyterLab, open the three notebooks, and run them before the hackathon:
+Then launch JupyterLab and run all three notebooks end to end before the hackathon:
 
-         jupyter lab
+```bash
+source .venv/bin/activate          # Windows: .venv\Scripts\activate
+jupyter lab
+```
 
-       Run all three end to end so they execute successfully on your machine. We will explain
-       them during the hackathon, and then together we will recreate a version of one of them
-       on the server GUI using our Neuro-Workflow AI agents.
+### Activity 1 — Run the example notebooks locally and learn the Python API
 
-Activity 1 — Run the example notebooks locally and learn the Python API
+Three example workflows are provided, built with the NW Model Builder nodes:
 
-  Three example workflows are provided in the notebooks folder, built with the NW Model
-  Builder nodes:
+- `NW_SingleCell_PointNeuron.ipynb` — a single point-neuron driven by a current clamp.
+- `NW_BalancedNetwork_PointNeuron.ipynb` — an excitatory/inhibitory balanced network.
+- `NW_Ring_PointNeuron.ipynb` — a ring-topology network.
 
-    - NW_SingleCell_PointNeuron.ipynb   — a single point-neuron driven by a current clamp.
-    - NW_BalancedNetwork_PointNeuron.ipynb — an excitatory/inhibitory balanced network.
-    - NW_Ring_PointNeuron.ipynb         — a ring-topology network.
+Run each notebook locally and follow the NeuroWorkflow Python API as you go. The pattern is
+the same in all three:
 
-  Run each notebook locally and follow the Neuro-Workflow Python API as you go. The pattern is
-  the same in all three:
+1. Create the nodes.
+2. Configure each node's parameters.
+3. Create a `WorkflowBuilder`, add the nodes, and connect their ports.
+4. Set the workflow context (e.g. the results path).
+5. Build the workflow and execute it.
+6. Validate the outputs (confirm the run succeeded and no output is empty / `None`).
 
-    1) Create the nodes.
-    2) Configure each node's parameters.
-    3) Create a WorkflowBuilder, add the nodes, and connect their ports.
-    4) Set the workflow context (e.g. the results path).
-    5) Build the workflow and execute it.
-    6) Validate the outputs (confirm the run succeeded and no output is empty / None).
+**Goal:** understand how nodes, parameters, ports, connections, and execution fit together —
+the foundation for everything that follows.
 
-  Goal: understand how nodes, parameters, ports, connections, and execution fit together —
-  this is the foundation for everything that follows.
+### Activity 2 — Reproduce one workflow in the GUI on the server
 
-Activity 2 — Reproduce one workflow in the GUI on the server
+Choose any one of the three workflows and rebuild it visually in the web application on the
+server. The NW Model Builder nodes are already available on the server, so you do not create
+any node here — you assemble the workflow:
 
-  Choose any one of the three workflows and rebuild it visually in the web application on the
-  server. The NW Model Builder nodes are already available on the server, so you do not create
-  any node here — you assemble the workflow:
+1. Add the required nodes from the palette.
+2. Connect their ports to form the workflow graph.
+3. Configure the parameters of each node.
+4. Build the workflow, generate the code, and run it.
 
-    1) Add the required nodes from the palette.
-    2) Connect their ports to form the workflow graph.
-    3) Configure the parameters of each node.
-    4) Build the workflow, generate the code, and run it.
+Do this with the help of the in-app AI assistant, which can add nodes, connect them, and set
+parameters for you on request.
 
-  Do this with the help of the Neuro-Workflow AI agents (the in-app AI assistant), which can
-  add nodes, connect them, and set parameters for you on request.
+**Goal:** see that the same model you ran locally in Python can be reproduced and executed
+visually on the server.
 
-  Goal: see that the same model you ran locally in Python can be reproduced and executed
-  visually on the server.
+---
 
-
-2. Nodes and Workflow Creation Using AI Coding Agents
+## Theme 2 — Build nodes from your own code with AI agents
 
 This theme is similar to Theme 1, except that here you create the nodes and the workflow from
-your own source code, with the help of AI coding agents.
+your **own** source code, with the help of an AI coding agent:
 
-  - You bring your own Python code (a model, a preprocessing or analysis script, a simulation
-    — unstructured is fine; that is the starting point).
-  - You use an AI coding agent (Claude Code or Codex) guided by our create-node SKILL.md to
-    turn that code into Neuro-Workflow nodes and a workflow. The skill encodes the conventions
-    and checks we developed from experience building and testing nodes manually, so the agent
-    produces clean, uploadable nodes.
-  - You run the generated nodes and workflow locally (in a notebook) and validate the outputs.
-  - You upload the nodes to the server using the GUI.
-  - You create a workflow on the server with the help of the Neuro-Workflow AI agents (the
-    in-app AI assistant), the same way as in Theme 1.
+- You bring your own Python code (a model, a preprocessing or analysis script, a simulation —
+  unstructured is fine; that is the starting point).
+- You use an AI coding agent (**Claude Code** or **Codex**) guided by our `create-node` skill
+  to turn that code into NeuroWorkflow nodes and a workflow. The skill encodes the conventions
+  and checks we developed building and testing nodes by hand, so the agent produces clean,
+  uploadable nodes.
+- You run the generated nodes and workflow locally and validate the outputs.
+- You upload the nodes to the server through the GUI.
+- You assemble the workflow on the server with the in-app AI assistant, the same way as in
+  Theme 1.
 
-The materials for this theme are in the hackathon folder:
+### Setup
 
-  - README.md            — the step-by-step participant agenda.
-  - SETUP.md             — environment setup for each agent (scripts + manual fallback).
-  - CLAUDE.md / AGENTS.md — the agent instructions (identical; Claude Code reads CLAUDE.md,
-                            Codex reads AGENTS.md).
-  - create-node SKILL.md — the node-creation skill the agent follows.
-  - check_node.py        — a validator that checks each generated node.
-  - quick_setup/         — one-command setup scripts (setup_claude.sh, setup_codex.sh).
-  - examples/            — a dependency-free example to get a first green run, plus a sample
-                            unstructured script to use if you did not bring your own code.
+From your own working folder, run the one-command script for your agent (keep this kit
+read-only):
 
-Setup — download the kit, then run the script from your own test folder
+```bash
+# Claude Code:
+bash /path/to/hackathon/quick_setup/setup_claude.sh
+# Codex:
+bash /path/to/hackathon/quick_setup/setup_codex.sh
+```
 
-  We will provide the hackathon folder. The setup is location-independent: the script reads
-  what it needs from the internet and writes the workspace into your current folder. So you
-  keep the hackathon folder as shared, read-only material, and run the script from a separate
-  test folder of your own.
+Each script creates a venv, installs a pinned NeuroWorkflow + JupyterLab + matplotlib, makes a
+`source_code/` folder (drop your code here) and a `my_nodes/` folder (the agent writes here),
+and installs the `create-node` skill for your agent. Full details — both agents, the manual
+fallback, and a dependency-free **green-run** sanity check — are in [`SETUP.md`](./SETUP.md).
 
-    1) Download the hackathon folder we provide and store it anywhere on your computer.
-       Example: ./hackathon
+### Step-by-step walkthrough
 
-    2) Create a folder for your test, in any location (inside or outside hackathon), and cd
-       into it. Example:
+The complete four-step agenda — build nodes locally, test them with `check_node.py`, upload
+them, and run the workflow on the server — is in **[`README.md`](./README.md)**. Start there
+once your environment is set up. If you didn't bring your own code, it points you at
+[`examples/sample_target/`](./examples/sample_target/), a realistic unstructured script to use
+as a stand-in.
 
-         mkdir ./mytest
-         cd ./mytest
+---
 
-    3) From inside your test folder, run the setup script for your agent using the path to
-       where you stored the hackathon folder. Example (hackathon is one level up):
+## Running on the server
 
-         # Claude Code:
-         bash ../hackathon/quick_setup/setup_claude.sh
-         # Codex:
-         bash ../hackathon/quick_setup/setup_codex.sh
+For this hackathon, workflows run **directly on the application server**, so please keep
+example runs **lightweight** (short simulations, modest network sizes). A dedicated HPC
+compute backend is not used in this round.
 
-  Everything the script creates — the Python virtual environment (venv/), the source_code/ and
-  my_nodes/ folders, the create-node skill, and the agent instruction file — is written inside
-  your test folder (./mytest), not into the hackathon folder. Put your own code in source_code/;
-  the agent writes the generated nodes and workflow into my_nodes/.
+---
 
-  (The script downloads a pinned neuroworkflow + JupyterLab + matplotlib, so you need an
-  internet connection the first time you run it. It is safe to re-run.)
+## Support
+
+A built-in AI assistant is available inside the platform for participants who prefer not to use
+Claude Code or Codex directly. **Working locally with a coding agent is the recommended path
+for Theme 2** — it gives you full control over node development. If a simulator install fails
+or anything blocks you, ask an organizer rather than burning session time.
+
+---
+
+## What's in this folder
+
+| File | Purpose |
+|------|---------|
+| [`PARTICIPANT_GUIDE.md`](./PARTICIPANT_GUIDE.md) | This guide — the entry point. |
+| [`README.md`](./README.md) | Theme 2 step-by-step walkthrough (build nodes from your own code). |
+| [`SETUP.md`](./SETUP.md) | Theme 2 environment setup for each agent (scripts + manual fallback). |
+| [`quick_setup/`](./quick_setup/) | Theme 2 one-command setup scripts (`setup_claude.sh`, `setup_codex.sh`). |
+| [`pointneuron_env_setup/`](./pointneuron_env_setup/) | Theme 1 environment setup (NEST + BMTK, any OS) + the three notebooks. |
+| [`CLAUDE.md`](./CLAUDE.md) / [`AGENTS.md`](./AGENTS.md) | The agent's instructions (identical; Claude Code reads `CLAUDE.md`, Codex reads `AGENTS.md`). |
+| [`check_node.py`](./check_node.py) | Deterministic node validator (`ALL NODES PASSED` / failures). |
+| [`examples/hello_node/`](./examples/hello_node/) | The dependency-free 5-minute green-run example. |
+| [`examples/sample_target/`](./examples/sample_target/) | A realistic unstructured script to use as input if you didn't bring your own code. |

--- a/hackathon/README.md
+++ b/hackathon/README.md
@@ -1,59 +1,43 @@
-# NeuroWorkflow Hackathon — Participant Guide
+# Theme 2 — Build NeuroWorkflow nodes from your own code
 
-Welcome! In this hackathon you will turn **your own Python code** into reusable **NeuroWorkflow nodes**
-and a **workflow**, with an AI coding agent doing most of the heavy lifting. You then run it locally,
+> Part of the **NeuroWorkflow Hackathon** kit. Start with
+> [`PARTICIPANT_GUIDE.md`](./PARTICIPANT_GUIDE.md) for the overview, the core concepts, and
+> Theme 1. **This file is the detailed step-by-step walkthrough for Theme 2.**
+
+In Theme 2 you turn **your own Python code** into reusable **NeuroWorkflow nodes** and a
+**workflow**, with an AI coding agent doing most of the heavy lifting. You then run it locally,
 upload it to the NeuroWorkflow web app, and execute it on the server.
 
-**No prior NeuroWorkflow experience is required.** The agent + the `create-node` skill guide every step.
+**No prior NeuroWorkflow experience is required.** The agent + the `create-node` skill guide
+every step.
 
 ---
 
-## What is a node / a workflow?
+## Setup
 
-- A **node** is a Python class wrapping one scientific operation (e.g. "build network", "run simulation",
-  "compute firing rates"). It declares its inputs, outputs, and parameters so it can be connected to other
-  nodes — even ones written by other teams or other simulators.
-- A **workflow** is a graph of connected nodes. Running it executes the nodes in order and passes data
-  along the connections.
-
-The 5-minute example in `examples/hello_node/` shows both, with no simulator needed.
-
----
-
-## Before you come
-
-| Item | Detail |
-|------|--------|
-| **Register** | Send your name, affiliation, and email. We create your NeuroWorkflow account in advance. |
-| **Bring your code** | Any Python you have — a model, preprocessing, analysis, or simulation. **Unstructured is fine** — that is the starting point. |
-| **AI agent** | Bring your own **Claude Code** (preferred) or **Codex** subscription. If you don't have one, OpenAI API keys are provided — install **Codex** in that case. |
-| **Laptop** | Python 3 + pip. If your code needs **NEST / TVB** (or another simulator), install it locally if you can (conda recommended for NEST) so you can test. The organizers will make sure the simulators your run needs are available on the server — ask if your local install fails. |
-
----
-
-## Setup (once, at the start)
-
-Run the one-command script for your agent from a fresh working folder
-(full details and a manual fallback are in [`SETUP.md`](./SETUP.md)):
+From your own working folder, run the one-command script for your agent — keep the hackathon
+kit as read-only reference (full details and a manual fallback are in [`SETUP.md`](./SETUP.md)):
 
 ```bash
 # Claude Code:
-bash quick_setup/setup_claude.sh
+bash /path/to/hackathon/quick_setup/setup_claude.sh
 # Codex:
-bash quick_setup/setup_codex.sh
+bash /path/to/hackathon/quick_setup/setup_codex.sh
 ```
 
-This creates a Python virtual environment, installs NeuroWorkflow + JupyterLab + matplotlib, makes a
-`source_code/` folder (drop your code here) and a `my_nodes/` folder (the agent writes here), and installs
-the `create-node` skill for your agent.
+This creates a Python virtual environment, installs NeuroWorkflow + JupyterLab + matplotlib,
+makes a `source_code/` folder (drop your code here) and a `my_nodes/` folder (the agent writes
+here), and installs the `create-node` skill for your agent.
 
-**Sanity check — get a green run first.** Before using your own code, run the tiny example so you know the
-toolchain works and you can see what a finished node looks like:
+**Sanity check — get a green run first.** Before using your own code, run the tiny
+dependency-free example (no simulator) so you know the toolchain works and you can see what a
+finished node looks like. With your venv active:
 
 ```bash
-cd hackathon/examples/hello_node
-python workflow.py        # compare the printed numbers with EXPECTED_OUTPUT.md
+python /path/to/hackathon/examples/hello_node/workflow.py   # compare with EXPECTED_OUTPUT.md
 ```
+
+(`SETUP.md` step C-2 also shows how to fetch this example straight into your working folder.)
 
 ---
 
@@ -100,22 +84,5 @@ You drive **steps 1–2** locally with your agent. Steps **3–4** happen in the
 
 ---
 
-## Support
-
-A built-in AI assistant is available inside the platform for participants who prefer not to use Claude
-Code or Codex directly. **Working locally with a coding agent is the recommended path** — it gives you
-full control over node development. If a simulator install fails or anything blocks you, ask an organizer
-rather than burning session time.
-
----
-
-## What's in this folder
-
-| File | Purpose |
-|------|---------|
-| [`README.md`](./README.md) | This guide. |
-| [`SETUP.md`](./SETUP.md) | Exact setup steps (scripts + manual fallback) for both agents. |
-| [`CLAUDE.md`](./CLAUDE.md) / [`AGENTS.md`](./AGENTS.md) | The agent's instructions (identical; Claude Code reads `CLAUDE.md`, Codex reads `AGENTS.md`). |
-| [`check_node.py`](./check_node.py) | Deterministic node validator (`ALL NODES PASSED` / failures). |
-| [`examples/hello_node/`](./examples/hello_node/) | The dependency-free 5-minute green-run example. |
-| [`examples/sample_target/`](./examples/sample_target/) | A realistic unstructured script to use as input if you didn't bring your own code. |
+For the file index, the core concepts, Theme 1, and support, see
+[`PARTICIPANT_GUIDE.md`](./PARTICIPANT_GUIDE.md).

--- a/hackathon/SETUP.md
+++ b/hackathon/SETUP.md
@@ -1,12 +1,13 @@
 # NeuroWorkflow Hackathon — Participant Setup
 
-> **Fastest path — use the official one-command script for your agent** (in this repo):
+> **Fastest path — use the official one-command script for your agent.** Run it from **your
+> own working folder** (keep the hackathon kit as read-only reference):
 >
 > ```bash
 > # Claude Code:
-> bash quick_setup/setup_claude.sh
+> bash /path/to/hackathon/quick_setup/setup_claude.sh
 > # Codex:
-> bash quick_setup/setup_codex.sh
+> bash /path/to/hackathon/quick_setup/setup_codex.sh
 > ```
 >
 > Each script is idempotent and does everything below automatically: creates the venv, installs a

--- a/hackathon/pointneuron_env_setup/README.md
+++ b/hackathon/pointneuron_env_setup/README.md
@@ -37,11 +37,6 @@ notebooks into `./notebooks`. It is idempotent — re-run any time.
 > supported one (`brew install python@3.11`) and re-run, pass
 > `PYTHON=python3.11 bash setup_pointneuron.sh`, or use **Path B (conda)** below.
 
-> **Before this PR is merged to `main`**, pin the branch:
-> ```bash
-> NW_REF=izumi/hackathon-pointneuron-setup bash setup_pointneuron.sh
-> ```
-
 Then:
 
 ```bash


### PR DESCRIPTION
## Summary

Reconciles the `hackathon/` folder after #66 and #68 merged, per Carlos's review. **Docs-only — no runtime code is touched.**

- **`PARTICIPANT_GUIDE.md` is now the single entry point.** It carries the core concepts, a two-themes overview, "Before you come", and a **file index that links every file** in the folder; each theme links out to its detailed file instead of duplicating it.
- **`pointneuron_env_setup/` is wired into Theme 1.** The old inline manual NEST steps are replaced by the any-OS setup (Path A pip-wheel script = easy NEST install; Path B conda).
- **`README.md` is now the canonical Theme 2 walkthrough.** Dropped the duplicate "Participant Guide" H1 and the concept / before-you-come / support / file-index sections (now only in the guide); added a breadcrumb back to the guide. The four-step agenda lives in exactly one place.
- **Setup model standardized** across guide/README/SETUP: run the script from your own working folder, keeping the kit read-only.
- **Small fixes:** Windows `activate` lines, fixed README's contradictory run-location, removed the now-stale "before this PR is merged, pin the branch" note in `pointneuron_env_setup/README.md`.

## To-do checklist

- [x] `PARTICIPANT_GUIDE.md` = entry point that links the folder's files
- [x] Reconcile the two setup paths (Theme 1 manual venv vs Theme 2 `quick_setup`) + integrate the any-OS `pointneuron_env_setup/`
- [x] Unify `PARTICIPANT_GUIDE.md` Section 2 with `README.md` (overlapping Theme 2)
- [x] Small fixes / wording (Windows, easy NEST install)