### PR TITLE
Fix interactive workflow execution and display matplotlib figures inline

### DIFF
--- a/gui/workflow_backend/django-project/app/workflow/jupyter_execution_service.py
+++ b/gui/workflow_backend/django-project/app/workflow/jupyter_execution_service.py
@@ -33,6 +33,21 @@ KERNEL_START_TIMEOUT = 30
 EXECUTE_IDLE_TIMEOUT = 600  # max seconds to wait for execution to finish
 
 
+def _image_event(mime_bundle: dict) -> dict:
+    """Build an image event from a Jupyter display mime bundle.
+
+    Whitespace is stripped from the base64 payload so the frontend can
+    embed it directly in a ``data:`` URI.
+    """
+    return {
+        "type": "image",
+        "data": {
+            "content": "".join(mime_bundle["image/png"].split()),
+            "mime": "image/png",
+        },
+    }
+
+
 class JupyterExecutionService:
     """Execute code on a Jupyter kernel running inside the JupyterLab container.
 
@@ -208,14 +223,20 @@ class JupyterExecutionService:
         async with connect(
             ws_url,
             additional_headers=self._headers,
-            max_size=2**23,  # 8 MB
+            max_size=2**27,  # 128 MB; inline figures arrive as one base64 frame
             open_timeout=30,
         ) as ws:
             await ws.send(json.dumps(execute_request))
             logger.info("Sent execute_request (msg_id=%s)", msg_id)
 
-            execution_done = False
-            while not execution_done:
+            # Execution is complete only when both the shell reply and the
+            # iopub "idle" status have arrived. The channels are independent:
+            # execute_reply can beat large iopub messages (e.g. inline
+            # figures) still in flight, so stopping on the reply alone would
+            # drop them.
+            reply_status = None
+            iopub_idle = False
+            while reply_status is None or not iopub_idle:
                 try:
                     raw = await asyncio.wait_for(
                         ws.recv(), timeout=EXECUTE_IDLE_TIMEOUT
@@ -255,11 +276,24 @@ class JupyterExecutionService:
                     }
 
                 elif msg_type == "execute_result":
-                    text = content.get("data", {}).get("text/plain", "")
-                    yield {
-                        "type": "execute_result",
-                        "data": {"content": text},
-                    }
+                    data = content.get("data", {})
+                    if "image/png" in data:
+                        yield _image_event(data)
+                    else:
+                        yield {
+                            "type": "execute_result",
+                            "data": {"content": data.get("text/plain", "")},
+                        }
+
+                elif msg_type == "display_data":
+                    data = content.get("data", {})
+                    if "image/png" in data:
+                        yield _image_event(data)
+                    elif "text/plain" in data:
+                        yield {
+                            "type": "execute_result",
+                            "data": {"content": data.get("text/plain", "")},
+                        }
 
                 elif msg_type == "error":
                     yield {
@@ -272,9 +306,13 @@ class JupyterExecutionService:
                     }
 
                 elif msg_type == "execute_reply":
-                    status = content.get("status", "ok")
-                    yield {
-                        "type": "done",
-                        "data": {"status": status},
-                    }
-                    execution_done = True
+                    reply_status = content.get("status", "ok")
+
+                elif msg_type == "status":
+                    if content.get("execution_state") == "idle":
+                        iopub_idle = True
+
+            yield {
+                "type": "done",
+                "data": {"status": reply_status},
+            }

--- a/gui/workflow_backend/django-project/app/workflow/jupyter_execution_service.py
+++ b/gui/workflow_backend/django-project/app/workflow/jupyter_execution_service.py
@@ -5,7 +5,7 @@ import os
 import uuid
 
 import httpx
-import websockets
+from websockets.asyncio.client import connect
 
 logger = logging.getLogger(__name__)
 
@@ -205,9 +205,9 @@ class JupyterExecutionService:
 
         logger.info("Connecting to kernel WS: %s", ws_url)
 
-        async with websockets.connect(
+        async with connect(
             ws_url,
-            extra_headers=self._headers,
+            additional_headers=self._headers,
             max_size=2**23,  # 8 MB
             open_timeout=30,
         ) as ws:

--- a/gui/workflow_backend/django-project/app/workflow/views.py
+++ b/gui/workflow_backend/django-project/app/workflow/views.py
@@ -882,6 +882,10 @@ class WorkflowRunStreamView(APIView):
                 status=status.HTTP_400_BAD_REQUEST,
             )
 
+        # Replace sys.exit(main()) with main() so the script does not raise
+        # SystemExit(0) when executed in a Jupyter kernel.
+        code = code.replace("sys.exit(main())", "main()")
+
         # Prepend os.chdir so the script runs in the correct working directory
         working_dir = f"{JUPYTER_HOME}/codes/projects/{project_dir.name}"
         code = (

--- a/gui/workflow_frontend/src/api/workflowRunApi.ts
+++ b/gui/workflow_frontend/src/api/workflowRunApi.ts
@@ -44,6 +44,9 @@ export const runWorkflowStream = async (
 
   const decoder = new TextDecoder();
   let buffer = "";
+  // Persists across read() chunks: a multi-MB `data:` line (e.g. a base64
+  // image) can complete many chunks after its `event:` line arrived.
+  let currentEventType = "";
 
   while (true) {
     const { done, value } = await reader.read();
@@ -53,8 +56,6 @@ export const runWorkflowStream = async (
 
     const lines = buffer.split("\n");
     buffer = lines.pop() || "";
-
-    let currentEventType = "";
 
     for (const line of lines) {
       if (line.startsWith("event: ")) {

--- a/gui/workflow_frontend/src/views/home/components/logViewModal.tsx
+++ b/gui/workflow_frontend/src/views/home/components/logViewModal.tsx
@@ -10,14 +10,16 @@ import {
   Box,
   Badge,
   HStack,
+  Image,
   Spinner,
   Text,
   useColorModeValue,
 } from "@chakra-ui/react";
 
 export interface LogEntry {
-  type: "stdout" | "stderr" | "execute_result" | "error" | "info";
+  type: "stdout" | "stderr" | "execute_result" | "error" | "info" | "image";
   content: string;
+  mime?: string; // set for type "image" (e.g. "image/png")
 }
 
 interface LogViewProps {
@@ -104,6 +106,19 @@ export default function LogViewModal({
               <Text color={subtextColor}>Waiting for output...</Text>
             )}
             {logEntries.map((entry, i) => {
+              if (entry.type === "image") {
+                return (
+                  <Image
+                    key={i}
+                    src={`data:${entry.mime || "image/png"};base64,${entry.content}`}
+                    alt="figure output"
+                    maxW="100%"
+                    maxH="400px"
+                    my={2}
+                    borderRadius="md"
+                  />
+                );
+              }
               const style = typeStyles[entry.type] || typeStyles.info;
               return (
                 <Box

--- a/gui/workflow_frontend/src/views/home/components/projectSelector.tsx
+++ b/gui/workflow_frontend/src/views/home/components/projectSelector.tsx
@@ -346,6 +346,16 @@ export const ProjectSelector = ({
                 { type: "execute_result", content: event.data.content as string },
               ]);
               break;
+            case "image":
+              setLogEntries(prev => [
+                ...prev,
+                {
+                  type: "image",
+                  content: event.data.content as string,
+                  mime: (event.data.mime as string) || "image/png",
+                },
+              ]);
+              break;
             case "error": {
               const tb = (event.data.traceback as string[]) || [];
               const errorText = tb.length > 0


### PR DESCRIPTION
## Summary

Interactive workflow execution (the Run button) failed or silently lost output in several ways. This PR makes it work end-to-end and renders matplotlib figures inline in the execution log.

## Fixes

- **Every run failed with a TypeError**: the backend container has websockets 16 while the code used the pre-14 `extra_headers` API, so the kernel WebSocket connection always failed. Migrated to `websockets.asyncio.client.connect` with `additional_headers`, which works on both the locked 13.1 and newer versions.
- **Inline matplotlib figures**: `display_data` messages (what `plt.show()` emits) were dropped by the backend. `image/png` payloads are now forwarded as a new `image` SSE event and rendered as images in the execution log modal.
- **Runs with large figures aborted**: raised the WebSocket frame limit from 8 MB to 128 MB.
- **Output was silently lost**: execution now completes only after both the shell `execute_reply` and the iopub `status: idle` have arrived. The channels are independent, so `execute_reply` could beat large iopub messages still in flight, and everything behind them was discarded.
- **SSE parser fix**: the event type was lost when a multi-MB `data:` line spanned multiple read chunks (guaranteed to happen for images).
- **Successful runs reported as errors**: the generated script ends with `sys.exit(main())`, which raises `SystemExit` inside the Jupyter kernel. The run path now applies the same `main()` replacement the notebook export already uses.

## Changed files

- Backend: `jupyter_execution_service.py` (WS connection, message handling, completion condition), `views.py` (sys.exit replacement)
- Frontend: `workflowRunApi.ts` (parser), `projectSelector.tsx` (image event), `logViewModal.tsx` (inline image rendering)

## Testing

- Backend verified against a live kernel via docker exec: a small figure arrives in order (stdout → image → stdout → done ok); a 9.4 MB PNG (previously aborted by the 8 MB limit) streams successfully; a real project run finishes done(ok) with no SystemExit.
- `tsc --noEmit` passes; isort clean (black flags only pre-existing lines left untouched).
- Manual frontend test: figures render inline in the modal; text-only runs unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L77mAJQZVU9rC2BecmBqbn