### PR TITLE
Stage project-local source for remote Slurm runs

### DIFF
--- a/gui/workflow_backend/django-project/app/workflow/execution/remote_slurm_executor.py
+++ b/gui/workflow_backend/django-project/app/workflow/execution/remote_slurm_executor.py
@@ -21,7 +21,7 @@ from typing import Optional
 
 from django.conf import settings
 
-from app.workflow.path_utils import batch_run_dir
+from app.workflow.path_utils import batch_run_dir, projects_root
 
 from .base import ExecutionBackend, ExecutionResult, ExecutionStatus
 
@@ -228,17 +228,28 @@ class RemoteSlurmExecutor(ExecutionBackend):
         result.remote_run_dir = remote_run_dir
 
         local_dir = batch_run_dir(workflow_id, run_id, create=True)
-        (local_dir / "workflow.py").write_text(code)
-        (local_dir / "run.sbatch").write_text(
-            self._render_sbatch(
-                run_id, project_name, remote_run_dir, resource_requests or {}
-            )
-        )
 
-        # Stage the node implementation package alongside the workflow so the
-        # generated script (which does ``from nodes.<cat>.<Node> import ...``)
-        # can import it on the compute node. When ``python workflow.py`` runs in
-        # the run dir, sys.path[0] is that dir, so ``<run_dir>/nodes`` resolves.
+        # Stage the project's own local files first (e.g. a project-local
+        # ``microcircuit/`` package or data files) so imports and relative
+        # paths that work in Jupyter -- where the project dir is the CWD --
+        # also resolve on the compute node. Exclude ``batch/`` (this staging
+        # tree itself) and ``results/`` (stale local outputs); the generated
+        # workflow.py/run.sbatch are written afterwards so they always win.
+        project_dir = projects_root() / str(workflow_id)
+        if project_dir.is_dir():
+            shutil.copytree(
+                project_dir,
+                local_dir,
+                ignore=shutil.ignore_patterns(
+                    "batch", "results", "__pycache__", "*.pyc", ".ipynb_checkpoints"
+                ),
+                dirs_exist_ok=True,
+            )
+
+        # Stage the shared node implementation package so the generated script
+        # (which does ``from nodes.<cat>.<Node> import ...``) can import it on
+        # the compute node. When ``python workflow.py`` runs in the run dir,
+        # sys.path[0] is that dir, so ``<run_dir>/nodes`` resolves.
         nodes_src = Path(settings.MEDIA_ROOT)
         if nodes_src.is_dir():
             shutil.copytree(
@@ -247,6 +258,15 @@ class RemoteSlurmExecutor(ExecutionBackend):
                 ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
                 dirs_exist_ok=True,
             )
+
+        # Written last so the freshly generated code and sbatch are authoritative
+        # (they override any stale copies picked up from the project dir).
+        (local_dir / "workflow.py").write_text(code)
+        (local_dir / "run.sbatch").write_text(
+            self._render_sbatch(
+                run_id, project_name, remote_run_dir, resource_requests or {}
+            )
+        )
 
         try:
             self._ssh(f"mkdir -p {remote_run_dir}")


### PR DESCRIPTION
## Summary
- `RemoteSlurmExecutor.submit()` now copies the project's own directory (`codes/projects/<id>/`) into each cluster run's staging dir before rsync, so **project-local packages and data are available on the compute node** — matching Jupyter execution where the project dir is the CWD.
- Excludes `batch/` (the staging tree itself), `results/` (stale local outputs), and caches (`__pycache__`, `*.pyc`, `.ipynb_checkpoints`).
- Reorders staging so the generated `workflow.py` and `run.sbatch` are written **last** and stay authoritative (never clobbered by a stale copy from the project dir).

## Why
The Microcircuit (Potjans & Diesmann) project imports a project-local `microcircuit/` package that lives in `codes/projects/<id>/microcircuit/`. It was never staged to the compute node, so cluster runs failed immediately with `ModuleNotFoundError: No module named 'microcircuit'`. Locally (Jupyter) it works only because the project dir is the CWD.

This staging happens on the app server *before* job submission (rsync of inputs), consistent with the RIKEN-approved job-management flow; no data is fetched/pushed during job execution.

## Test plan
- [x] Pre-flighted the Microcircuit project end-to-end through the Slurm pipeline (partition `ccalc`, 4 CPUs, 8 GB, 20 min walltime): job completed, 48 artifacts synced back including a fully populated `raster_plot.png` (L2/3–L6 E/I spiking), `box_plot.png`, and per-population `rate*.dat`.
- [x] Confirmed the generated `workflow.py`/`run.sbatch` are not overwritten by the project dir copy.
- [x] Remote + local + DB records cleaned up after the pre-flight.
- [x] Re-ran Microcircuit from the UI on the live server (deployed alongside PR #74): completed successfully.