### PR TITLE
Remote Slurm job-submission backend (RIKEN compute server) - Phase 1

### DIFF
--- a/deployment/compute_server/README.md
+++ b/deployment/compute_server/README.md
@@ -12,7 +12,8 @@ ssh-agent in the backend container holds no key until an admin unlocks it.
 - Login node: `digitalbrain.brainminds.jp`, user `neuro-workflow`. Used only for
   `ssh`/`rsync`/`sbatch`/`sacct` (login node has a 4 GB / 512-proc cap; no heavy
   or persistent processes). All compute happens inside jobs.
-- Account: `neuro-workflow`. Default partition: `ccalc` (CPU). GPU partitions:
+- Account: `kobetsu_neuro-workflow` (the login user is `neuro-workflow`, but the
+  Slurm association resolves to this account). Default partition: `ccalc` (CPU). GPU partitions:
   `gcalc1` (`--gres=gpu:L40:N`) and `gcalc2` (`--gres=gpu:H100:N`).
 - Working dir: `/data/neuro-workflow` (shared FS, unlimited pool; mounted on all
   nodes). Runs are staged under `/data/neuro-workflow/runs/<run_id>`. `$HOME` has
@@ -31,7 +32,7 @@ Defaults are set in `gui/docker-compose.prod.yml`; override in `gui/.env` if nee
 - `SLURM_USER=neuro-workflow`
 - `SLURM_REMOTE_DIR=/data/neuro-workflow/runs`
 - `SLURM_PARTITION=ccalc`
-- `SLURM_ACCOUNT=neuro-workflow`
+- `SLURM_ACCOUNT=kobetsu_neuro-workflow`
 - `SLURM_REMOTE_VENV=/data/neuro-workflow/local/venv`
 - `SLURM_PYTHON_MODULE=python/3.11.14`
 - `SLURM_SSH_KEY` is intentionally **unset** so auth uses the ssh-agent.

--- a/deployment/compute_server/README.md
+++ b/deployment/compute_server/README.md
@@ -1,0 +1,139 @@
+# Remote Slurm execution - operator runbook (RIKEN compute server)
+
+This enables the Django backend to submit a workflow as a **Slurm batch job** on
+the RIKEN compute server over SSH, poll its status, and read back results.
+
+It is **additive and OFF by default**: the live JupyterHub run path is untouched,
+and this path runs only when a run is submitted with `backend=slurm`. The
+ssh-agent in the backend container holds no key until an admin unlocks it.
+
+## Facts baked into the implementation (from RIKEN)
+
+- Login node: `digitalbrain.brainminds.jp`, user `neuro-workflow`. Used only for
+  `ssh`/`rsync`/`sbatch`/`sacct` (login node has a 4 GB / 512-proc cap; no heavy
+  or persistent processes). All compute happens inside jobs.
+- Account: `neuro-workflow`. Default partition: `ccalc` (CPU). GPU partitions:
+  `gcalc1` (`--gres=gpu:L40:N`) and `gcalc2` (`--gres=gpu:H100:N`).
+- Working dir: `/data/neuro-workflow` (shared FS, unlimited pool; mounted on all
+  nodes). Runs are staged under `/data/neuro-workflow/runs/<run_id>`. `$HOME` has
+  a strict quota - do not use it. The OS `/tmp` is tiny - the wrapper redirects
+  `TMPDIR` into the run dir.
+- No conda (institutional licensing). Python via Environment Modules
+  (`module load python/3.11.14`) + a venv at `/data/neuro-workflow/local/venv`.
+- `sacct` is enabled (used for status); interactive `srun` is currently
+  unavailable - we only use `sbatch`.
+
+## Configuration (env vars read by `RemoteSlurmExecutor`)
+
+Defaults are set in `gui/docker-compose.prod.yml`; override in `gui/.env` if needed.
+
+- `SLURM_HOST=digitalbrain.brainminds.jp`
+- `SLURM_USER=neuro-workflow`
+- `SLURM_REMOTE_DIR=/data/neuro-workflow/runs`
+- `SLURM_PARTITION=ccalc`
+- `SLURM_ACCOUNT=neuro-workflow`
+- `SLURM_REMOTE_VENV=/data/neuro-workflow/local/venv`
+- `SLURM_PYTHON_MODULE=python/3.11.14`
+- `SLURM_SSH_KEY` is intentionally **unset** so auth uses the ssh-agent.
+
+---
+
+## Phase 1 - prove the pipe
+
+### A. Compute-server venv (one-time)
+
+On the compute server, as the `neuro-workflow` user:
+
+```bash
+ssh neuro-workflow@digitalbrain.brainminds.jp
+# copy setup_compute_venv.sh over (scp) or paste it, then:
+bash setup_compute_venv.sh            # base: neuroworkflow + numpy
+```
+
+### B. Deploy the backend (app server) - additive
+
+```bash
+cd /data/neuro-workflow/gui
+docker compose -f docker-compose.yml -f docker-compose.prod.yml build backend
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d backend
+```
+
+Rebuild adds `openssh-client`+`rsync` and the ssh-agent entrypoint. The key is
+mounted read-only; nothing else changes.
+
+### C. Unlock the SSH key (admin, once per backend restart)
+
+```bash
+BACKEND=$(docker compose -f /data/neuro-workflow/gui/docker-compose.yml ps -q backend)
+docker exec -e SSH_AUTH_SOCK=/tmp/ssh-agent.sock -it "$BACKEND" ssh-add /root/.ssh/id_ed25519
+# enter the key passphrase once; verify:
+docker exec -e SSH_AUTH_SOCK=/tmp/ssh-agent.sock "$BACKEND" ssh-add -l
+```
+
+If `ssh-add -l` shows the fingerprint, the backend can now submit jobs. On every
+backend restart the agent memory clears - rerun this one command.
+
+### D. Verify the pipe (admin)
+
+First confirm the container can reach the login node and authenticate:
+
+```bash
+docker exec -e SSH_AUTH_SOCK=/tmp/ssh-agent.sock "$BACKEND" \
+  ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new \
+  neuro-workflow@digitalbrain.brainminds.jp 'hostname; sacct --version'
+```
+
+Then exercise the executor directly (bypasses HTTP/Keycloak), using the test
+workflow in this folder:
+
+```bash
+docker exec -e SSH_AUTH_SOCK=/tmp/ssh-agent.sock -i "$BACKEND" \
+  python django-project/manage.py shell <<'PY'
+from app.workflow.execution import RemoteSlurmExecutor
+ex = RemoteSlurmExecutor()
+code = open('/django-app/deployment/compute_server/test_workflow.py').read()
+r = ex.submit('pipe-test', 'pipe-test', code,
+              run_id='pipe-test-1', resource_requests={'time': '00:05:00'})
+print('submit:', r.status, r.remote_job_id, r.remote_run_dir, r.error)
+PY
+```
+
+Wait a few seconds, then poll:
+
+```bash
+docker exec -e SSH_AUTH_SOCK=/tmp/ssh-agent.sock -i "$BACKEND" \
+  python django-project/manage.py shell <<'PY'
+from app.workflow.execution import RemoteSlurmExecutor
+ex = RemoteSlurmExecutor()
+s = ex.get_status('pipe-test-1', job_id='<JOB_ID_FROM_SUBMIT>',
+                  remote_dir='/data/neuro-workflow/runs/pipe-test-1')
+print('status:', s.status, 'exit:', s.exit_code)
+print(s.stdout)
+PY
+```
+
+Success = status `COMPLETED`, exit code `0`, and stdout containing the test
+summary. The full UI/API path (`POST /api/workflow/<id>/run-submit/` with
+`{"backend": "slurm"}`) uses exactly this executor.
+
+---
+
+## Phase 2 - real simulator (NEST)
+
+Re-run the venv setup with the simulator extras (the compute nodes are Linux
+x86_64, so the NEST PyPI wheel + Python 3.11 module path works without conda):
+
+```bash
+ssh neuro-workflow@digitalbrain.brainminds.jp
+WITH_NEST=1 bash setup_compute_venv.sh
+```
+
+If a dependency must build from source and is killed by the login-node limits,
+run the same command inside a short `sbatch` on `ccalc`. If the NEST wheel is
+ever unavailable for the node architecture, fall back to a source build under
+`/data/neuro-workflow/local` exposed via an Environment Module, and set
+`SLURM_PYTHON_MODULE`/activation accordingly - the wrapper already does
+`module load` + venv activate.
+
+Then submit a NEST PointNeuron workflow with `backend=slurm` and verify it
+returns artifacts (SONATA files, spike/voltage reports) from the run dir.

