### PR TITLE
Capture project attribution metadata for acknowledgment

### DIFF
--- a/gui/workflow_backend/django-project/app/workflow/migrations/0004_flowproject_attribution.py
+++ b/gui/workflow_backend/django-project/app/workflow/migrations/0004_flowproject_attribution.py
@@ -1,0 +1,77 @@
+from django.db import migrations, models
+
+
+def _add_column(name, ddl_type, default_sql):
+    """Idempotent ADD COLUMN + drop the DB-level default (kept only for the
+    backfill of existing rows), mirroring migration 0003's approach so this is
+    safe to run even if a column was already created out-of-band."""
+    return migrations.RunSQL(
+        sql=f"""
+        ALTER TABLE flow_projects
+        ADD COLUMN IF NOT EXISTS {name} {ddl_type} NOT NULL DEFAULT {default_sql};
+        ALTER TABLE flow_projects
+        ALTER COLUMN {name} DROP DEFAULT;
+        """,
+        reverse_sql=f"""
+        ALTER TABLE flow_projects
+        DROP COLUMN IF EXISTS {name};
+        """,
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("workflow", "0003_flowproject_reference_hpc_target"),
+    ]
+
+    operations = [
+        migrations.SeparateDatabaseAndState(
+            database_operations=[
+                _add_column("doi", "varchar(255)", "''"),
+                _add_column("data_source", "text", "''"),
+                _add_column("license", "varchar(255)", "''"),
+                _add_column("funding", "text", "''"),
+                _add_column("contact_email", "varchar(255)", "''"),
+                _add_column("links", "jsonb", "'[]'::jsonb"),
+                _add_column("contributors", "jsonb", "'[]'::jsonb"),
+            ],
+            state_operations=[
+                migrations.AddField(
+                    model_name="flowproject",
+                    name="doi",
+                    field=models.CharField(blank=True, default="", max_length=255),
+                ),
+                migrations.AddField(
+                    model_name="flowproject",
+                    name="data_source",
+                    field=models.TextField(blank=True, default=""),
+                ),
+                migrations.AddField(
+                    model_name="flowproject",
+                    name="license",
+                    field=models.CharField(blank=True, default="", max_length=255),
+                ),
+                migrations.AddField(
+                    model_name="flowproject",
+                    name="funding",
+                    field=models.TextField(blank=True, default=""),
+                ),
+                migrations.AddField(
+                    model_name="flowproject",
+                    name="contact_email",
+                    field=models.CharField(blank=True, default="", max_length=255),
+                ),
+                migrations.AddField(
+                    model_name="flowproject",
+                    name="links",
+                    field=models.JSONField(blank=True, default=list),
+                ),
+                migrations.AddField(
+                    model_name="flowproject",
+                    name="contributors",
+                    field=models.JSONField(blank=True, default=list),
+                ),
+            ],
+        ),
+    ]

--- a/gui/workflow_backend/django-project/app/workflow/models.py
+++ b/gui/workflow_backend/django-project/app/workflow/models.py
@@ -38,6 +38,19 @@ class FlowProject(models.Model):
         blank=True,
         default="",
     )
+    # --- Attribution / acknowledgment metadata -------------------------------
+    # Captures how to credit and cite the work behind a project. Fixed
+    # single-value fields are discrete columns; the two variable-length lists
+    # (contributors, links) are JSON so the UI can add/remove rows freely.
+    doi = models.CharField(max_length=255, blank=True, default="")
+    data_source = models.TextField(blank=True, default="")
+    license = models.CharField(max_length=255, blank=True, default="")
+    funding = models.TextField(blank=True, default="")
+    contact_email = models.CharField(max_length=255, blank=True, default="")
+    # [{"label": str, "url": str}]
+    links = models.JSONField(default=list, blank=True)
+    # [{"name": str, "affiliation": str, "orcid": str, "researchmap": str, "role": str}]
+    contributors = models.JSONField(default=list, blank=True)
     created_at = models.DateTimeField(auto_now_add=True)
     updated_at = models.DateTimeField(auto_now=True)
     is_active = models.BooleanField(default=True)

--- a/gui/workflow_backend/django-project/app/workflow/serializers.py
+++ b/gui/workflow_backend/django-project/app/workflow/serializers.py
@@ -36,6 +36,13 @@ class FlowProjectSerializer(serializers.ModelSerializer):
             "visibility",
             "reference",
             "hpc_target",
