### PR TITLE
Fix: create NEST data_path before kernel init so BG spikes are recorded

### DIFF
--- a/gui/workflow_backend/django-project/codes/neuroworkflow/utils/BG/BG_helpers.py
+++ b/gui/workflow_backend/django-project/codes/neuroworkflow/utils/BG/BG_helpers.py
@@ -26,6 +26,9 @@ def initialize_nest(sim_params):
     nest.set_verbosity("M_WARNING")
     nest.SetKernelStatus({"overwrite_files": True})
     nest.SetKernelStatus({"local_num_threads": int(sim_params["nbcpu"])})
+    # NEST does not create data_path itself; it must exist before the kernel is
+    # told to write spikes there, or recording silently falls back to the CWD.
+    os.makedirs(sim_params["data_path"], exist_ok=True)
     nest.SetKernelStatus({"data_path": sim_params["data_path"]})
     if str(sim_params["dt"]) != "0.1":
         nest.SetKernelStatus({"resolution": float(sim_params["dt"])})

--- a/gui/workflow_backend/django-project/codes/neuroworkflow/utils/BG/BG_helpers.py
+++ b/gui/workflow_backend/django-project/codes/neuroworkflow/utils/BG/BG_helpers.py
@@ -23,7 +23,11 @@ import numpy as np
 
 def initialize_nest(sim_params):
     nest.ResetKernel()
-    nest.set_verbosity("M_WARNING")
+    try:
+        # NEST 3.8+ API; the old set_verbosity() string form is deprecated.
+        nest.verbosity = nest.VerbosityLevel.WARNING
+    except (AttributeError, TypeError):
+        nest.set_verbosity("M_WARNING")
     nest.SetKernelStatus({"overwrite_files": True})
     nest.SetKernelStatus({"local_num_threads": int(sim_params["nbcpu"])})
     # NEST does not create data_path itself; it must exist before the kernel is

--- a/src/neuroworkflow/utils/BG/BG_helpers.py
+++ b/src/neuroworkflow/utils/BG/BG_helpers.py
@@ -26,6 +26,9 @@ def initialize_nest(sim_params):
     nest.set_verbosity("M_WARNING")
     nest.SetKernelStatus({"overwrite_files": True})
     nest.SetKernelStatus({"local_num_threads": int(sim_params["nbcpu"])})
+    # NEST does not create data_path itself; it must exist before the kernel is
+    # told to write spikes there, or recording silently falls back to the CWD.
+    os.makedirs(sim_params["data_path"], exist_ok=True)
     nest.SetKernelStatus({"data_path": sim_params["data_path"]})
     if str(sim_params["dt"]) != "0.1":
         nest.SetKernelStatus({"resolution": float(sim_params["dt"])})

--- a/src/neuroworkflow/utils/BG/BG_helpers.py
+++ b/src/neuroworkflow/utils/BG/BG_helpers.py
@@ -23,7 +23,11 @@ import numpy as np
 
 def initialize_nest(sim_params):
     nest.ResetKernel()
-    nest.set_verbosity("M_WARNING")
+    try:
+        # NEST 3.8+ API; the old set_verbosity() string form is deprecated.
+        nest.verbosity = nest.VerbosityLevel.WARNING
+    except (AttributeError, TypeError):
+        nest.set_verbosity("M_WARNING")
     nest.SetKernelStatus({"overwrite_files": True})
     nest.SetKernelStatus({"local_num_threads": int(sim_params["nbcpu"])})
     # NEST does not create data_path itself; it must exist before the kernel is


### PR DESCRIPTION
## Summary
Follow-up to the Slurm compute-cluster work. Two NEST fixes in `initialize_nest()`:

1. **Empty spike rasters (main fix).** `data_path` was set on the NEST kernel *before* the directory existed, so NEST dropped the setting and wrote spike `.dat` files to the CWD; `NESTBGWriterNode` then found no spikes in `data_path` and produced empty rasters (mean rates were fine, counted in memory). Now the directory is created with `os.makedirs(..., exist_ok=True)` before it is set on the kernel.
2. **Deprecation warning.** `nest.set_verbosity("M_WARNING")` is deprecated in NEST 3.8+ and printed a `UserWarning` on every run. Switched to `nest.verbosity = nest.VerbosityLevel.WARNING` with a fallback to the old call for older builds.

Applied to both `src/neuroworkflow/utils/BG/BG_helpers.py` (source package — what pip installs / runs on the compute node) and the synced `gui/.../codes/neuroworkflow/utils/BG/BG_helpers.py` (local Jupyter execution).

## Test plan
- [x] Reproduced on the cluster: `BG macaque` completes but rasters are empty and `.dat` files land in the run-dir root.
- [x] With the fix installed in the compute venv, re-ran `BG macaque`: 110 spike `.dat` files now land in `results/`, writer reports non-zero counts (GPe 16457, GPi 11275, …), `spike_rasters.png` is populated, and the `data_path`/verbosity warnings are gone.

## Notes
- Pre-existing, unrelated: `src/.../NESTBGNetworkNode.py` imports `neuroworkflow.utils.BG_helpers` (should be `...utils.BG.BG_helpers`). The `codes/` copy is correct and is the one used at runtime, so this is latent; not touched here.