### PR TITLE
Cluster runs: co-locate per project + prefill resources from context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,6 @@ temp/
 # Sandbox nodes (local experimentation only)
 src/neuroworkflow/nodes/sandbox/
 
-# Remote (Slurm) execution runtime dirs: staged job inputs + fetched results
-gui/workflow_backend/django-project/run_staging/
-gui/workflow_backend/django-project/run_results/
+# Remote (Slurm) execution runtime dirs: per-run staged inputs + fetched
+# results, co-located under each project (codes/projects/<id>/batch/<run_id>/)
+gui/workflow_backend/django-project/codes/projects/*/batch/

--- a/gui/workflow_backend/django-project/app/workflow/execution/base.py
+++ b/gui/workflow_backend/django-project/app/workflow/execution/base.py
@@ -62,11 +62,14 @@ class ExecutionBackend(ABC):
         *,
         job_id: Optional[str] = None,
         remote_dir: Optional[str] = None,
+        project_id: Optional[str] = None,
     ) -> ExecutionResult:
         """Poll the status of a previously submitted run.
 
         ``job_id`` and ``remote_dir`` are supplied by the caller from persisted
         state so the backend does not depend on process-local memory.
+        ``project_id`` lets the backend locate the per-project working dir when
+        fetching results.
         """
         ...
 

--- a/gui/workflow_backend/django-project/app/workflow/execution/local_executor.py
+++ b/gui/workflow_backend/django-project/app/workflow/execution/local_executor.py
@@ -99,6 +99,7 @@ class LocalExecutor(ExecutionBackend):
         *,
         job_id: Optional[str] = None,
         remote_dir: Optional[str] = None,
+        project_id: Optional[str] = None,
     ) -> ExecutionResult:
         entry = _runs.get(run_id)
         if not entry:

--- a/gui/workflow_backend/django-project/app/workflow/execution/remote_slurm_executor.py
+++ b/gui/workflow_backend/django-project/app/workflow/execution/remote_slurm_executor.py
@@ -21,6 +21,8 @@ from typing import Optional
 
 from django.conf import settings
 
+from app.workflow.path_utils import batch_run_dir
+
 from .base import ExecutionBackend, ExecutionResult, ExecutionStatus
 
 logger = logging.getLogger(__name__)
@@ -107,10 +109,6 @@ class RemoteSlurmExecutor(ExecutionBackend):
             "SLURM_REMOTE_VENV", "/data/neuro-workflow/local/venv"
         )
         self.python_module = os.getenv("SLURM_PYTHON_MODULE", "python/3.11.14")
-        self.local_staging = Path(settings.BASE_DIR) / "run_staging"
-        self.local_staging.mkdir(parents=True, exist_ok=True)
-        self.local_results = Path(settings.BASE_DIR) / "run_results"
-        self.local_results.mkdir(parents=True, exist_ok=True)
 
     # -- low-level helpers ---------------------------------------------------
 
@@ -126,19 +124,23 @@ class RemoteSlurmExecutor(ExecutionBackend):
     def _remote_run_dir(self, run_id: str) -> str:
         return f"{self.remote_dir}/{run_id}"
 
-    def _fetch_results(self, run_id: str, remote_run_dir: str) -> dict:
+    def _fetch_results(
+        self, run_id: str, remote_run_dir: str, project_id: str
+    ) -> dict:
         """Rsync the job's ``results/`` dir back to the app server and index it.
 
-        Returns an artifacts dict ``{"files": [{"path", "size"}, ...]}`` listing
-        every fetched file (recursively) relative to the local results dir.
-        Best-effort: returns ``{}`` if there are no results or the copy fails.
+        Results land in ``codes/projects/<project_id>/batch/<run_id>/results/``
+        (co-located with the project). Returns an artifacts dict
+        ``{"files": [{"path", "size"}, ...]}`` listing every fetched file
+        (recursively) relative to that results dir. Best-effort: returns ``{}``
+        if there are no results or the copy fails.
         """
         try:
             self._ssh(f"test -d {remote_run_dir}/results")
         except Exception:
             return {}
 
-        local_dir = self.local_results / run_id
+        local_dir = batch_run_dir(project_id, run_id) / "results"
         local_dir.mkdir(parents=True, exist_ok=True)
         try:
             self._sync_from_remote(f"{remote_run_dir}/results/", str(local_dir) + "/")
@@ -225,8 +227,7 @@ class RemoteSlurmExecutor(ExecutionBackend):
         remote_run_dir = self._remote_run_dir(run_id)
         result.remote_run_dir = remote_run_dir
 
-        local_dir = self.local_staging / run_id
-        local_dir.mkdir(parents=True, exist_ok=True)
+        local_dir = batch_run_dir(workflow_id, run_id, create=True)
         (local_dir / "workflow.py").write_text(code)
         (local_dir / "run.sbatch").write_text(
             self._render_sbatch(
@@ -271,6 +272,7 @@ class RemoteSlurmExecutor(ExecutionBackend):
         *,
         job_id: Optional[str] = None,
         remote_dir: Optional[str] = None,
+        project_id: Optional[str] = None,
     ) -> ExecutionResult:
         result = ExecutionResult(run_id=run_id)
         result.remote_job_id = job_id
@@ -313,9 +315,11 @@ class RemoteSlurmExecutor(ExecutionBackend):
         # On success, pull the result artifacts back to the app server. The
         # DetailView only polls while the run is non-terminal, so this runs once
         # (on the poll that first observes COMPLETED).
-        if result.status == ExecutionStatus.COMPLETED:
+        if result.status == ExecutionStatus.COMPLETED and project_id:
             try:
-                result.artifacts = self._fetch_results(run_id, remote_run_dir)
+                result.artifacts = self._fetch_results(
+                    run_id, remote_run_dir, project_id
+                )
             except Exception as exc:
                 logger.warning("fetch_results failed for run %s: %s", run_id, exc)
 

--- a/gui/workflow_backend/django-project/app/workflow/path_utils.py
+++ b/gui/workflow_backend/django-project/app/workflow/path_utils.py
@@ -30,6 +30,22 @@ def stable_project_dir(project, *, create: bool = False) -> Path:
     return path
 
 
+def batch_run_dir(project_id, run_id, *, create: bool = False) -> Path:
+    """Per-run working dir for cluster (batch) executions, co-located with the
+    project so Jupyter and cluster runs share ``codes/projects/<project_id>/``.
+
+    Layout: ``codes/projects/<project_id>/batch/<run_id>/`` holding the staged
+    inputs (workflow.py, run.sbatch, nodes/) and a ``results/`` subdir for the
+    artifacts fetched back from the compute server.
+    """
+    path = _ensure_under_root(
+        projects_root() / str(project_id) / "batch" / str(run_id)
+    )
+    if create:
+        path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
 def legacy_project_dir(project) -> Path:
     legacy_name = (project.name or str(project.id)).replace(" ", "").capitalize()
     legacy_name = re.sub(r"[^A-Za-z0-9_.-]", "_", legacy_name) or str(project.id)

--- a/gui/workflow_backend/django-project/app/workflow/views.py
+++ b/gui/workflow_backend/django-project/app/workflow/views.py
@@ -3,9 +3,7 @@ import asyncio
 import json
 import logging
 import os
-from pathlib import Path
 
-from django.conf import settings
 from django.db import transaction
 from django.db.models import Q
 from django.http import (
@@ -30,6 +28,7 @@ from .code_generation_service import CodeGenerationService
 from .jupyter_execution_service import JupyterExecutionService
 from .models import FlowEdge, FlowNode, FlowProject, WorkflowRun
 from .path_utils import (
+    batch_run_dir,
     code_file_path,
     existing_project_dir,
     notebook_file_path,
@@ -1300,6 +1299,7 @@ class WorkflowRunDetailView(APIView):
                     str(run.id),
                     job_id=run.slurm_job_id or None,
                     remote_dir=run.remote_run_dir or None,
+                    project_id=str(run.workflow_id),
                 )
                 run.status = exec_result.status.value
                 if exec_result.exit_code is not None:
@@ -1374,9 +1374,10 @@ class WorkflowRunCancelView(APIView):
 class WorkflowRunArtifactView(APIView):
     """Download a single result artifact fetched back from a remote run.
 
-    Files live under ``BASE_DIR/run_results/<run_id>/`` (populated by the
-    executor when a run completes). The relative file path is passed as the
-    ``path`` query parameter and is validated against directory traversal.
+    Files live under ``codes/projects/<project_id>/batch/<run_id>/results/``
+    (populated by the executor when a run completes). The relative file path is
+    passed as the ``path`` query parameter and is validated against directory
+    traversal.
     """
 
     authentication_classes = [KeycloakAuthentication]
@@ -1399,7 +1400,7 @@ class WorkflowRunArtifactView(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
-        base = (Path(settings.BASE_DIR) / "run_results" / str(run.id)).resolve()
+        base = (batch_run_dir(str(workflow_id), str(run.id)) / "results").resolve()
         target = (base / rel).resolve()
         if base != target and base not in target.parents:
             return Response(

--- a/gui/workflow_frontend/src/views/home/components/ClusterRunModal.tsx
+++ b/gui/workflow_frontend/src/views/home/components/ClusterRunModal.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   Modal,
   ModalOverlay,
@@ -22,6 +22,10 @@ interface ClusterRunModalProps {
   onClose: () => void;
   onSubmit: (resourceRequests: Record<string, unknown>) => void;
   isSubmitting: boolean;
+  // Project-level defaults from FlowProject.workflow_context.resource_requirements
+  // (cpus / memory_gb / gpus / walltime_hours / queue). Used to prefill the
+  // form; the user can still override for this particular run.
+  contextResources?: Record<string, unknown>;
 }
 
 // Partition -> GPU model, per the RIKEN compute server (gcalc1: L40, gcalc2: H100).
@@ -30,17 +34,44 @@ const GPU_PARTITIONS: Record<string, string> = {
   gcalc2: "H100",
 };
 
+const KNOWN_PARTITIONS = new Set(["ccalc", "gcalc1", "gcalc2"]);
+
+// WorkflowContextEditor stores wall time as a number of hours; the sbatch
+// --time directive wants HH:MM:SS.
+const hoursToHHMMSS = (h: unknown): string | undefined => {
+  const n = typeof h === "number" ? h : Number(h);
+  if (!n || n <= 0 || Number.isNaN(n)) return undefined;
+  const total = Math.round(n * 3600);
+  const hh = Math.floor(total / 3600);
+  const mm = Math.floor((total % 3600) / 60);
+  const ss = total % 60;
+  return [hh, mm, ss].map((x) => String(x).padStart(2, "0")).join(":");
+};
+
 const ClusterRunModal: React.FC<ClusterRunModalProps> = ({
   isOpen,
   onClose,
   onSubmit,
   isSubmitting,
+  contextResources,
 }) => {
   const [partition, setPartition] = useState("ccalc");
   const [walltime, setWalltime] = useState("00:30:00");
   const [cpus, setCpus] = useState("2");
   const [memGb, setMemGb] = useState("4");
   const [gpus, setGpus] = useState("1");
+
+  // Prefill from the project's resource defaults each time the dialog opens.
+  useEffect(() => {
+    if (!isOpen) return;
+    const r = (contextResources || {}) as Record<string, any>;
+    const q = typeof r.queue === "string" ? r.queue : "";
+    setPartition(KNOWN_PARTITIONS.has(q) ? q : "ccalc");
+    setCpus(r.cpus != null ? String(r.cpus) : "2");
+    setMemGb(r.memory_gb != null ? String(r.memory_gb) : "4");
+    setWalltime(hoursToHHMMSS(r.walltime_hours) ?? "00:30:00");
+    setGpus(r.gpus != null ? String(r.gpus) : "1");
+  }, [isOpen, contextResources]);
 
   const isGpu = partition in GPU_PARTITIONS;
 
@@ -64,7 +95,8 @@ const ClusterRunModal: React.FC<ClusterRunModalProps> = ({
           <Text fontSize="sm" color="gray.600" mb={4}>
             The workflow code is regenerated and submitted as a Slurm batch job
             on the RIKEN compute server. Progress and results appear in the Runs
-            panel (bottom-right).
+            panel (bottom-right). Values are prefilled from the project's
+            resource settings — adjust to override for this run.
           </Text>
           <VStack spacing={4} align="stretch">
             <FormControl>

--- a/gui/workflow_frontend/src/views/home/homeView.tsx
+++ b/gui/workflow_frontend/src/views/home/homeView.tsx
@@ -1337,6 +1337,10 @@ const HomeView = () => {
           onClose={() => setIsClusterModalOpen(false)}
           onSubmit={handleRunOnClusterSubmit}
           isSubmitting={isSubmittingCluster}
+          contextResources={
+            projects.find((p) => p.id === selectedProject)?.workflow_context
+              ?.resource_requirements as Record<string, unknown> | undefined
+          }
         />
 
         {/* Node menu */}