+            "doi",
+            "data_source",
+            "license",
+            "funding",
+            "contact_email",
+            "links",
+            "contributors",
             "created_at",
             "updated_at",
             "is_active",
@@ -86,6 +93,36 @@ class FlowProjectSerializer(serializers.ModelSerializer):
 
     def get_can_change_visibility(self, obj):
         return self.get_is_owned_by_me(obj)
+
+    # -- Attribution JSON-list validation ------------------------------------
+    # Both fields are free-form JSON lists in the DB; normalise them to a
+    # predictable shape (list of dicts with only the known string keys) and
+    # drop entirely-empty rows so the UI's add/remove behaviour stays clean.
+    _CONTRIBUTOR_KEYS = ("name", "affiliation", "orcid", "researchmap", "role")
+    _LINK_KEYS = ("label", "url")
+
+    @staticmethod
+    def _clean_rows(value, allowed_keys, field_name):
+        if value in (None, ""):
+            return []
+        if not isinstance(value, list):
+            raise serializers.ValidationError(f"{field_name} must be a list.")
+        cleaned = []
+        for row in value:
+            if not isinstance(row, dict):
+                raise serializers.ValidationError(
+                    f"Each {field_name} entry must be an object."
+                )
+            item = {k: str(row.get(k, "")).strip() for k in allowed_keys}
+            if any(item.values()):  # skip rows the user left completely blank
+                cleaned.append(item)
+        return cleaned
+
+    def validate_contributors(self, value):
+        return self._clean_rows(value, self._CONTRIBUTOR_KEYS, "contributors")
+
+    def validate_links(self, value):
+        return self._clean_rows(value, self._LINK_KEYS, "links")
 
 
 class FlowNodeSerializer(serializers.ModelSerializer):