--- a/deployment/compute_server/setup_compute_venv.sh
+++ b/deployment/compute_server/setup_compute_venv.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+# One-time (idempotent) setup of the NeuroWorkflow runtime venv on the RIKEN
+# compute server, used by the remote Slurm execution backend.
+#
+# Run this ON the compute server (login node), as the neuro-workflow user:
+#   ssh neuro-workflow@digitalbrain.brainminds.jp
+#   bash setup_compute_venv.sh                 # Phase 1: base (neuroworkflow + numpy)
+#   WITH_NEST=1 bash setup_compute_venv.sh     # Phase 2: + [pointnet,nest] simulator stack
+#
+# No conda (RIKEN institutional licensing forbids it). Uses Environment Modules
+# + a venv under /data/neuro-workflow/local, which is on the shared filesystem
+# and therefore visible to every compute node.
+#
+# Note on the login node limits (4 GB RAM / 512 procs): wheel-based installs
+# (numpy, the NEST PyPI wheel, neuroworkflow) are light and fine here. If a
+# dependency has to build from source and gets killed, run this inside a small
+# `sbatch` job on the ccalc partition instead.
+set -euo pipefail
+
+PREFIX="${PREFIX:-/data/neuro-workflow/local}"
+VENV_DIR="${VENV_DIR:-$PREFIX/venv}"
+PYTHON_MODULE="${PYTHON_MODULE:-python/3.11.14}"
+NW_REF="${NW_REF:-main}"
+WITH_NEST="${WITH_NEST:-0}"
+
+echo "==> Loading Python module ($PYTHON_MODULE)"
+if command -v module >/dev/null 2>&1; then
+  module load "$PYTHON_MODULE" 2>/dev/null || \
+    echo "    (module load failed; falling back to a python3.11/python3 on PATH)"
+fi
+PYBASE="$(command -v python3.11 || command -v python3)"
+echo "    using $("$PYBASE" --version 2>&1) ($PYBASE)"
+
+echo "==> Creating venv at $VENV_DIR"
+mkdir -p "$PREFIX"
+[ -x "$VENV_DIR/bin/python" ] || "$PYBASE" -m venv "$VENV_DIR"
+PYBIN="$VENV_DIR/bin/python"
+"$PYBIN" -m pip install --upgrade pip >/dev/null
+
+if [ "$WITH_NEST" = "1" ]; then
+  echo "==> Installing neuroworkflow[pointnet,nest] (NEST PyPI wheel + bmtk) @ $NW_REF"
+  # pandas<2.3: BMTK breaks on pandas 3.0 StringDtype (matches the hackathon pin).
+  "$VENV_DIR/bin/pip" install \
+    "neuroworkflow[pointnet,nest] @ git+https://github.com/oist/neuro-workflow.git@${NW_REF}" \
+    "pandas<2.3"
+else
+  echo "==> Installing neuroworkflow (base) + numpy @ $NW_REF"
+  "$VENV_DIR/bin/pip" install \
+    "git+https://github.com/oist/neuro-workflow.git@${NW_REF}" \
+    numpy
+fi
+
+echo "==> Verifying import"
+"$PYBIN" -c "from neuroworkflow.core.node import Node; import numpy; print('neuroworkflow + numpy OK')"
+if [ "$WITH_NEST" = "1" ]; then
+  "$PYBIN" -c "import nest, bmtk; print('NEST', nest.__version__, '+ bmtk OK')"
+fi
+
+echo "==> Done. The Slurm wrapper activates this venv automatically."
+echo "    Manual activation: source $VENV_DIR/bin/activate"