### PR DESCRIPTION
Follow-ups to #71 (which was already merged), addressing Carlos's review notes.

## Summary
- **Folder unification.** Cluster runs no longer key purely by `run_id` under top-level `run_staging/`/`run_results/`. Inputs are staged and results fetched under `codes/projects/<project_id>/batch/<run_id>/`, co-located with the project (where Jupyter results also live). New `path_utils.batch_run_dir()`; `get_status()` now receives `project_id` (threaded from `WorkflowRunDetailView`); the artifact download view resolves under the project's batch results dir. `.gitignore` updated to `codes/projects/*/batch/`.
- **Resource de-duplication.** `ClusterRunModal` is prefilled from the project's `workflow_context.resource_requirements` (`cpus` / `memory_gb` / `gpus` / `walltime_hours` / `queue`), mapping to the executor's SBATCH keys, while remaining an optional per-run override (the "context = defaults, modal = override" option).

## Changes
- `path_utils.py` — `batch_run_dir()`.
- `execution/base.py`, `execution/local_executor.py`, `execution/remote_slurm_executor.py` — `project_id` in `get_status`; stage/fetch under the per-project batch dir.
- `views.py` — pass `project_id`; download view resolves under batch results dir.
- `ClusterRunModal.tsx`, `homeView.tsx` — prefill from project context.
- `.gitignore`.

## Testing (against the live compute server)
- Submitted the "Balanced E-I Network" (BMTK PointNet) workflow through the real submit/detail views: `running` -> `completed`.
- Inputs staged and **25 SONATA artifacts** fetched under `codes/projects/<id>/batch/<run_id>/results/`.
- Download of `output/spikes.h5` -> HTTP 200; `../../../../../etc/passwd` -> HTTP 400.
- Frontend builds clean (tsc + Vite); backend reloaded and deployed.

## Test plan for reviewers
- [ ] Set project resource defaults (Edit project -> resources); open Run on Compute Cluster and confirm the dialog is prefilled.
- [ ] Submit, watch the Runs panel to completion, download a result file.