--- a/gui/workflow_frontend/src/views/home/components/acknowledgmentModal.tsx
+++ b/gui/workflow_frontend/src/views/home/components/acknowledgmentModal.tsx
@@ -1,0 +1,205 @@
+import {
+  Box,
+  Button,
+  HStack,
+  Link,
+  Modal,
+  ModalBody,
+  ModalCloseButton,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Text,
+  useToast,
+  VStack,
+} from '@chakra-ui/react';
+import { CopyIcon, ExternalLinkIcon } from '@chakra-ui/icons';
+import { Project } from '../type';
+
+const doiUrl = (doi: string) =>
+  doi.startsWith('http') ? doi : `https://doi.org/${doi.replace(/^doi:/i, '').trim()}`;
+
+const orcidUrl = (orcid: string) =>
+  orcid.startsWith('http') ? orcid : `https://orcid.org/${orcid.trim()}`;
+
+const hasAttribution = (p: Project): boolean =>
+  Boolean(
+    (p.contributors && p.contributors.length) ||
+      (p.links && p.links.length) ||
+      p.doi ||
+      p.data_source ||
+      p.license ||
+      p.funding ||
+      p.contact_email
+  );
+
+const buildPlainText = (p: Project): string => {
+  const lines: string[] = [];
+  lines.push(`Project: ${p.name}`);
+  if (p.contributors && p.contributors.length) {
+    const people = p.contributors
+      .map((c) => {
+        const parts = [c.name];
+        if (c.affiliation) parts.push(`(${c.affiliation})`);
+        if (c.role) parts.push(`[${c.role}]`);
+        return parts.filter(Boolean).join(' ');
+      })
+      .filter(Boolean);
+    if (people.length) lines.push(`Contributors: ${people.join('; ')}`);
+  }
+  if (p.doi) lines.push(`DOI: ${doiUrl(p.doi)}`);
+  if (p.data_source) lines.push(`Data source: ${p.data_source}`);
+  if (p.license) lines.push(`License: ${p.license}`);
+  if (p.funding) lines.push(`Funding: ${p.funding}`);
+  if (p.contact_email) lines.push(`Contact: ${p.contact_email}`);
+  if (p.links && p.links.length) {
+    lines.push('Links:');
+    p.links.forEach((l) => lines.push(`  - ${l.label ? `${l.label}: ` : ''}${l.url}`));
+  }
+  return lines.join('\n');
+};
+
+const Field = ({ label, children }: { label: string; children: React.ReactNode }) => (
+  <Box>
+    <Text fontSize="xs" color="gray.500" fontWeight="semibold" textTransform="uppercase">
+      {label}
+    </Text>
+    <Box fontSize="sm">{children}</Box>
+  </Box>
+);
+
+interface Props {
+  project: Project | null;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+export const AcknowledgmentModal = ({ project, isOpen, onClose }: Props) => {
+  const toast = useToast();
+  if (!project) return null;
+
+  const empty = !hasAttribution(project);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(buildPlainText(project));
+      toast({ title: 'Copied to clipboard', status: 'success', duration: 2000, isClosable: true });
+    } catch {
+      toast({ title: 'Copy failed', status: 'error', duration: 2000, isClosable: true });
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="lg" scrollBehavior="inside">
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>How to cite / Acknowledgment</ModalHeader>
+        <ModalCloseButton />
+        <ModalBody>
+          <Text fontWeight="semibold" mb={3}>
+            {project.name}
+          </Text>
+
+          {empty ? (
+            <Text fontSize="sm" color="gray.500">
+              No attribution details have been added for this project yet.
+            </Text>
+          ) : (
+            <VStack align="stretch" spacing={3}>
+              {project.contributors && project.contributors.length > 0 && (
+                <Field label="Contributors">
+                  <VStack align="stretch" spacing={1} mt={1}>
+                    {project.contributors.map((c, i) => (
+                      <Box key={i}>
+                        <Text as="span" fontWeight="medium">
+                          {c.name}
+                        </Text>
+                        {c.affiliation && (
+                          <Text as="span" color="gray.600">
+                            {' '}
+                            — {c.affiliation}
+                          </Text>
+                        )}
+                        {c.role && (
+                          <Text as="span" color="gray.500">
+                            {' '}
+                            [{c.role}]
+                          </Text>
+                        )}
+                        <HStack spacing={3} mt={0.5}>
+                          {c.orcid && (
+                            <Link href={orcidUrl(c.orcid)} isExternal color="teal.600" fontSize="xs">
+                              ORCID <ExternalLinkIcon mx="1px" />
+                            </Link>
+                          )}
+                          {c.researchmap && (
+                            <Link href={c.researchmap} isExternal color="teal.600" fontSize="xs">
+                              researchmap <ExternalLinkIcon mx="1px" />
+                            </Link>
+                          )}
+                        </HStack>
+                      </Box>
+                    ))}
+                  </VStack>
+                </Field>
+              )}
+
+              {project.doi && (
+                <Field label="DOI">
+                  <Link href={doiUrl(project.doi)} isExternal color="teal.600">
+                    {project.doi} <ExternalLinkIcon mx="1px" />
+                  </Link>
+                </Field>
+              )}
+
+              {project.data_source && (
+                <Field label="Data source">
+                  <Text whiteSpace="pre-wrap">{project.data_source}</Text>
+                </Field>
+              )}
+
+              {project.license && <Field label="License">{project.license}</Field>}
+
+              {project.funding && (
+                <Field label="Funding">
+                  <Text whiteSpace="pre-wrap">{project.funding}</Text>
+                </Field>
+              )}
+
+              {project.contact_email && (
+                <Field label="Contact">
+                  <Link href={`mailto:${project.contact_email}`} color="teal.600">
+                    {project.contact_email}
+                  </Link>
+                </Field>
+              )}
+
+              {project.links && project.links.length > 0 && (
+                <Field label="Links">
+                  <VStack align="stretch" spacing={1} mt={1}>
+                    {project.links.map((l, i) => (
+                      <Link key={i} href={l.url} isExternal color="teal.600">
+                        {l.label || l.url} <ExternalLinkIcon mx="1px" />
+                      </Link>
+                    ))}
+                  </VStack>
+                </Field>
+              )}
+            </VStack>
+          )}
+        </ModalBody>
+        <ModalFooter>
+          <Button variant="ghost" mr={3} onClick={onClose}>
+            Close
+          </Button>
+          <Button leftIcon={<CopyIcon />} colorScheme="blue" onClick={handleCopy} isDisabled={empty}>
+            Copy acknowledgment
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+};
+
+export default AcknowledgmentModal;

--- a/gui/workflow_frontend/src/views/home/components/attributionEditor.tsx
+++ b/gui/workflow_frontend/src/views/home/components/attributionEditor.tsx
@@ -1,0 +1,239 @@
+import {
+  Box,
+  Button,
+  Divider,
+  FormLabel,
+  HStack,
+  IconButton,
+  Input,
+  SimpleGrid,
+  Text,
+  Textarea,
+  VStack,
+} from '@chakra-ui/react';
+import { AddIcon, DeleteIcon } from '@chakra-ui/icons';
+import { AttributionDraft, Contributor, ProjectLink } from '../type';
+
+const emptyContributor = (): Contributor => ({
+  name: '',
+  affiliation: '',
+  orcid: '',
+  researchmap: '',
+  role: '',
+});
+
+const emptyLink = (): ProjectLink => ({ label: '', url: '' });
+
+interface Props {
+  value: AttributionDraft;
+  onChange: (next: AttributionDraft) => void;
+  isDisabled?: boolean;
+}
+
+export const AttributionEditor = ({ value, onChange, isDisabled = false }: Props) => {
+  const patch = (partial: Partial<AttributionDraft>) => onChange({ ...value, ...partial });
+
+  const updateContributor = (idx: number, field: keyof Contributor, v: string) => {
+    const next = value.contributors.map((c, i) => (i === idx ? { ...c, [field]: v } : c));
+    patch({ contributors: next });
+  };
+  const addContributor = () => patch({ contributors: [...value.contributors, emptyContributor()] });
+  const removeContributor = (idx: number) =>
+    patch({ contributors: value.contributors.filter((_, i) => i !== idx) });
+
+  const updateLink = (idx: number, field: keyof ProjectLink, v: string) => {
+    const next = value.links.map((l, i) => (i === idx ? { ...l, [field]: v } : l));
+    patch({ links: next });
+  };
+  const addLink = () => patch({ links: [...value.links, emptyLink()] });
+  const removeLink = (idx: number) => patch({ links: value.links.filter((_, i) => i !== idx) });
+
+  return (
+    <Box>
+      <Text fontWeight="semibold" fontSize="sm" mb={2}>
+        Attribution &amp; Acknowledgment
+      </Text>
+      <Text fontSize="xs" color="gray.500" mb={3}>
+        Credit the people, data, and publications behind this workflow so the work can be properly
+        acknowledged and cited.
+      </Text>
+
+      {/* Contributors */}
+      <FormLabel fontSize="sm" mb={1}>
+        Contributors
+      </FormLabel>
+      <VStack spacing={3} align="stretch">
+        {value.contributors.map((c, idx) => (
+          <Box key={idx} borderWidth="1px" borderRadius="md" p={3}>
+            <HStack justify="space-between" mb={2}>
+              <Text fontSize="xs" color="gray.500">
+                Contributor {idx + 1}
+              </Text>
+              <IconButton
+                aria-label="Remove contributor"
+                icon={<DeleteIcon />}
+                size="xs"
+                variant="ghost"
+                colorScheme="red"
+                isDisabled={isDisabled}
+                onClick={() => removeContributor(idx)}
+              />
+            </HStack>
+            <SimpleGrid columns={{ base: 1, md: 2 }} spacing={2}>
+              <Input
+                size="sm"
+                placeholder="Name"
+                value={c.name}
+                isDisabled={isDisabled}
+                onChange={(e) => updateContributor(idx, 'name', e.target.value)}
+              />
+              <Input
+                size="sm"
+                placeholder="Affiliation"
+                value={c.affiliation ?? ''}
+                isDisabled={isDisabled}
+                onChange={(e) => updateContributor(idx, 'affiliation', e.target.value)}
+              />
+              <Input
+                size="sm"
+                placeholder="Role (e.g. PI, data, code)"
+                value={c.role ?? ''}
+                isDisabled={isDisabled}
+                onChange={(e) => updateContributor(idx, 'role', e.target.value)}
+              />
+              <Input
+                size="sm"
+                placeholder="ORCID (e.g. 0000-0002-1825-0097)"
+                value={c.orcid ?? ''}
+                isDisabled={isDisabled}
+                onChange={(e) => updateContributor(idx, 'orcid', e.target.value)}
+              />
+              <Input
+                size="sm"
+                placeholder="researchmap URL"
+                value={c.researchmap ?? ''}
+                isDisabled={isDisabled}
+                onChange={(e) => updateContributor(idx, 'researchmap', e.target.value)}
+              />
+            </SimpleGrid>
+          </Box>
+        ))}
+      </VStack>
+      <Button
+        leftIcon={<AddIcon />}
+        size="xs"
+        variant="outline"
+        mt={2}
+        isDisabled={isDisabled}
+        onClick={addContributor}
+      >
+        Add contributor
+      </Button>
+
+      <Divider my={4} />
+
+      {/* Fixed project-level fields */}
+      <SimpleGrid columns={{ base: 1, md: 2 }} spacing={3}>
+        <Box>
+          <FormLabel fontSize="sm">DOI</FormLabel>
+          <Input
+            size="sm"
+            placeholder="10.1234/zenodo.123456"
+            value={value.doi}
+            isDisabled={isDisabled}
+            onChange={(e) => patch({ doi: e.target.value })}
+          />
+        </Box>
+        <Box>
+          <FormLabel fontSize="sm">License</FormLabel>
+          <Input
+            size="sm"
+            placeholder="e.g. CC-BY-4.0"
+            value={value.license}
+            isDisabled={isDisabled}
+            onChange={(e) => patch({ license: e.target.value })}
+          />
+        </Box>
+        <Box>
+          <FormLabel fontSize="sm">Contact email</FormLabel>
+          <Input
+            size="sm"
+            type="email"
+            placeholder="contact@example.org"
+            value={value.contact_email}
+            isDisabled={isDisabled}
+            onChange={(e) => patch({ contact_email: e.target.value })}
+          />
+        </Box>
+      </SimpleGrid>
+      <Box mt={3}>
+        <FormLabel fontSize="sm">Data source</FormLabel>
+        <Textarea
+          size="sm"
+          placeholder="Origin of the data used (dataset name, repository, URL, accession, etc.)"
+          value={value.data_source}
+          isDisabled={isDisabled}
+          onChange={(e) => patch({ data_source: e.target.value })}
+        />
+      </Box>
+      <Box mt={3}>
+        <FormLabel fontSize="sm">Funding / grant acknowledgment</FormLabel>
+        <Textarea
+          size="sm"
+          placeholder="e.g. Supported by Brain/MINDS 2.0 (grant no. ...)"
+          value={value.funding}
+          isDisabled={isDisabled}
+          onChange={(e) => patch({ funding: e.target.value })}
+        />
+      </Box>
+
+      <Divider my={4} />
+
+      {/* Links */}
+      <FormLabel fontSize="sm" mb={1}>
+        Links
+      </FormLabel>
+      <VStack spacing={2} align="stretch">
+        {value.links.map((l, idx) => (
+          <HStack key={idx} align="center">
+            <Input
+              size="sm"
+              placeholder="Label (e.g. Paper, Dataset, Homepage)"
+              value={l.label}
+              isDisabled={isDisabled}
+              onChange={(e) => updateLink(idx, 'label', e.target.value)}
+              flex="1"
+            />
+            <Input
+              size="sm"
+              placeholder="https://..."
+              value={l.url}
+              isDisabled={isDisabled}
+              onChange={(e) => updateLink(idx, 'url', e.target.value)}
+              flex="2"
+            />
+            <IconButton
+              aria-label="Remove link"
+              icon={<DeleteIcon />}
+              size="xs"
+              variant="ghost"
+              colorScheme="red"
+              isDisabled={isDisabled}
+              onClick={() => removeLink(idx)}
+            />
+          </HStack>
+        ))}
+      </VStack>
+      <Button
+        leftIcon={<AddIcon />}
+        size="xs"
+        variant="outline"
+        mt={2}
+        isDisabled={isDisabled}
+        onClick={addLink}
+      >
+        Add link
+      </Button>
+    </Box>
+  );
+};

--- a/gui/workflow_frontend/src/views/home/components/projectSelector.tsx
+++ b/gui/workflow_frontend/src/views/home/components/projectSelector.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useCallback, useRef } from 'react';
-import { HpcTarget, Project, Visibility } from '../type'
+import { AttributionDraft, HpcTarget, Project, Visibility } from '../type'
 import {
   HStack,
   Box,
@@ -23,9 +23,10 @@ import {
   RadioGroup,
   Radio,
   Stack,
+  Divider,
   useDisclosure,
 } from '@chakra-ui/react';
-import { CheckIcon, WarningIcon, DeleteIcon, EditIcon } from '@chakra-ui/icons';
+import { CheckIcon, WarningIcon, DeleteIcon, EditIcon, InfoOutlineIcon } from '@chakra-ui/icons';
 import { FiMenu, FiPlay } from 'react-icons/fi';
 import { useTabContext } from '../../../components/tabs/TabManager';
 import { useAuth } from '../../../auth/authContext';
@@ -33,6 +34,18 @@ import { createAuthHeaders } from '../../../api/authHeaders';
 import LogViewModal, { LogEntry } from "./logViewModal";
 import { runWorkflowStream } from '../../../api/workflowRunApi';
 import { WorkflowContextEditor } from '../../../components/WorkflowContextEditor';
+import { AttributionEditor } from './attributionEditor';
+import { AcknowledgmentModal } from './acknowledgmentModal';
+
+const emptyAttribution = (): AttributionDraft => ({
+  doi: '',
+  data_source: '',
+  license: '',
+  funding: '',
+  contact_email: '',
+  links: [],
+  contributors: [],
+});
 import { JUPYTER_BASE_URL } from '../../../config/urls';
 
 export const ProjectSelector = ({ 
@@ -62,6 +75,8 @@ export const ProjectSelector = ({
   const [visibilityDraft, setVisibilityDraft] = useState<Visibility>('private');
   const [referenceDraft, setReferenceDraft] = useState<string>('');
   const [hpcTargetDraft, setHpcTargetDraft] = useState<HpcTarget>('');
+  const [attributionDraft, setAttributionDraft] = useState<AttributionDraft>(emptyAttribution());
+  const { isOpen: isAckOpen, onOpen: onAckOpen, onClose: onAckClose } = useDisclosure();
   const currentProject = selectedProject
     ? projects.find((p) => p.id === selectedProject) ?? null
     : null;
@@ -124,6 +139,13 @@ export const ProjectSelector = ({
       description: descriptionPayload,
       reference: referenceDraft,
       hpc_target: hpcTargetDraft,
+      doi: attributionDraft.doi,
+      data_source: attributionDraft.data_source,
+      license: attributionDraft.license,
+      funding: attributionDraft.funding,
+      contact_email: attributionDraft.contact_email,
+      links: attributionDraft.links,
+      contributors: attributionDraft.contributors,
     };
     if (currentProject?.can_change_visibility && visibilityDraft !== currentProject.visibility) {
       payload.visibility = visibilityDraft;
@@ -166,6 +188,15 @@ export const ProjectSelector = ({
       if (updated.hpc_target !== undefined) {
         setHpcTargetDraft(updated.hpc_target);
       }
+      setAttributionDraft({
+        doi: updated.doi ?? '',
+        data_source: updated.data_source ?? '',
+        license: updated.license ?? '',
+        funding: updated.funding ?? '',
+        contact_email: updated.contact_email ?? '',
+        links: updated.links ?? [],
+        contributors: updated.contributors ?? [],
+      });
       onContextClose();
     } catch (error) {
       toast({
@@ -545,6 +576,15 @@ export const ProjectSelector = ({
                     setVisibilityDraft(project?.visibility ?? 'private');
                     setReferenceDraft(project?.reference ?? '');
                     setHpcTargetDraft(project?.hpc_target ?? '');
+                    setAttributionDraft({
+                      doi: project?.doi ?? '',
+                      data_source: project?.data_source ?? '',
+                      license: project?.license ?? '',
+                      funding: project?.funding ?? '',
+                      contact_email: project?.contact_email ?? '',
+                      links: project?.links ?? [],
+                      contributors: project?.contributors ?? [],
+                    });
                     onContextOpen();
                   }}
                   _hover={{
@@ -555,7 +595,25 @@ export const ProjectSelector = ({
                 />
               </Tooltip>
             )}
-            
+
+            {selectedProject && (
+              <Tooltip label="How to cite / Acknowledgment" placement="top">
+                <IconButton
+                  aria-label="How to cite / Acknowledgment"
+                  icon={<InfoOutlineIcon />}
+                  size="sm"
+                  colorScheme="teal"
+                  variant="outline"
+                  onClick={onAckOpen}
+                  _hover={{
+                    bg: "teal.50",
+                    borderColor: "teal.400"
+                  }}
+                  marginTop={2}
+                />
+              </Tooltip>
+            )}
+
             {selectedProject && onProjectDelete && currentProject?.can_delete && (
               <Tooltip label="Delete project" placement="top">
                 <IconButton
@@ -619,6 +677,12 @@ export const ProjectSelector = ({
         onStop={handleStopWorkflow}
       />
 
+      <AcknowledgmentModal
+        project={currentProject}
+        isOpen={isAckOpen}
+        onClose={onAckClose}
+      />
+
       <Modal isOpen={isContextOpen} onClose={onContextClose} size="lg">
         <ModalOverlay />
         <ModalContent>
@@ -669,6 +733,11 @@ export const ProjectSelector = ({
                 <option value="fugaku">Fugaku</option>
               </Select>
             </Box>
+            <Divider my={4} />
+            <Box mb={4}>
+              <AttributionEditor value={attributionDraft} onChange={setAttributionDraft} />
+            </Box>
+            <Divider my={4} />
             <WorkflowContextEditor
               key={contextResetKey}
               initialContext={contextInitial}

--- a/gui/workflow_frontend/src/views/home/type.ts
+++ b/gui/workflow_frontend/src/views/home/type.ts
@@ -84,6 +84,29 @@ export interface ProjectOwner {
   last_name?: string;
 }
 
+export interface Contributor {
+  name: string;
+  affiliation?: string;
+  orcid?: string;
+  researchmap?: string;
+  role?: string;
+}
+
+export interface ProjectLink {
+  label: string;
+  url: string;
+}
+
+export interface AttributionDraft {
+  doi: string;
+  data_source: string;
+  license: string;
+  funding: string;
+  contact_email: string;
+  links: ProjectLink[];
+  contributors: Contributor[];
+}
+
 export interface Project {
   id: string;
   name: string;
@@ -92,6 +115,13 @@ export interface Project {
   visibility: Visibility;
   reference?: string;
   hpc_target?: HpcTarget;
+  doi?: string;
+  data_source?: string;
+  license?: string;
+  funding?: string;
+  contact_email?: string;
+  links?: ProjectLink[];
+  contributors?: Contributor[];
   owner?: ProjectOwner;
   is_owned_by_me: boolean;
   can_edit: boolean;


### PR DESCRIPTION
## Summary
Addresses hackathon user feedback: *"Proper acknowledgment of each work/contribution. Modify Project panel to capture DOI, data source, links, research map, affiliation, name, etc."*

Adds structured attribution/acknowledgment metadata to a project so the people, data, and publications behind it can be properly credited and cited.

**Backend** (`FlowProject`)
- New fields: `doi`, `data_source`, `license`, `funding`, `contact_email` (discrete columns) and `links`, `contributors` (JSON lists).
- `contributors` entries: `{ name, affiliation, orcid, researchmap, role }`; `links` entries: `{ label, url }`.
- Migration `0004` follows the existing idempotent `SeparateDatabaseAndState` + `ADD COLUMN IF NOT EXISTS` pattern (safe to re-run).
- Serializer exposes the fields and normalizes the two JSON lists (known string keys only; blank rows dropped).

**Frontend**
- Project edit modal gains an **Attribution & Acknowledgment** section: repeatable contributor rows (name / affiliation / role / ORCID / researchmap), repeatable links, plus DOI, data source, license, funding, contact email.
- New read-only **"How to cite / Acknowledgment"** modal (info button next to the project) that formats contributors (with ORCID/researchmap/DOI links) and offers a one-click copy of a plain-text acknowledgment.

## Notes
- `makemigrations --check` flags only a pre-existing, unrelated `workflow_context` field alter (already on `main`); the attribution fields are fully captured by `0004`.
- No live deployment performed. Deploying requires applying the migration and rebuilding the frontend.

## Test plan
- [x] Backend files compile; `makemigrations --check` shows no missing migration for the new fields
- [x] Frontend `tsc -b` passes; new components lint clean
- [ ] Apply migration on a deployment and edit a project's attribution end-to-end
- [ ] Verify the acknowledgment modal renders links and copy works