--- a/deployment/compute_server/test_workflow.py
+++ b/deployment/compute_server/test_workflow.py
@@ -1,0 +1,33 @@
+"""Lightweight, self-contained workflow for validating the remote Slurm pipe.
+
+No simulator and no network access - just numpy. It proves the full loop
+(stage -> rsync -> sbatch -> sacct -> result retrieval) end to end. Outputs are
+written into the per-run directory (the job runs with --chdir into it), which
+lives on /data/neuro-workflow, so nothing touches the OS /tmp.
+"""
+
+import json
+import platform
+
+import numpy as np
+
+rng = np.random.default_rng(42)
+x = rng.normal(size=10_000)
+
+summary = {
+    "node": platform.node(),
+    "python": platform.python_version(),
+    "numpy": np.__version__,
+    "n": int(x.size),
+    "mean": float(x.mean()),
+    "std": float(x.std()),
+}
+
+print("NeuroWorkflow remote-pipe test")
+for key, value in summary.items():
+    print(f"  {key}: {value}")
+
+with open("result.json", "w") as fh:
+    json.dump(summary, fh, indent=2)
+
+print("wrote result.json")

--- a/gui/docker-compose.prod.yml
+++ b/gui/docker-compose.prod.yml
@@ -12,6 +12,13 @@
 services:
   backend:
     command: bash -c "python3 django-project/manage.py migrate --noinput && cd django-project && gunicorn config.wsgi:application --bind 0.0.0.0:3000 --workers ${GUNICORN_WORKERS:-3} --timeout ${GUNICORN_TIMEOUT:-180}"
+    # Mount the passphrase-protected SSH key read-only for the remote Slurm
+    # backend. An admin unlocks it once per restart via:
+    #   docker exec -e SSH_AUTH_SOCK=/tmp/ssh-agent.sock -it <backend> \
+    #       ssh-add /root/.ssh/id_ed25519
+    # (Appended to the base service's volumes; the key is never written to.)
+    volumes:
+      - ${SLURM_SSH_KEY_HOST:-/root/.ssh/id_ed25519}:/root/.ssh/id_ed25519:ro
     environment:
       - MCP_SERVER_URL=http://mcp:8001
       - ALLOWED_HOSTS_ALL=false
@@ -20,6 +27,18 @@ services:
       - CSRF_TRUSTED_ORIGINS_EXTRA=${CSRF_TRUSTED_ORIGINS_EXTRA:-https://snnbuilder.riken.jp}
       - DJANGO_DEBUG=${DJANGO_DEBUG:-false}
       - JUPYTERHUB_BASE_URL=${JUPYTERHUB_BASE_URL:-/jupyter/}
+      # --- Remote Slurm execution (RIKEN compute server) ---------------------
+      # Additive and OFF by default: these only take effect when a workflow run
+      # is submitted with backend=slurm. SLURM_SSH_KEY is intentionally NOT set
+      # so the executor authenticates via the ssh-agent (see entrypoint.sh).
+      - SSH_AUTH_SOCK=/tmp/ssh-agent.sock
+      - SLURM_HOST=${SLURM_HOST:-digitalbrain.brainminds.jp}
+      - SLURM_USER=${SLURM_USER:-neuro-workflow}
+      - SLURM_REMOTE_DIR=${SLURM_REMOTE_DIR:-/data/neuro-workflow/runs}
+      - SLURM_PARTITION=${SLURM_PARTITION:-ccalc}
+      - SLURM_ACCOUNT=${SLURM_ACCOUNT:-neuro-workflow}
+      - SLURM_REMOTE_VENV=${SLURM_REMOTE_VENV:-/data/neuro-workflow/local/venv}
+      - SLURM_PYTHON_MODULE=${SLURM_PYTHON_MODULE:-python/3.11.14}
 
   jupyterhub:
     environment:

--- a/gui/docker-compose.prod.yml
+++ b/gui/docker-compose.prod.yml
@@ -36,7 +36,7 @@ services:
       - SLURM_USER=${SLURM_USER:-neuro-workflow}
       - SLURM_REMOTE_DIR=${SLURM_REMOTE_DIR:-/data/neuro-workflow/runs}
       - SLURM_PARTITION=${SLURM_PARTITION:-ccalc}
-      - SLURM_ACCOUNT=${SLURM_ACCOUNT:-neuro-workflow}
+      - SLURM_ACCOUNT=${SLURM_ACCOUNT:-kobetsu_neuro-workflow}
       - SLURM_REMOTE_VENV=${SLURM_REMOTE_VENV:-/data/neuro-workflow/local/venv}
       - SLURM_PYTHON_MODULE=${SLURM_PYTHON_MODULE:-python/3.11.14}
 

--- a/gui/workflow_backend/Dockerfile
+++ b/gui/workflow_backend/Dockerfile
@@ -4,9 +4,13 @@ FROM python:3.11.11-slim
 WORKDIR /app
 
 # Install required packages
+#   openssh-client + rsync: needed to submit jobs to / sync files with the
+#   RIKEN compute server over SSH (remote Slurm execution backend).
 RUN apt-get update && apt-get install -y \
     build-essential \
     libpq-dev \
+    openssh-client \
+    rsync \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Poetry
@@ -29,8 +33,15 @@ RUN pip install --no-cache-dir openai allensdk requests fuzzywuzzy python-Levens
 # Copy project file
 COPY . .
 
+# Entrypoint starts an ssh-agent (for remote Slurm submission) then execs the
+# container command. The compose `command:` is preserved as arguments to it.
+RUN cp /app/entrypoint.sh /usr/local/bin/entrypoint.sh \
+    && chmod +x /usr/local/bin/entrypoint.sh
+
 # Port 3000 is open
 EXPOSE 3000
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]
 
 # run command
 CMD ["python", "django-project/manage.py", "runserver", "0.0.0.0:3000"]

--- a/gui/workflow_backend/django-project/app/workflow/execution/base.py
+++ b/gui/workflow_backend/django-project/app/workflow/execution/base.py
@@ -30,6 +30,7 @@ class ExecutionResult:
     started_at: Optional[datetime] = None
     finished_at: Optional[datetime] = None
     remote_job_id: Optional[str] = None
+    remote_run_dir: Optional[str] = None
     artifacts: dict = field(default_factory=dict)
 
 
@@ -43,22 +44,38 @@ class ExecutionBackend(ABC):
         project_name: str,
         code: str,
         *,
+        run_id: Optional[str] = None,
         resource_requests: Optional[dict] = None,
     ) -> ExecutionResult:
-        """Submit a workflow run. Returns immediately with a pending result."""
+        """Submit a workflow run. Returns immediately with a pending result.
+
+        ``run_id`` lets the caller pin the run identifier (e.g. the DB
+        WorkflowRun id) so staging dirs, remote dirs and later status polls all
+        line up. If omitted, a fresh UUID is generated.
+        """
         ...
 
     @abstractmethod
-    def get_status(self, run_id: str) -> ExecutionResult:
-        """Poll the status of a previously submitted run."""
+    def get_status(
+        self,
+        run_id: str,
+        *,
+        job_id: Optional[str] = None,
+        remote_dir: Optional[str] = None,
+    ) -> ExecutionResult:
+        """Poll the status of a previously submitted run.
+
+        ``job_id`` and ``remote_dir`` are supplied by the caller from persisted
+        state so the backend does not depend on process-local memory.
+        """
         ...
 
     @abstractmethod
-    def get_logs(self, run_id: str) -> str:
+    def get_logs(self, run_id: str, *, remote_dir: Optional[str] = None) -> str:
         """Return combined stdout+stderr collected so far."""
         ...
 
     @abstractmethod
-    def cancel(self, run_id: str) -> bool:
+    def cancel(self, run_id: str, *, job_id: Optional[str] = None) -> bool:
         """Attempt to cancel a running job. Returns True if cancelled."""
         ...

--- a/gui/workflow_backend/django-project/app/workflow/execution/local_executor.py
+++ b/gui/workflow_backend/django-project/app/workflow/execution/local_executor.py
@@ -32,12 +32,15 @@ class LocalExecutor(ExecutionBackend):
         project_name: str,
         code: str,
         *,
+        run_id: Optional[str] = None,
         resource_requests: Optional[dict] = None,
     ) -> ExecutionResult:
         result = ExecutionResult(
             status=ExecutionStatus.PENDING,
             submitted_at=datetime.now(timezone.utc),
         )
+        if run_id:
+            result.run_id = run_id
         project_dir = self.code_dir / str(workflow_id)
         script_path = project_dir / "workflow.py"
 
@@ -90,7 +93,13 @@ class LocalExecutor(ExecutionBackend):
         finally:
             res.finished_at = datetime.now(timezone.utc)
 
-    def get_status(self, run_id: str) -> ExecutionResult:
+    def get_status(
+        self,
+        run_id: str,
+        *,
+        job_id: Optional[str] = None,
+        remote_dir: Optional[str] = None,
+    ) -> ExecutionResult:
         entry = _runs.get(run_id)
         if not entry:
             r = ExecutionResult(run_id=run_id, status=ExecutionStatus.FAILED)
@@ -98,7 +107,7 @@ class LocalExecutor(ExecutionBackend):
             return r
         return entry["result"]
 
-    def get_logs(self, run_id: str) -> str:
+    def get_logs(self, run_id: str, *, remote_dir: Optional[str] = None) -> str:
         entry = _runs.get(run_id)
         if not entry:
             return ""
@@ -112,7 +121,7 @@ class LocalExecutor(ExecutionBackend):
             parts.append(f"ERROR: {res.error}")
         return "\n".join(parts)
 
-    def cancel(self, run_id: str) -> bool:
+    def cancel(self, run_id: str, *, job_id: Optional[str] = None) -> bool:
         entry = _runs.get(run_id)
         if not entry:
             return False

--- a/gui/workflow_backend/django-project/app/workflow/execution/remote_slurm_executor.py
+++ b/gui/workflow_backend/django-project/app/workflow/execution/remote_slurm_executor.py
@@ -1,4 +1,11 @@
-"""Remote execution backend — submits jobs to a Slurm cluster over SSH."""
+"""Remote execution backend - submits jobs to a Slurm cluster over SSH.
+
+Targets the RIKEN compute server (login node reachable over SSH; jobs run via
+``sbatch`` on shared storage under ``/data/neuro-workflow``). Authentication is
+handled by an ssh-agent running in the backend container (see entrypoint.sh):
+the executor does NOT pass ``-i`` unless ``SLURM_SSH_KEY`` is explicitly set, so
+a passphrase-protected key unlocked once by an admin "just works".
+"""
 
 from __future__ import annotations
 
@@ -6,6 +13,7 @@ import logging
 import os
 import re
 import subprocess
+import uuid
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
@@ -16,26 +24,36 @@ from .base import ExecutionBackend, ExecutionResult, ExecutionStatus
 
 logger = logging.getLogger(__name__)
 
+_TEMPLATE_PATH = (
+    Path(__file__).resolve().parent / "templates" / "slurm_wrapper.sh.template"
+)
+
 _SLURM_STATE_MAP = {
     "PENDING": ExecutionStatus.PENDING,
     "RUNNING": ExecutionStatus.RUNNING,
     "COMPLETING": ExecutionStatus.RUNNING,
+    "CONFIGURING": ExecutionStatus.RUNNING,
     "COMPLETED": ExecutionStatus.COMPLETED,
     "FAILED": ExecutionStatus.FAILED,
     "TIMEOUT": ExecutionStatus.FAILED,
     "CANCELLED": ExecutionStatus.CANCELLED,
     "NODE_FAIL": ExecutionStatus.FAILED,
     "OUT_OF_MEMORY": ExecutionStatus.FAILED,
+    "BOOT_FAIL": ExecutionStatus.FAILED,
+    "DEADLINE": ExecutionStatus.FAILED,
+    "PREEMPTED": ExecutionStatus.FAILED,
 }
+
+_SSH_OPTS = ["-o", "StrictHostKeyChecking=accept-new", "-o", "BatchMode=yes"]
 
 
 def _ssh_cmd(host: str, user: str, cmd: str, key_path: Optional[str] = None) -> str:
     """Run a command on a remote host via SSH and return stdout."""
-    ssh_args = ["ssh", "-o", "StrictHostKeyChecking=no", "-o", "BatchMode=yes"]
+    ssh_args = ["ssh", *_SSH_OPTS]
     if key_path:
-        ssh_args += ["-i", key_path]
+        ssh_args += ["-i", key_path, "-o", "IdentitiesOnly=yes"]
     ssh_args += [f"{user}@{host}", cmd]
