### PR TITLE
Run workflows on the RIKEN compute cluster (Slurm) with result retrieval

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,7 @@ temp/
 
 # Sandbox nodes (local experimentation only)
 src/neuroworkflow/nodes/sandbox/
+
+# Remote (Slurm) execution runtime dirs: staged job inputs + fetched results
+gui/workflow_backend/django-project/run_staging/
+gui/workflow_backend/django-project/run_results/

--- a/gui/workflow_backend/django-project/app/workflow/execution/remote_slurm_executor.py
+++ b/gui/workflow_backend/django-project/app/workflow/execution/remote_slurm_executor.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import logging
 import os
 import re
+import shutil
 import subprocess
 import uuid
 from datetime import datetime, timezone
@@ -108,6 +109,8 @@ class RemoteSlurmExecutor(ExecutionBackend):
         self.python_module = os.getenv("SLURM_PYTHON_MODULE", "python/3.11.14")
         self.local_staging = Path(settings.BASE_DIR) / "run_staging"
         self.local_staging.mkdir(parents=True, exist_ok=True)
+        self.local_results = Path(settings.BASE_DIR) / "run_results"
+        self.local_results.mkdir(parents=True, exist_ok=True)
 
     # -- low-level helpers ---------------------------------------------------
 
@@ -117,8 +120,42 @@ class RemoteSlurmExecutor(ExecutionBackend):
     def _sync_to_remote(self, local: str, remote: str) -> None:
         _rsync(local, remote, self.host, self.user, self.key_path, to_remote=True)
 
+    def _sync_from_remote(self, remote: str, local: str) -> None:
+        _rsync(remote, local, self.host, self.user, self.key_path, to_remote=False)
+
     def _remote_run_dir(self, run_id: str) -> str:
         return f"{self.remote_dir}/{run_id}"