-    result = subprocess.run(ssh_args, capture_output=True, text=True, timeout=30)
+    result = subprocess.run(ssh_args, capture_output=True, text=True, timeout=60)
     if result.returncode != 0:
         raise RuntimeError(
             f"SSH command failed (rc={result.returncode}): {result.stderr.strip()}"
@@ -51,40 +69,47 @@ def _rsync(
     key_path: Optional[str] = None,
     to_remote: bool = True,
 ) -> None:
-    """rsync files to/from the remote host."""
-    rsync_args = ["rsync", "-az", "--mkpath"]
+    """rsync files to/from the remote host (over the same SSH/agent auth)."""
+    ssh_e = "ssh " + " ".join(_SSH_OPTS)
     if key_path:
-        rsync_args += ["-e", f"ssh -i {key_path} -o StrictHostKeyChecking=no"]
-    else:
-        rsync_args += ["-e", "ssh -o StrictHostKeyChecking=no"]
+        ssh_e += f" -i {key_path} -o IdentitiesOnly=yes"
+    rsync_args = ["rsync", "-az", "--mkpath", "-e", ssh_e]
     if to_remote:
         rsync_args += [src, f"{user}@{host}:{dst}"]
     else:
         rsync_args += [f"{user}@{host}:{src}", dst]
-    subprocess.run(rsync_args, check=True, capture_output=True, text=True, timeout=120)
+    subprocess.run(rsync_args, check=True, capture_output=True, text=True, timeout=300)
 
 
 class RemoteSlurmExecutor(ExecutionBackend):
     """Submit workflow scripts to a Slurm cluster via SSH.
 
     Configuration is read from environment variables:
-      SLURM_HOST          – hostname or IP of the login node
-      SLURM_USER          – SSH user
-      SLURM_SSH_KEY       – path to private key (optional, uses ssh-agent otherwise)
-      SLURM_REMOTE_DIR    – remote working directory (default: ~/neuroworkflow-runs)
-      SLURM_PARTITION      – Slurm partition (optional)
-      SLURM_ACCOUNT        – Slurm account (optional)
+      SLURM_HOST          - hostname of the login node
+      SLURM_USER          - SSH user
+      SLURM_SSH_KEY       - path to private key (optional; uses ssh-agent if unset)
+      SLURM_REMOTE_DIR    - remote working dir root (shared FS, e.g. /data/neuro-workflow/runs)
+      SLURM_PARTITION     - default Slurm partition (RIKEN default: ccalc)
+      SLURM_ACCOUNT       - Slurm account (RIKEN: neuro-workflow)
+      SLURM_REMOTE_VENV   - venv to activate in the job (e.g. /data/neuro-workflow/local/venv)
+      SLURM_PYTHON_MODULE - Environment Module to load for Python (e.g. python/3.11.14)
     """
 
     def __init__(self):
         self.host = os.getenv("SLURM_HOST", "")
         self.user = os.getenv("SLURM_USER", "")
         self.key_path = os.getenv("SLURM_SSH_KEY") or None
-        self.remote_dir = os.getenv("SLURM_REMOTE_DIR", "~/neuroworkflow-runs")
-        self.partition = os.getenv("SLURM_PARTITION", "")
-        self.account = os.getenv("SLURM_ACCOUNT", "")
+        self.remote_dir = os.getenv("SLURM_REMOTE_DIR", "/data/neuro-workflow/runs")
+        self.partition = os.getenv("SLURM_PARTITION", "ccalc")
+        self.account = os.getenv("SLURM_ACCOUNT", "neuro-workflow")
+        self.remote_venv = os.getenv(
+            "SLURM_REMOTE_VENV", "/data/neuro-workflow/local/venv"
+        )
+        self.python_module = os.getenv("SLURM_PYTHON_MODULE", "python/3.11.14")
         self.local_staging = Path(settings.BASE_DIR) / "run_staging"
         self.local_staging.mkdir(parents=True, exist_ok=True)
+
+    # -- low-level helpers ---------------------------------------------------
 
     def _ssh(self, cmd: str) -> str:
         return _ssh_cmd(self.host, self.user, cmd, self.key_path)
@@ -92,10 +117,58 @@ class RemoteSlurmExecutor(ExecutionBackend):
     def _sync_to_remote(self, local: str, remote: str) -> None:
         _rsync(local, remote, self.host, self.user, self.key_path, to_remote=True)
 
-    def _sync_from_remote(self, remote: str, local: str) -> None:
-        _rsync(remote, local, self.host, self.user, self.key_path, to_remote=False)
+    def _remote_run_dir(self, run_id: str) -> str:
+        return f"{self.remote_dir}/{run_id}"
 
-    # ── Interface implementation ───────────────────────────────────────
+    def _build_sbatch_extras(self, rr: dict) -> str:
+        """Translate a resource_requests dict into #SBATCH directive lines.
+
+        Partition/account default to the RIKEN values but can be overridden
+        per-run. --gres is passed through verbatim (e.g. "gpu:L40:1" on gcalc1,
+        "gpu:H100:1" on gcalc2); ccalc needs no gres.
+        """
+        lines = []
+        partition = rr.get("partition") or self.partition
+        account = rr.get("account") or self.account
+        if partition:
+            lines.append(f"#SBATCH --partition={partition}")
+        if account:
+            lines.append(f"#SBATCH --account={account}")
+        if rr.get("nodes"):
+            lines.append(f"#SBATCH --nodes={rr['nodes']}")
+        if rr.get("ntasks"):
+            lines.append(f"#SBATCH --ntasks={rr['ntasks']}")
+        if rr.get("cpus_per_task"):
+            lines.append(f"#SBATCH --cpus-per-task={rr['cpus_per_task']}")
+        if rr.get("mem"):
+            lines.append(f"#SBATCH --mem={rr['mem']}")
+        if rr.get("time"):
+            lines.append(f"#SBATCH --time={rr['time']}")
+        if rr.get("gres"):
+            lines.append(f"#SBATCH --gres={rr['gres']}")
+        return "\n".join(lines)
+
+    def _render_sbatch(
+        self, run_id: str, project_name: str, remote_run_dir: str, rr: dict
+    ) -> str:
+        safe_job_name = "nw-" + re.sub(r"[^A-Za-z0-9_-]", "-", str(run_id))[:16]
+        template = _TEMPLATE_PATH.read_text()
+        replacements = {
+            "{{JOB_NAME}}": safe_job_name,
+            "{{RUN_DIR}}": remote_run_dir,
+            "{{SBATCH_EXTRAS}}": self._build_sbatch_extras(rr),
+            "{{RUN_ID}}": str(run_id),
+            "{{PROJECT_NAME}}": str(project_name),
+            "{{SCRIPT_NAME}}": "workflow.py",
+            "{{PYTHON_MODULE}}": self.python_module,
+            "{{VENV_PATH}}": self.remote_venv,
+        }
+        rendered = template
+        for key, value in replacements.items():
+            rendered = rendered.replace(key, value)
+        return rendered
+
+    # -- interface implementation -------------------------------------------
 
     def submit(
         self,
@@ -103,53 +176,26 @@ class RemoteSlurmExecutor(ExecutionBackend):
         project_name: str,
         code: str,
         *,
+        run_id: Optional[str] = None,
         resource_requests: Optional[dict] = None,
     ) -> ExecutionResult:
+        run_id = run_id or str(uuid.uuid4())
         result = ExecutionResult(
+            run_id=run_id,
             status=ExecutionStatus.PENDING,
             submitted_at=datetime.now(timezone.utc),
         )
-        run_id = result.run_id
-        remote_run_dir = f"{self.remote_dir}/{run_id}"
+        remote_run_dir = self._remote_run_dir(run_id)
+        result.remote_run_dir = remote_run_dir
 
         local_dir = self.local_staging / run_id
         local_dir.mkdir(parents=True, exist_ok=True)
-
-        safe_job_name = re.sub(r"[^A-Za-z0-9_-]", "-", str(workflow_id))[:20]
-        script_name = "workflow.py"
-        (local_dir / script_name).write_text(code)
-
-        rr = resource_requests or {}
-        sbatch_lines = [
-            "#!/bin/bash",
-            f"#SBATCH --job-name=nw-{safe_job_name}",
-            f"#SBATCH --output={remote_run_dir}/slurm-%j.out",
-            f"#SBATCH --error={remote_run_dir}/slurm-%j.err",
-        ]
-        if self.partition:
-            sbatch_lines.append(f"#SBATCH --partition={self.partition}")
-        if self.account:
-            sbatch_lines.append(f"#SBATCH --account={self.account}")
-        if rr.get("nodes"):
-            sbatch_lines.append(f"#SBATCH --nodes={rr['nodes']}")
-        if rr.get("ntasks"):
-            sbatch_lines.append(f"#SBATCH --ntasks={rr['ntasks']}")
-        if rr.get("cpus_per_task"):
-            sbatch_lines.append(f"#SBATCH --cpus-per-task={rr['cpus_per_task']}")
-        if rr.get("mem"):
-            sbatch_lines.append(f"#SBATCH --mem={rr['mem']}")
-        if rr.get("time"):
-            sbatch_lines.append(f"#SBATCH --time={rr['time']}")
-        if rr.get("gres"):
-            sbatch_lines.append(f"#SBATCH --gres={rr['gres']}")
-
-        sbatch_lines += [
-            "",
-            f"cd {remote_run_dir}",
-            f"python {script_name} > stdout.log 2> stderr.log",
-            "echo $? > exit_code.txt",
-        ]
-        (local_dir / "run.sbatch").write_text("\n".join(sbatch_lines) + "\n")
+        (local_dir / "workflow.py").write_text(code)
+        (local_dir / "run.sbatch").write_text(
+            self._render_sbatch(
+                run_id, project_name, remote_run_dir, resource_requests or {}
+            )
+        )
 
         try:
             self._ssh(f"mkdir -p {remote_run_dir}")
@@ -169,16 +215,23 @@ class RemoteSlurmExecutor(ExecutionBackend):
 
         return result
 
-    def get_status(self, run_id: str) -> ExecutionResult:
+    def get_status(
+        self,
+        run_id: str,
+        *,
+        job_id: Optional[str] = None,
+        remote_dir: Optional[str] = None,
+    ) -> ExecutionResult:
         result = ExecutionResult(run_id=run_id)
+        result.remote_job_id = job_id
 
-        meta = self._read_remote_meta(run_id)
-        job_id = meta.get("job_id")
         if not job_id:
             result.status = ExecutionStatus.FAILED
-            result.error = "No remote job ID found"
+            result.error = "No remote job ID recorded for this run"
             return result
-        result.remote_job_id = job_id
+
+        remote_run_dir = remote_dir or self._remote_run_dir(run_id)
+        result.remote_run_dir = remote_run_dir
 
         try:
             out = self._ssh(
@@ -191,7 +244,6 @@ class RemoteSlurmExecutor(ExecutionBackend):
             result.status = ExecutionStatus.RUNNING
 
         if result.status in (ExecutionStatus.COMPLETED, ExecutionStatus.FAILED):
-            remote_run_dir = f"{self.remote_dir}/{run_id}"
             try:
                 result.exit_code = int(
                     self._ssh(f"cat {remote_run_dir}/exit_code.txt").strip()
@@ -206,32 +258,25 @@ class RemoteSlurmExecutor(ExecutionBackend):
                 result.stderr = self._ssh(f"cat {remote_run_dir}/stderr.log")
             except Exception:
                 pass
+            result.finished_at = datetime.now(timezone.utc)
 
         return result
 
-    def get_logs(self, run_id: str) -> str:
-        remote_run_dir = f"{self.remote_dir}/{run_id}"
+    def get_logs(self, run_id: str, *, remote_dir: Optional[str] = None) -> str:
+        remote_run_dir = remote_dir or self._remote_run_dir(run_id)
         parts = []
-        for f in ("stdout.log", "stderr.log"):
+        for fname in ("stdout.log", "stderr.log"):
             try:
-                content = self._ssh(f"cat {remote_run_dir}/{f} 2>/dev/null || true")
+                content = self._ssh(
+                    f"cat {remote_run_dir}/{fname} 2>/dev/null || true"
+                )
                 if content:
                     parts.append(content)
             except Exception:
                 pass
-        try:
-            slurm_out = self._ssh(
-                f"cat {remote_run_dir}/slurm-*.out 2>/dev/null || true"
-            )
-            if slurm_out:
-                parts.append(slurm_out)
-        except Exception:
-            pass
         return "\n".join(parts)
 
-    def cancel(self, run_id: str) -> bool:
-        meta = self._read_remote_meta(run_id)
-        job_id = meta.get("job_id")
+    def cancel(self, run_id: str, *, job_id: Optional[str] = None) -> bool:
         if not job_id:
             return False
         try:
@@ -240,15 +285,3 @@ class RemoteSlurmExecutor(ExecutionBackend):
         except Exception as exc:
             logger.warning("scancel failed for job %s: %s", job_id, exc)
             return False
-
-    # ── Helpers ────────────────────────────────────────────────────────
-
-    def _read_remote_meta(self, run_id: str) -> dict:
-        """Read metadata from the local staging area for this run."""
-        local_dir = self.local_staging / run_id
-        meta: dict = {}
-        meta_file = local_dir / "meta.json"
-        if meta_file.exists():
-            import json
-            meta = json.loads(meta_file.read_text())
-        return meta

--- a/gui/workflow_backend/django-project/app/workflow/execution/remote_slurm_executor.py
+++ b/gui/workflow_backend/django-project/app/workflow/execution/remote_slurm_executor.py
@@ -90,7 +90,7 @@ class RemoteSlurmExecutor(ExecutionBackend):
       SLURM_SSH_KEY       - path to private key (optional; uses ssh-agent if unset)
       SLURM_REMOTE_DIR    - remote working dir root (shared FS, e.g. /data/neuro-workflow/runs)
       SLURM_PARTITION     - default Slurm partition (RIKEN default: ccalc)
-      SLURM_ACCOUNT       - Slurm account (RIKEN: neuro-workflow)
+      SLURM_ACCOUNT       - Slurm account (RIKEN: kobetsu_neuro-workflow)
       SLURM_REMOTE_VENV   - venv to activate in the job (e.g. /data/neuro-workflow/local/venv)
       SLURM_PYTHON_MODULE - Environment Module to load for Python (e.g. python/3.11.14)
     """
@@ -101,7 +101,7 @@ class RemoteSlurmExecutor(ExecutionBackend):
         self.key_path = os.getenv("SLURM_SSH_KEY") or None
         self.remote_dir = os.getenv("SLURM_REMOTE_DIR", "/data/neuro-workflow/runs")
         self.partition = os.getenv("SLURM_PARTITION", "ccalc")
-        self.account = os.getenv("SLURM_ACCOUNT", "neuro-workflow")
+        self.account = os.getenv("SLURM_ACCOUNT", "kobetsu_neuro-workflow")
         self.remote_venv = os.getenv(
             "SLURM_REMOTE_VENV", "/data/neuro-workflow/local/venv"
         )

--- a/gui/workflow_backend/django-project/app/workflow/execution/templates/slurm_wrapper.sh.template
+++ b/gui/workflow_backend/django-project/app/workflow/execution/templates/slurm_wrapper.sh.template
@@ -1,21 +1,27 @@
 #!/bin/bash
 # ============================================================================
-# NeuroWorkflow Slurm Job Wrapper
+# NeuroWorkflow Slurm Job Wrapper (RIKEN compute server)
 #
-# This template is staged alongside the generated Python script on the
-# compute node.  The RemoteSlurmExecutor fills in the {{placeholders}}
-# before submission.
+# Staged next to the generated workflow.py and submitted with sbatch. The
+# RemoteSlurmExecutor fills in the {{placeholders}} before submission.
 #
-# Outputs:
-#   stdout.log      – captured standard output
-#   stderr.log      – captured standard error
-#   exit_code.txt   – numeric exit code of the Python script
-#   manifest.json   – job metadata written after completion
+# RIKEN constraints baked in:
+#   * No conda (institutional licensing) -- we use Environment Modules + a venv
+#     under /data/neuro-workflow/local.
+#   * OS /tmp is tiny -- TMPDIR is redirected into the per-run directory.
+#   * The job only processes data already in /data/neuro-workflow (no network
+#     downloads during execution).
+#
+# Outputs (in RUN_DIR):
+#   stdout.log / stderr.log  -- captured Python output
+#   exit_code.txt            -- numeric exit code of workflow.py
+#   manifest.json            -- job metadata written after completion
 # ============================================================================
 
 #SBATCH --job-name={{JOB_NAME}}
 #SBATCH --output={{RUN_DIR}}/slurm-%j.out
 #SBATCH --error={{RUN_DIR}}/slurm-%j.err
+#SBATCH --chdir={{RUN_DIR}}
 {{SBATCH_EXTRAS}}
 
 set -uo pipefail
@@ -25,6 +31,10 @@ SCRIPT="{{SCRIPT_NAME}}"
 
 cd "${RUN_DIR}" || exit 1
 
+# Keep heavy temp files off the tiny OS /tmp (RIKEN guidance).
+export TMPDIR="${RUN_DIR}/tmp"
+mkdir -p "${TMPDIR}"
+
 echo "=== NeuroWorkflow Job ==="
 echo "Run ID:    {{RUN_ID}}"
 echo "Project:   {{PROJECT_NAME}}"
@@ -32,21 +42,23 @@ echo "Node:      $(hostname)"
 echo "Start:     $(date -Iseconds)"
 echo "========================="
 
-# ── Environment setup ──────────────────────────────────────────────────
-# Activate a conda/venv environment if configured.
-if [ -n "${NW_CONDA_ENV:-}" ]; then
-    source "$(conda info --base)/etc/profile.d/conda.sh"
-    conda activate "${NW_CONDA_ENV}"
-elif [ -n "${NW_VENV_PATH:-}" ]; then
-    source "${NW_VENV_PATH}/bin/activate"
+# -- Environment setup (Environment Modules + venv; NO conda) ----------------
+# Load the system Python module, then activate the project venv that carries
+# neuroworkflow (and, for simulator jobs, the self-built NEST/TVB modules).
+if command -v module >/dev/null 2>&1; then
+    module load {{PYTHON_MODULE}} 2>/dev/null || true
+fi
+if [ -d "{{VENV_PATH}}" ]; then
+    # shellcheck disable=SC1091
+    source "{{VENV_PATH}}/bin/activate"
 fi
 
-# ── Execution ──────────────────────────────────────────────────────────
+# -- Execution ---------------------------------------------------------------
 python "${SCRIPT}" > stdout.log 2> stderr.log
 EXIT_CODE=$?
 echo ${EXIT_CODE} > exit_code.txt
 
-# ── Manifest ───────────────────────────────────────────────────────────
+# -- Manifest ----------------------------------------------------------------
 cat > manifest.json <<MANIFEST_EOF
 {
   "run_id": "{{RUN_ID}}",
@@ -54,7 +66,6 @@ cat > manifest.json <<MANIFEST_EOF
   "script": "${SCRIPT}",
   "exit_code": ${EXIT_CODE},
   "node": "$(hostname)",
-  "start_time": "$(date -Iseconds -r stdout.log 2>/dev/null || echo unknown)",
   "end_time": "$(date -Iseconds)",
   "slurm_job_id": "${SLURM_JOB_ID:-unknown}"
 }

--- a/gui/workflow_backend/django-project/app/workflow/views.py
+++ b/gui/workflow_backend/django-project/app/workflow/views.py
@@ -1243,11 +1243,16 @@ class WorkflowRunSubmitView(APIView):
                 workflow_id=str(workflow_id),
                 project_name=project_name,
                 code=code,
+                run_id=str(run.id),
                 resource_requests=resource_reqs,
             )
             run.status = exec_result.status.value
             if exec_result.remote_job_id:
                 run.slurm_job_id = exec_result.remote_job_id
+            if exec_result.remote_run_dir:
+                run.remote_run_dir = exec_result.remote_run_dir
+            if exec_result.error:
+                run.error_message = exec_result.error
             run.save()
         except Exception as exc:
             logger.exception("Failed to submit run %s", run.id)
@@ -1284,7 +1289,11 @@ class WorkflowRunDetailView(APIView):
         ):
             executor = _get_executor(run.backend)
             try:
-                exec_result = executor.get_status(str(run.id))
+                exec_result = executor.get_status(
+                    str(run.id),
+                    job_id=run.slurm_job_id or None,
+                    remote_dir=run.remote_run_dir or None,
+                )
                 run.status = exec_result.status.value
                 if exec_result.exit_code is not None:
                     run.exit_code = exec_result.exit_code
@@ -1345,7 +1354,7 @@ class WorkflowRunCancelView(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
         executor = _get_executor(run.backend)
-        cancelled = executor.cancel(str(run.id))
+        cancelled = executor.cancel(str(run.id), job_id=run.slurm_job_id or None)
         if cancelled:
             run.status = WorkflowRun.Status.CANCELLED
             run.save()

--- a/gui/workflow_backend/entrypoint.sh
+++ b/gui/workflow_backend/entrypoint.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Container entrypoint for the NeuroWorkflow Django backend.
+#
+# Starts a long-lived ssh-agent on a fixed socket so the backend can submit
+# jobs to the RIKEN compute server over SSH using a passphrase-protected key
+# that an admin unlocks ONCE per container start:
+#
+#   docker exec -e SSH_AUTH_SOCK=/tmp/ssh-agent.sock -it <backend> \
+#       ssh-add /root/.ssh/id_ed25519
+#
+# This is additive and inert by default: the agent simply holds no keys until
+# an admin adds one, and nothing here runs unless a workflow is submitted with
+# backend=slurm. The live (JupyterHub) execution path is unaffected.
+set -e
+
+export SSH_AUTH_SOCK=/tmp/ssh-agent.sock
+
+# Start the agent only if its socket is not already live (fresh /tmp on start).
+if [ ! -S "$SSH_AUTH_SOCK" ]; then
+    ssh-agent -a "$SSH_AUTH_SOCK" >/dev/null
+fi
+
+exec "$@"


### PR DESCRIPTION
## Summary

Phase 1 of remote workflow execution on the RIKEN compute server, built on the existing (previously unused, buggy) `RemoteSlurmExecutor` scaffold. **Additive and OFF by default** - the live JupyterHub run path is untouched; this path runs only when a run is submitted with `backend=slurm`, and the in-container ssh-agent holds no key until an admin unlocks it.

### Backend image / plumbing
- `Dockerfile`: install `openssh-client` + `rsync`; add an entrypoint that starts a long-lived `ssh-agent` on `/tmp/ssh-agent.sock` and execs the compose command.
- `docker-compose.prod.yml` (additive): mount the passphrase-protected key read-only and set RIKEN `SLURM_*` env vars (host, user, account, `partition=ccalc`, remote dir `/data/neuro-workflow/runs`, venv, python module). `SLURM_SSH_KEY` is left unset so auth uses the agent.

### Executor fixes (the scaffold was non-functional)
- Canonical `run_id`: `submit()` accepts `run_id` and uses the DB `WorkflowRun.id` for staging + remote dir; the view persists `remote_run_dir` and `slurm_job_id`.
- Robust status: `get_status()` takes `job_id` + `remote_dir` from the persisted run (no more process-local `meta.json`), so polling survives container restarts.
- sbatch rendered from the wrapper template; `resource_requests` mapped to `#SBATCH` flags incl. `--gres` per partition.

### Wrapper template (RIKEN-compatible)
- Drop conda; use Environment Modules (`module load python`) + a venv under `/data/neuro-workflow/local`; redirect `TMPDIR` off the tiny OS `/tmp`; add `--chdir`.

### Operator deliverables (`deployment/compute_server/`)
- `setup_compute_venv.sh` (base + optional `WITH_NEST` simulator stack), `test_workflow.py` (numpy pipe test), and a runbook covering deploy / key-unlock / verify and the Phase 2 NEST setup.

## Test plan (operator, after merge)

Requires the key passphrase and a backend rebuild, so it is done by an admin (see `deployment/compute_server/README.md`):
- [ ] Create the compute venv (`setup_compute_venv.sh`).
- [ ] Rebuild + restart backend with the prod override; `ssh-add` the key once.
- [ ] Submit `test_workflow.py` via the executor; confirm `COMPLETED`, exit 0, stdout retrieved.
- [ ] Phase 2: `WITH_NEST=1` venv + a NEST PointNeuron workflow returns artifacts.

## Notes
- No runtime behavior changes unless `backend=slurm` is used; default `WorkflowRun.backend` remains `jupyter`.
- Phase 2 (NEST) and the live rollout are deliberately follow-ups, gated on operator action.