+
+    def _fetch_results(self, run_id: str, remote_run_dir: str) -> dict:
+        """Rsync the job's ``results/`` dir back to the app server and index it.
+
+        Returns an artifacts dict ``{"files": [{"path", "size"}, ...]}`` listing
+        every fetched file (recursively) relative to the local results dir.
+        Best-effort: returns ``{}`` if there are no results or the copy fails.
+        """
+        try:
+            self._ssh(f"test -d {remote_run_dir}/results")
+        except Exception:
+            return {}
+
+        local_dir = self.local_results / run_id
+        local_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            self._sync_from_remote(f"{remote_run_dir}/results/", str(local_dir) + "/")
+        except Exception as exc:
+            logger.warning("Failed to fetch results for run %s: %s", run_id, exc)
+            return {}
+
+        files = []
+        for f in sorted(local_dir.rglob("*")):
+            if f.is_file():
+                files.append(
+                    {
+                        "path": str(f.relative_to(local_dir)),
+                        "size": f.stat().st_size,
+                    }
+                )
+        return {"files": files}
 
     def _build_sbatch_extras(self, rr: dict) -> str:
         """Translate a resource_requests dict into #SBATCH directive lines.
@@ -197,6 +234,19 @@ class RemoteSlurmExecutor(ExecutionBackend):
             )
         )
 
+        # Stage the node implementation package alongside the workflow so the
+        # generated script (which does ``from nodes.<cat>.<Node> import ...``)
+        # can import it on the compute node. When ``python workflow.py`` runs in
+        # the run dir, sys.path[0] is that dir, so ``<run_dir>/nodes`` resolves.
+        nodes_src = Path(settings.MEDIA_ROOT)
+        if nodes_src.is_dir():
+            shutil.copytree(
+                nodes_src,
+                local_dir / "nodes",
+                ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
+                dirs_exist_ok=True,
+            )
+
         try:
             self._ssh(f"mkdir -p {remote_run_dir}")
             self._sync_to_remote(f"{local_dir}/", remote_run_dir + "/")
@@ -259,6 +309,15 @@ class RemoteSlurmExecutor(ExecutionBackend):
             except Exception:
                 pass
             result.finished_at = datetime.now(timezone.utc)
+
+        # On success, pull the result artifacts back to the app server. The
+        # DetailView only polls while the run is non-terminal, so this runs once
+        # (on the poll that first observes COMPLETED).
+        if result.status == ExecutionStatus.COMPLETED:
+            try:
+                result.artifacts = self._fetch_results(run_id, remote_run_dir)
+            except Exception as exc:
+                logger.warning("fetch_results failed for run %s: %s", run_id, exc)
 
         return result
 

--- a/gui/workflow_backend/django-project/app/workflow/urls.py
+++ b/gui/workflow_backend/django-project/app/workflow/urls.py
@@ -13,6 +13,7 @@ from .views import (
     WorkflowRunDetailView,
     WorkflowRunListView,
     WorkflowRunCancelView,
+    WorkflowRunArtifactView,
     WorkflowResultsView,
     WorkflowReportView,
     WorkflowCodeView,
@@ -118,6 +119,11 @@ urlpatterns = [
         WorkflowRunCancelView.as_view(),
         name="workflow-run-cancel"
     ),  # POST (cancel a run)
+    path(
+        "<uuid:workflow_id>/runs/<uuid:run_id>/artifacts/",
+        WorkflowRunArtifactView.as_view(),
+        name="workflow-run-artifact"
+    ),  # GET(?path=... download one fetched result file)
     # Results listing
     path(
         "<uuid:workflow_id>/results/",

--- a/gui/workflow_backend/django-project/app/workflow/views.py
+++ b/gui/workflow_backend/django-project/app/workflow/views.py
@@ -3,10 +3,17 @@ import asyncio
 import json
 import logging
 import os
+from pathlib import Path
 
+from django.conf import settings
 from django.db import transaction
 from django.db.models import Q
-from django.http import JsonResponse, StreamingHttpResponse
+from django.http import (
+    FileResponse,
+    Http404,
+    JsonResponse,
+    StreamingHttpResponse,
+)
 from django.shortcuts import get_object_or_404
 from django.utils.decorators import method_decorator
 from django.views.decorators.csrf import csrf_exempt
@@ -1303,6 +1310,8 @@ class WorkflowRunDetailView(APIView):
                     run.stderr = exec_result.stderr
                 if exec_result.error:
                     run.error_message = exec_result.error
+                if exec_result.artifacts:
+                    run.artifacts = exec_result.artifacts
                 if exec_result.started_at:
                     run.started_at = exec_result.started_at
                 if exec_result.finished_at:
@@ -1359,3 +1368,46 @@ class WorkflowRunCancelView(APIView):
             run.status = WorkflowRun.Status.CANCELLED
             run.save()
         return Response(WorkflowRunSerializer(run).data)
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class WorkflowRunArtifactView(APIView):
+    """Download a single result artifact fetched back from a remote run.
+
+    Files live under ``BASE_DIR/run_results/<run_id>/`` (populated by the
+    executor when a run completes). The relative file path is passed as the
+    ``path`` query parameter and is validated against directory traversal.
+    """
+
+    authentication_classes = [KeycloakAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, workflow_id, run_id):
+        get_accessible_project(request, workflow_id, write=False)
+        run = get_object_or_404(
+            WorkflowRun.objects.filter(
+                Q(user=request.user) | Q(workflow__owner=request.user)
+            ),
+            id=run_id,
+            workflow_id=workflow_id,
+        )
+
+        rel = request.query_params.get("path", "").strip()
+        if not rel:
+            return Response(
+                {"error": "Missing 'path' query parameter"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        base = (Path(settings.BASE_DIR) / "run_results" / str(run.id)).resolve()
+        target = (base / rel).resolve()
+        if base != target and base not in target.parents:
+            return Response(
+                {"error": "Invalid path"}, status=status.HTTP_400_BAD_REQUEST
+            )
+        if not target.is_file():
+            raise Http404("Artifact not found")
+
+        return FileResponse(
+            open(target, "rb"), as_attachment=True, filename=target.name
+        )

--- a/gui/workflow_frontend/src/api/workflowRunApi.ts
+++ b/gui/workflow_frontend/src/api/workflowRunApi.ts
@@ -135,6 +135,41 @@ export const listWorkflowRuns = async (
   return res.json();
 };
 
+export interface ArtifactFile {
+  path: string;
+  size: number;
+}
+
+/**
+ * Download a single result artifact fetched back from a remote run.
+ *
+ * Auth is Bearer-token based, so a plain link can't be used — we fetch the
+ * file with the auth headers, then trigger a browser download from the blob.
+ */
+export const downloadArtifact = async (
+  workflowId: string,
+  runId: string,
+  path: string
+): Promise<void> => {
+  const headers = await createAuthHeaders();
+  const res = await fetch(
+    `${API_PREFIX}/workflow/${workflowId}/runs/${runId}/artifacts/?path=${encodeURIComponent(
+      path
+    )}`,
+    { headers }
+  );
+  if (!res.ok) throw new Error(`Download failed: ${res.status}`);
+  const blob = await res.blob();
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = path.split("/").pop() || "artifact";
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+};
+
 export const cancelWorkflowRun = async (
   workflowId: string,
   runId: string

--- a/gui/workflow_frontend/src/views/home/WorkflowToolbar.tsx
+++ b/gui/workflow_frontend/src/views/home/WorkflowToolbar.tsx
@@ -23,6 +23,7 @@ interface WorkflowToolbarProps {
   handleOpenJupyter: () => void;
   handleGenerateCode: () => void;
   handleExportFlowJSON: () => void;
+  onRunOnCluster: () => void;
 }
 
 export const WorkflowToolbar: React.FC<WorkflowToolbarProps> = ({
@@ -36,6 +37,7 @@ export const WorkflowToolbar: React.FC<WorkflowToolbarProps> = ({
   handleOpenJupyter,
   handleGenerateCode,
   handleExportFlowJSON,
+  onRunOnCluster,
 }) => {
   // Subscribe only to the node count, not the full sharedNodes array, so the
   // toolbar does not re-render on every drag frame. Length changes only when
@@ -144,6 +146,24 @@ export const WorkflowToolbar: React.FC<WorkflowToolbarProps> = ({
               {!selectedProject ? "Select Project First" :
               nodesCount === 0 ? "Add Nodes to Generate" :
               "📝 Generate Code"}
+            </Button>
+
+            <Button
+              colorScheme="teal"
+              variant="solid"
+              size="sm"
+              onClick={onRunOnCluster}
+              isDisabled={!selectedProject || nodesCount === 0}
+              _hover={{ bg: "teal.600", transform: "translateY(-1px)" }}
+              _disabled={{
+                opacity: 0.4,
+                cursor: "not-allowed"
+              }}
+              transition="all 0.2s"
+            >
+              {!selectedProject ? "Select Project First" :
+              nodesCount === 0 ? "Add Nodes to Run" :
+              "☁️ Run on Compute Cluster"}
             </Button>
 
             <Button

--- a/gui/workflow_frontend/src/views/home/components/ClusterRunModal.tsx
+++ b/gui/workflow_frontend/src/views/home/components/ClusterRunModal.tsx
@@ -1,0 +1,150 @@
+import React, { useState } from "react";
+import {
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalHeader,
+  ModalCloseButton,
+  ModalBody,
+  ModalFooter,
+  Button,
+  FormControl,
+  FormLabel,
+  Select,
+  Input,
+  VStack,
+  HStack,
+  Text,
+} from "@chakra-ui/react";
+
+interface ClusterRunModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (resourceRequests: Record<string, unknown>) => void;
+  isSubmitting: boolean;
+}
+
+// Partition -> GPU model, per the RIKEN compute server (gcalc1: L40, gcalc2: H100).
+const GPU_PARTITIONS: Record<string, string> = {
+  gcalc1: "L40",
+  gcalc2: "H100",
+};
+
+const ClusterRunModal: React.FC<ClusterRunModalProps> = ({
+  isOpen,
+  onClose,
+  onSubmit,
+  isSubmitting,
+}) => {
+  const [partition, setPartition] = useState("ccalc");
+  const [walltime, setWalltime] = useState("00:30:00");
+  const [cpus, setCpus] = useState("2");
+  const [memGb, setMemGb] = useState("4");
+  const [gpus, setGpus] = useState("1");
+
+  const isGpu = partition in GPU_PARTITIONS;
+
+  const handleSubmit = () => {
+    const rr: Record<string, unknown> = { partition, time: walltime };
+    if (cpus.trim()) rr.cpus_per_task = Number(cpus);
+    if (memGb.trim()) rr.mem = `${Number(memGb)}G`;
+    if (isGpu && gpus.trim()) {
+      rr.gres = `gpu:${GPU_PARTITIONS[partition]}:${Number(gpus)}`;
+    }
+    onSubmit(rr);
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} isCentered>
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>Run on compute cluster</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <Text fontSize="sm" color="gray.600" mb={4}>
+            The workflow code is regenerated and submitted as a Slurm batch job
+            on the RIKEN compute server. Progress and results appear in the Runs
+            panel (bottom-right).
+          </Text>
+          <VStack spacing={4} align="stretch">
+            <FormControl>
+              <FormLabel fontSize="sm">Partition</FormLabel>
+              <Select
+                size="sm"
+                value={partition}
+                onChange={(e) => setPartition(e.target.value)}
+              >
+                <option value="ccalc">ccalc — CPU nodes</option>
+                <option value="gcalc1">gcalc1 — GPU (NVIDIA L40)</option>
+                <option value="gcalc2">gcalc2 — GPU (NVIDIA H100)</option>
+              </Select>
+            </FormControl>
+
+            <HStack spacing={3}>
+              <FormControl>
+                <FormLabel fontSize="sm">CPUs</FormLabel>
+                <Input
+                  size="sm"
+                  type="number"
+                  min={1}
+                  value={cpus}
+                  onChange={(e) => setCpus(e.target.value)}
+                />
+              </FormControl>
+              <FormControl>
+                <FormLabel fontSize="sm">Memory (GB)</FormLabel>
+                <Input
+                  size="sm"
+                  type="number"
+                  min={1}
+                  value={memGb}
+                  onChange={(e) => setMemGb(e.target.value)}
+                />
+              </FormControl>
+            </HStack>
+
+            <HStack spacing={3}>
+              <FormControl>
+                <FormLabel fontSize="sm">Wall time (HH:MM:SS)</FormLabel>
+                <Input
+                  size="sm"
+                  value={walltime}
+                  onChange={(e) => setWalltime(e.target.value)}
+                  placeholder="00:30:00"
+                />
+              </FormControl>
+              {isGpu && (
+                <FormControl>
+                  <FormLabel fontSize="sm">GPUs</FormLabel>
+                  <Input
+                    size="sm"
+                    type="number"
+                    min={1}
+                    value={gpus}
+                    onChange={(e) => setGpus(e.target.value)}
+                  />
+                </FormControl>
+              )}
+            </HStack>
+          </VStack>
+        </ModalBody>
+        <ModalFooter>
+          <Button variant="ghost" size="sm" mr={3} onClick={onClose}>
+            Cancel
+          </Button>
+          <Button
+            colorScheme="teal"
+            size="sm"
+            onClick={handleSubmit}
+            isLoading={isSubmitting}
+            loadingText="Submitting..."
+          >
+            Submit job
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default ClusterRunModal;

--- a/gui/workflow_frontend/src/views/home/components/runStatusPanel.tsx
+++ b/gui/workflow_frontend/src/views/home/components/runStatusPanel.tsx
@@ -12,12 +12,20 @@ import {
   IconButton,
   Tooltip,
 } from "@chakra-ui/react";
-import { FiChevronDown, FiChevronUp, FiXCircle, FiRefreshCw } from "react-icons/fi";
+import {
+  FiChevronDown,
+  FiChevronUp,
+  FiXCircle,
+  FiRefreshCw,
+  FiDownload,
+} from "react-icons/fi";
 import {
   WorkflowRunRecord,
+  ArtifactFile,
   getWorkflowRunStatus,
   cancelWorkflowRun,
   listWorkflowRuns,
+  downloadArtifact,
 } from "../../../api/workflowRunApi";
 
 interface RunStatusPanelProps {
@@ -98,6 +106,10 @@ const RunStatusPanel: React.FC<RunStatusPanelProps> = ({
       // ignore
     }
   };
+
+  const artifactFiles: ArtifactFile[] =
+    (selectedRun?.artifacts as { files?: ArtifactFile[] } | undefined)?.files ??
+    [];
 
   if (runs.length === 0 && !latestRunId) return null;
 
@@ -223,6 +235,52 @@ const RunStatusPanel: React.FC<RunStatusPanelProps> = ({
               <Text fontSize="xs" color="red.500" mt={1}>
                 {selectedRun.error_message}
               </Text>
+            )}
+            {artifactFiles.length > 0 && (
+              <Box mt={2}>
+                <Text fontSize="xs" fontWeight="bold" mb={1}>
+                  Results ({artifactFiles.length})
+                </Text>
+                <VStack
+                  align="stretch"
+                  spacing={0}
+                  maxH="160px"
+                  overflowY="auto"
+                  border="1px solid"
+                  borderColor={borderColor}
+                  borderRadius="sm"
+                >
+                  {artifactFiles.map((f) => (
+                    <HStack
+                      key={f.path}
+                      justify="space-between"
+                      px={2}
+                      py={1}
+                      _hover={{ bg: useColorModeValue("gray.50", "gray.700") }}
+                    >
+                      <Text
+                        fontSize="xs"
+                        fontFamily="mono"
+                        isTruncated
+                        title={f.path}
+                      >
+                        {f.path}
+                      </Text>
+                      <Tooltip label={`Download (${f.size} bytes)`}>
+                        <IconButton
+                          aria-label={`Download ${f.path}`}
+                          icon={<FiDownload />}
+                          size="xs"
+                          variant="ghost"
+                          onClick={() =>
+                            downloadArtifact(workflowId, selectedRun.id, f.path)
+                          }
+                        />
+                      </Tooltip>
+                    </HStack>
+                  ))}
+                </VStack>
+              </Box>
             )}
             {!TERMINAL_STATUSES.has(selectedRun.status) && (
               <Button

--- a/gui/workflow_frontend/src/views/home/homeView.tsx
+++ b/gui/workflow_frontend/src/views/home/homeView.tsx
@@ -46,6 +46,8 @@ import { useKeyboardShortcuts } from '../../hooks/useKeyboardShortcuts';
 import NodeDetailsContent from './components/nodeDetailModal';
 import { DeleteConfirmDialog } from './components/deleteConfirmDialog';
 import RunStatusPanel from './components/runStatusPanel';
+import ClusterRunModal from './components/ClusterRunModal';
+import { submitWorkflowRun } from '../../api/workflowRunApi';
 import { useTabContext } from '../../components/tabs/TabManager';
 import { useFlowStore, PROJECT_ID_KEY } from '../../stores/flowStore';
 import { convertToStrIncFloat } from '../../utils/typeConversion';
@@ -62,6 +64,9 @@ const HomeView = () => {
   const [selectedProject, setSelectedProject] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState<boolean>(false);
   const [isGeneratingCode, setIsGeneratingCode] = useState<boolean>(false);
+  const [latestRunId, setLatestRunId] = useState<string | undefined>(undefined);
+  const [isClusterModalOpen, setIsClusterModalOpen] = useState<boolean>(false);
+  const [isSubmittingCluster, setIsSubmittingCluster] = useState<boolean>(false);
 
   // Autosave related status
   const [isConnected, setIsConnected] = useState<boolean>(true);
@@ -940,7 +945,7 @@ const HomeView = () => {
         duration: 2000,
         isClosable: true,
       });
-      return;
+      return false;
     }
 
     if (!reactFlowInstance.current) {
@@ -951,7 +956,7 @@ const HomeView = () => {
         duration: 2000,
         isClosable: true,
       });
-      return;
+      return false;
     }
 
     const currentSharedNodes = useFlowStore.getState().sharedNodes;
@@ -963,7 +968,7 @@ const HomeView = () => {
         duration: 3000,
         isClosable: true,
       });
-      return;
+      return false;
     }
 
     // CRITICAL: Save all nodes to database before generating code
@@ -1003,7 +1008,7 @@ const HomeView = () => {
         duration: 5000,
         isClosable: true,
       });
-      return;
+      return false;
     }
 
     // Wait a bit for all saves to complete
@@ -1064,6 +1069,7 @@ const HomeView = () => {
         isClosable: true,
       });
 
+      return true;
     } catch (error) {
       // Close loading toast (on error)
       toast.close(loadingToast);
@@ -1076,10 +1082,53 @@ const HomeView = () => {
         duration: 5000,
         isClosable: true,
       });
+      return false;
     } finally {
       setIsGeneratingCode(false);
     }
   }, [selectedProject, reactFlowInstance, createNodeAPI, updateNodeAPI, toast]);
+
+  // Regenerate code and submit the workflow as a Slurm batch job on the
+  // RIKEN compute cluster. Progress is surfaced by the RunStatusPanel.
+  const handleRunOnClusterSubmit = useCallback(
+    async (resourceRequests: Record<string, unknown>) => {
+      if (!selectedProject) return;
+      setIsSubmittingCluster(true);
+      try {
+        const generated = await handleGenerateCode();
+        if (!generated) {
+          return;
+        }
+        // Give the backend a moment to flush the generated script to disk.
+        await new Promise((resolve) => setTimeout(resolve, 400));
+        const run = await submitWorkflowRun(
+          selectedProject,
+          "slurm",
+          resourceRequests
+        );
+        setLatestRunId(run.id);
+        setIsClusterModalOpen(false);
+        toast({
+          title: "Job submitted to compute cluster",
+          description: `Run ${run.id.slice(0, 8)} (${run.status}). Track progress in the Runs panel.`,
+          status: "success",
+          duration: 5000,
+          isClosable: true,
+        });
+      } catch (error) {
+        toast({
+          title: "Cluster submission failed",
+          description: error instanceof Error ? error.message : "Unknown error",
+          status: "error",
+          duration: 6000,
+          isClosable: true,
+        });
+      } finally {
+        setIsSubmittingCluster(false);
+      }
+    },
+    [selectedProject, handleGenerateCode, toast]
+  );
 
   // Clean up
   useEffect(() => {
@@ -1238,6 +1287,7 @@ const HomeView = () => {
           handleOpenJupyter={handleOpenJupyter}
           handleGenerateCode={handleGenerateCode}
           handleExportFlowJSON={handleExportFlowJSON}
+          onRunOnCluster={() => setIsClusterModalOpen(true)}
         />
           
         {/* ReactFlow: Needs to be wrapped in ReactFlowProvider */}
@@ -1278,8 +1328,16 @@ const HomeView = () => {
         
         {/* Async run status panel */}
         {selectedProject && (
-          <RunStatusPanel workflowId={selectedProject} />
+          <RunStatusPanel workflowId={selectedProject} latestRunId={latestRunId} />
         )}
+
+        {/* Run-on-compute-cluster (Slurm) resource dialog */}
+        <ClusterRunModal
+          isOpen={isClusterModalOpen}
+          onClose={() => setIsClusterModalOpen(false)}
+          onSubmit={handleRunOnClusterSubmit}
+          isSubmitting={isSubmittingCluster}
+        />
 
         {/* Node menu */}
         {nodeMenuPosition && (


### PR DESCRIPTION
## Summary

Wires the existing remote **Slurm** execution backend into the app end-to-end so users can run a workflow on the RIKEN compute server and download their results — building on the plumbing merged in #70.

- **Run on Compute Cluster** action in the Flow Designer toolbar opens a small resource dialog (partition `ccalc`/`gcalc1`/`gcalc2`, CPUs, memory, wall-time, GPUs). It regenerates the workflow code, submits via `POST /runs/submit/` with `backend=slurm`, and shows live progress in the existing **Runs** panel. The Jupyter play button is unchanged.
- **`nodes/` staging**: app-generated scripts do `from nodes.<cat>.<Node> import ...`; the executor now stages the `nodes/` package into each run dir so those imports resolve on the compute node.
- **Result retrieval**: on `COMPLETED`, the executor rsyncs the job's `results/` dir back to the app server and indexes every file into `WorkflowRun.artifacts`.
- **Download endpoint**: `GET /workflow/{id}/runs/{run_id}/artifacts/?path=...` streams a single file as an attachment (owner/submitter only, directory-traversal guarded). The Runs panel lists results with token-authenticated per-file download buttons.
- Ignores the `run_staging/` and `run_results/` runtime dirs.

## Changes
- `execution/remote_slurm_executor.py` — stage `nodes/`; fetch + index results on completion.
- `views.py` / `urls.py` — persist `artifacts`; add `WorkflowRunArtifactView`.
- Frontend — `ClusterRunModal.tsx`, `WorkflowToolbar.tsx`, `homeView.tsx`, `runStatusPanel.tsx`, `workflowRunApi.ts`.

## Testing (verified against the live compute server)
- Submitted a real app workflow ("Balanced E-I Network", BMTK PointNet) via the actual `WorkflowRunSubmitView`/`WorkflowRunDetailView` (forced-auth): `running` → `completed`.
- Job ran NEST 3.10 on `ccalc` and produced full **SONATA** output; **25 artifacts** were fetched back and persisted (`network/*.h5`, `*_types.csv`, `output/spikes.h5`, `v_report.h5`, raster/trace PNGs, config, components).
- Resource dialog maps correctly to `#SBATCH` directives, incl. GPU `--gres=gpu:L40:1`.
- Download of `output/spikes.h5` → HTTP 200 attachment with correct byte count; `../../../etc/passwd` → HTTP 400.
- Frontend builds clean (tsc + Vite).

## Test plan for reviewers
- [ ] Log in, open a project with nodes, click **Run on Compute Cluster**, submit.
- [ ] Watch the Runs panel go pending → running → completed.
- [ ] Confirm the Results list appears and files download.

## Notes
- Admin op unchanged: after a backend container restart, unlock the SSH key once (`ssh-add` into the container's agent) so the executor can reach the compute server.
- Result fetch runs synchronously on the completing status poll (fine for the current MB-scale outputs).