### PR TITLE
Project data upload from the GUI (and fix 413 upload limit)

### DIFF
--- a/gui/nginx/neuro-workflow-proxy.conf
+++ b/gui/nginx/neuro-workflow-proxy.conf
@@ -1,0 +1,86 @@
+# Shared reverse-proxy locations for the NeuroWorkflow app.
+# Included by each app server block (neuro-workflow.dbrain.jp, …).
+#
+# Install / update on the host:
+#   sudo cp gui/nginx/neuro-workflow-proxy.conf /etc/nginx/snippets/neuro-workflow-proxy.conf
+#   sudo nginx -t && sudo systemctl reload nginx
+#
+# IMPORTANT: client_max_body_size must be set here (or in the server block).
+# Without it, nginx defaults to 1m and Jupyter/API uploads return 413.
+
+# --- Jupyter Hub Proxy ---
+location /jupyter/ {
+    client_max_body_size 50M;
+
+    proxy_pass http://127.0.0.1:8000;
+
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    proxy_read_timeout 300s;
+    proxy_send_timeout 300s;
+}
+
+# --- MCP Proxy ---
+location /mcp/ {
+    proxy_pass http://127.0.0.1:8001;
+
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    proxy_read_timeout 60s;
+}
+
+# --- Django API Backend Proxy ---
+location /api/ {
+    client_max_body_size 50M;
+
+    proxy_pass http://127.0.0.1:3000;
+
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    proxy_read_timeout 300s;
+    proxy_send_timeout 300s;
+    proxy_buffering off;
+    proxy_cache off;
+}
+
+# --- Keycloak Auth Proxy ---
+location /auth/ {
+    proxy_pass http://127.0.0.1:8080/auth/;
+    proxy_set_header Host              $host;
+    proxy_set_header X-Real-IP         $remote_addr;
+    proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+}
+
+# --- Frontend ---
+location / {
+    proxy_pass http://127.0.0.1:5173;
+
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    proxy_read_timeout 60s;
+}

--- a/gui/nginx/neuro-workflow.conf
+++ b/gui/nginx/neuro-workflow.conf
@@ -1,12 +1,19 @@
 # Nginx reverse-proxy config for NeuroWorkflow (RIKEN deployment).
 #
-# Install:
+# Install (monolithic example):
 #   sudo cp gui/nginx/neuro-workflow.conf /etc/nginx/sites-available/neuro-workflow
 #   sudo ln -sf /etc/nginx/sites-available/neuro-workflow /etc/nginx/sites-enabled/
 #   sudo nginx -t && sudo systemctl reload nginx
 #
+# Production at neuro-workflow.dbrain.jp uses the shared snippet instead:
+#   sudo cp gui/nginx/neuro-workflow-proxy.conf /etc/nginx/snippets/neuro-workflow-proxy.conf
+#   sudo nginx -t && sudo systemctl reload nginx
+#
 # All Docker services bind to 127.0.0.1 only (see docker-compose.yml BIND_HOST).
 # This file is the reference config; the server admin may adapt it.
+#
+# Keep client_max_body_size in sync with Django DATA_UPLOAD_MAX_MEMORY_SIZE
+# and path_utils.PROJECT_UPLOAD_MAX_BYTES (50M).
 
 upstream frontend_upstream {
     server 127.0.0.1:5173;

--- a/gui/workflow_backend/django-project/app/workflow/path_utils.py
+++ b/gui/workflow_backend/django-project/app/workflow/path_utils.py
@@ -8,6 +8,82 @@ WORKFLOW_CODE_FILENAME = "workflow.py"
 WORKFLOW_NOTEBOOK_FILENAME = "workflow.ipynb"
 ALLOWED_REPORT_SUFFIXES = {".md", ".markdown", ".txt"}
 
+# Project data uploads (GUI / API → codes/projects/<id>/)
+PROJECT_UPLOAD_MAX_BYTES = 50 * 1024 * 1024  # keep in sync with nginx client_max_body_size
+PROTECTED_PROJECT_FILENAMES = frozenset(
+    {
+        WORKFLOW_CODE_FILENAME,
+        WORKFLOW_NOTEBOOK_FILENAME,
+        "run.sbatch",
+    }
+)
+ALLOWED_UPLOAD_COMPOUND_SUFFIXES = frozenset(
+    {
+        ".nii.gz",
+        ".tar.gz",
+        ".npz.gz",
+        ".csv.gz",
+        ".json.gz",
+        ".tsv.gz",
+        ".txt.gz",
+    }
+)
+ALLOWED_UPLOAD_SUFFIXES = frozenset(
+    {
+        ".csv",
+        ".tsv",
+        ".txt",
+        ".json",
+        ".jsonl",
+        ".yaml",
+        ".yml",
+        ".md",
+        ".markdown",
+        ".zip",
+        ".tar",
+        ".tgz",
+        ".gz",
+        ".bz2",
+        ".xz",
+        ".h5",
+        ".hdf5",
+        ".mat",
+        ".npz",
+        ".npy",
+        ".pkl",
+        ".pickle",
+        ".parquet",
+        ".png",
+        ".jpg",
+        ".jpeg",
+        ".gif",
+        ".svg",
+        ".pdf",
+        ".xlsx",
+        ".xls",
+        ".ods",
+        ".nii",
+        ".nwb",
+        ".edf",
+        ".fif",
+        ".py",
+    }
+)
+
+
+def upload_file_suffix(filename: str) -> str:
+    """Return the effective suffix used for allowlist checks (supports .nii.gz etc.)."""
+    lower = (filename or "").lower()
+    for compound in sorted(ALLOWED_UPLOAD_COMPOUND_SUFFIXES, key=len, reverse=True):
+        if lower.endswith(compound):
+            return compound
+    return Path(filename or "").suffix.lower()
+
+
+def is_allowed_upload_filename(filename: str) -> bool:
+    suffix = upload_file_suffix(filename)
+    return suffix in ALLOWED_UPLOAD_SUFFIXES or suffix in ALLOWED_UPLOAD_COMPOUND_SUFFIXES
+
 
 def projects_root() -> Path:
     root = Path(settings.BASE_DIR) / "codes" / "projects"
@@ -94,4 +170,38 @@ def safe_report_path(project, filename: str, *, create_dir: bool = False) -> Pat
         raise ValueError("Invalid report filename")
 
     project_dir = stable_project_dir(project, create=create_dir) if create_dir else existing_project_dir(project)
+    return _ensure_under_root(project_dir / candidate.name)
+
+
+def safe_project_upload_path(project, filename: str, *, create_dir: bool = True) -> Path:
+    """Resolve a safe basename under the project's directory for data uploads.
+
+    Rejects path traversal, absolute paths, disallowed extensions, and
+    overwrites of generated workflow artifacts (``workflow.py`` / ``.ipynb``).
+    """
+    name = (filename or "").strip()
+    candidate = Path(name)
+    if (
+        not name
+        or "\x00" in name
+        or candidate.is_absolute()
+        or len(candidate.parts) != 1
+        or name in {".", ".."}
+        or ".." in candidate.parts
+    ):
+        raise ValueError("Invalid upload filename")
+
+    if not is_allowed_upload_filename(candidate.name):
+        raise ValueError(
+            f"File type '{upload_file_suffix(candidate.name) or '(none)'}' is not allowed"
+        )
+
+    if candidate.name.lower() in {n.lower() for n in PROTECTED_PROJECT_FILENAMES}:
+        raise ValueError(f"Cannot overwrite protected file '{candidate.name}'")
+
+    project_dir = (
+        stable_project_dir(project, create=True)
+        if create_dir
+        else existing_project_dir(project, create=False)
+    )
     return _ensure_under_root(project_dir / candidate.name)

--- a/gui/workflow_backend/django-project/app/workflow/urls.py
+++ b/gui/workflow_backend/django-project/app/workflow/urls.py
@@ -16,6 +16,7 @@ from .views import (
     WorkflowRunArtifactView,
     WorkflowResultsView,
     WorkflowReportView,
+    WorkflowProjectFilesView,
     WorkflowCodeView,
     ViewerChatToolView,
 )
@@ -149,6 +150,12 @@ urlpatterns = [
         ViewerChatToolView.as_view(),
         name="workflow-viewer-chat"
     ),  # POST({tool, args, data_path}) -> tool result / action dict
+    # Project data files (upload into codes/projects/<id>/)
+    path(
+        "<uuid:workflow_id>/files/",
+        WorkflowProjectFilesView.as_view(),
+        name="workflow-project-files",
+    ),  # GET(list), POST(upload), DELETE(?filename=)
     # Sample Data
     path(
         "sample-flow/", SampleFlowView.as_view(), name="sample-flow"

--- a/gui/workflow_backend/django-project/app/workflow/views.py
+++ b/gui/workflow_backend/django-project/app/workflow/views.py
@@ -4,6 +4,7 @@ import json
 import logging
 import os
 import shutil
+from pathlib import Path
 
 from django.db import transaction
 from django.db.models import Q
@@ -19,6 +20,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.static import serve as static_file_serve
 from rest_framework import permissions, status, viewsets
 from rest_framework.decorators import action
+from rest_framework.parsers import FormParser, MultiPartParser
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -29,10 +31,12 @@ from .code_generation_service import CodeGenerationService
 from .jupyter_execution_service import JupyterExecutionService
 from .models import FlowEdge, FlowNode, FlowProject, WorkflowRun
 from .path_utils import (
+    PROJECT_UPLOAD_MAX_BYTES,
     batch_run_dir,
     code_file_path,
     existing_project_dir,
     notebook_file_path,
+    safe_project_upload_path,
     safe_report_path,
 )
 from .permissions import (
@@ -1227,6 +1231,168 @@ class WorkflowCodeView(APIView):
 
         result["notebook_outputs"] = notebook_outputs
         return JsonResponse({"status": "success", **result})
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class WorkflowProjectFilesView(APIView):
+    """List / upload / delete data files in a workflow project's directory.
+
+    Files land in ``codes/projects/<project_id>/`` (same folder Jupyter opens),
+    so nodes and notebooks can read them by relative path.
+    """
+
+    parser_classes = (MultiPartParser, FormParser)
+    authentication_classes = [KeycloakAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request, workflow_id):
+        project = get_accessible_project(request, workflow_id, write=False)
+        project_dir = existing_project_dir(project, create=True)
+        files = []
+        if project_dir.exists():
+            for entry in sorted(project_dir.iterdir(), key=lambda p: p.name.lower()):
+                if not entry.is_file():
+                    continue
+                files.append(
+                    {
+                        "filename": entry.name,
+                        "size_bytes": entry.stat().st_size,
+                        "modified_at": entry.stat().st_mtime,
+                    }
+                )
+        return JsonResponse(
+            {
+                "status": "success",
+                "project_id": str(project.id),
+                "max_bytes": PROJECT_UPLOAD_MAX_BYTES,
+                "files": files,
+            }
+        )
+
+    def post(self, request, workflow_id):
+        project = get_accessible_project(request, workflow_id, write=True)
+        uploads = list(request.FILES.getlist("file")) or list(
+            request.FILES.getlist("files")
+        )
+        if not uploads:
+            return JsonResponse({"error": "No file provided (field name: file)"}, status=400)
+
+        overwrite = str(
+            request.data.get("overwrite", request.query_params.get("overwrite", ""))
+        ).lower() in {"1", "true", "yes"}
+
+        saved = []
+        errors = []
+        for uploaded in uploads:
+            raw_name = getattr(uploaded, "name", "") or ""
+            original_name = Path(raw_name).name
+            try:
+                if not original_name:
+                    raise ValueError("Missing filename")
+                # Reject client-supplied paths even if basename alone would be safe.
+                if (
+                    raw_name != original_name
+                    or "/" in raw_name
+                    or "\\" in raw_name
+                    or ".." in Path(raw_name).parts
+                ):
+                    raise ValueError("Invalid upload filename")
+                if uploaded.size is not None and uploaded.size > PROJECT_UPLOAD_MAX_BYTES:
+                    raise ValueError(
+                        f"File exceeds maximum size of "
+                        f"{PROJECT_UPLOAD_MAX_BYTES // (1024 * 1024)} MB"
+                    )
+
+                dest = safe_project_upload_path(project, original_name, create_dir=True)
+                existed = dest.exists()
+                if existed and not overwrite:
+                    raise ValueError(
+                        f"File '{original_name}' already exists "
+                        "(pass overwrite=true to replace)"
+                    )
+
+                # Stream to a temp file beside the destination, then rename.
+                tmp_path = dest.with_name(f".{dest.name}.uploading")
+                try:
+                    written = 0
+                    with open(tmp_path, "wb") as out:
+                        for chunk in uploaded.chunks():
+                            written += len(chunk)
+                            if written > PROJECT_UPLOAD_MAX_BYTES:
+                                raise ValueError(
+                                    f"File exceeds maximum size of "
+                                    f"{PROJECT_UPLOAD_MAX_BYTES // (1024 * 1024)} MB"
+                                )
+                            out.write(chunk)
+                    os.replace(tmp_path, dest)
+                finally:
+                    if tmp_path.exists():
+                        tmp_path.unlink(missing_ok=True)
+
+                saved.append(
+                    {
+                        "filename": dest.name,
+                        "size_bytes": dest.stat().st_size,
+                        "overwritten": existed,
+                    }
+                )
+            except ValueError as exc:
+                errors.append({"filename": original_name or None, "error": str(exc)})
+            except Exception as exc:
+                logger.exception(
+                    "Project file upload failed for %s / %s", workflow_id, original_name
+                )
+                errors.append(
+                    {
+                        "filename": original_name or None,
+                        "error": f"Upload failed: {exc}",
+                    }
+                )
+
+        if not saved and errors:
+            status_code = 400
+            return JsonResponse(
+                {
+                    "status": "error",
+                    "max_bytes": PROJECT_UPLOAD_MAX_BYTES,
+                    "uploaded": saved,
+                    "errors": errors,
+                },
+                status=status_code,
+            )
+
+        return JsonResponse(
+            {
+                "status": "success" if not errors else "partial",
+                "max_bytes": PROJECT_UPLOAD_MAX_BYTES,
+                "uploaded": saved,
+                "errors": errors,
+            },
+            status=201 if saved and not errors else 200,
+        )
+
+    def delete(self, request, workflow_id):
+        project = get_accessible_project(request, workflow_id, write=True)
+        filename = (
+            request.query_params.get("filename")
+            or request.data.get("filename")
+            or ""
+        ).strip()
+        if not filename:
+            return JsonResponse({"error": "filename is required"}, status=400)
+
+        try:
+            target = safe_project_upload_path(project, filename, create_dir=False)
+        except ValueError as exc:
+            return JsonResponse({"error": str(exc)}, status=400)
+
+        if not target.exists() or not target.is_file():
+            return JsonResponse({"error": "File not found"}, status=404)
+
+        target.unlink()
+        return JsonResponse(
+            {"status": "success", "filename": filename, "deleted": True}
+        )
 
 
 @method_decorator(csrf_exempt, name="dispatch")

--- a/gui/workflow_backend/django-project/config/settings.py
+++ b/gui/workflow_backend/django-project/config/settings.py
@@ -232,8 +232,9 @@ PROJECTS_ROOT = os.path.join(BASE_DIR, "codes/projects")
 # FILE UPLOAD SETTINGS
 # ==============================================================================
 
-FILE_UPLOAD_MAX_MEMORY_SIZE = 5 * 1024 * 1024  # 5MB
-DATA_UPLOAD_MAX_MEMORY_SIZE = 5 * 1024 * 1024  # 5MB
+# Keep aligned with nginx client_max_body_size and path_utils.PROJECT_UPLOAD_MAX_BYTES
+FILE_UPLOAD_MAX_MEMORY_SIZE = 50 * 1024 * 1024  # 50MB
+DATA_UPLOAD_MAX_MEMORY_SIZE = 50 * 1024 * 1024  # 50MB
 
 # ==============================================================================
 # TEMPLATES

--- a/gui/workflow_backend/django-project/tests/test_project_files.py
+++ b/gui/workflow_backend/django-project/tests/test_project_files.py
@@ -1,0 +1,120 @@
+"""Tests for project data file upload / list / delete API."""
+import pytest
+from django.core.files.uploadedfile import SimpleUploadedFile
+from django.urls import reverse
+
+from app.workflow.models import FlowProject
+from app.workflow.path_utils import PROJECT_UPLOAD_MAX_BYTES, projects_root
+
+pytestmark = pytest.mark.django_db
+
+
+def _make_project(owner, *, visibility="private", name="DataProj"):
+    return FlowProject.objects.create(name=name, owner=owner, visibility=visibility)
+
+
+def _files_url(project):
+    return reverse("workflow:workflow-project-files", args=[project.id])
+
+
+def test_upload_list_delete_roundtrip(auth_client, user_alice, tmp_path, settings):
+    settings.BASE_DIR = tmp_path
+    project = _make_project(user_alice)
+    client = auth_client(user_alice)
+    url = _files_url(project)
+
+    payload = b"col1,col2\n1,2\n"
+    upload = SimpleUploadedFile("demo.csv", payload, content_type="text/csv")
+    resp = client.post(url, {"file": upload}, format="multipart")
+    assert resp.status_code == 201, resp.content
+    body = resp.json()
+    assert body["status"] == "success"
+    assert body["uploaded"][0]["filename"] == "demo.csv"
+    assert body["uploaded"][0]["size_bytes"] == len(payload)
+
+    dest = projects_root() / str(project.id) / "demo.csv"
+    assert dest.is_file()
+    assert dest.read_bytes() == payload
+
+    resp = client.get(url)
+    assert resp.status_code == 200
+    names = [f["filename"] for f in resp.json()["files"]]
+    assert "demo.csv" in names
+    assert resp.json()["max_bytes"] == PROJECT_UPLOAD_MAX_BYTES
+
+    resp = client.delete(f"{url}?filename=demo.csv")
+    assert resp.status_code == 200
+    assert resp.json()["deleted"] is True
+    assert not dest.exists()
+
+
+def test_reject_path_traversal_and_protected(auth_client, user_alice, tmp_path, settings):
+    settings.BASE_DIR = tmp_path
+    project = _make_project(user_alice)
+    client = auth_client(user_alice)
+    url = _files_url(project)
+
+    from app.workflow.path_utils import safe_project_upload_path
+    import pytest as _pytest
+
+    with _pytest.raises(ValueError, match="Invalid upload filename"):
+        safe_project_upload_path(project, "../escape.csv")
+    with _pytest.raises(ValueError, match="Invalid upload filename"):
+        safe_project_upload_path(project, "subdir/data.csv")
+    with _pytest.raises(ValueError, match="protected"):
+        safe_project_upload_path(project, "workflow.py")
+
+    protected = SimpleUploadedFile("workflow.py", b"print(1)\n", content_type="text/x-python")
+    resp = client.post(url, {"file": protected}, format="multipart")
+    assert resp.status_code == 400
+    assert "protected" in resp.json()["errors"][0]["error"].lower()
+
+
+def test_reject_disallowed_extension(auth_client, user_alice, tmp_path, settings):
+    settings.BASE_DIR = tmp_path
+    project = _make_project(user_alice)
+    client = auth_client(user_alice)
+    url = _files_url(project)
+
+    exe = SimpleUploadedFile("malware.exe", b"MZ", content_type="application/octet-stream")
+    resp = client.post(url, {"file": exe}, format="multipart")
+    assert resp.status_code == 400
+    assert "not allowed" in resp.json()["errors"][0]["error"].lower()
+
+
+def test_overwrite_requires_flag(auth_client, user_alice, tmp_path, settings):
+    settings.BASE_DIR = tmp_path
+    project = _make_project(user_alice)
+    client = auth_client(user_alice)
+    url = _files_url(project)
+
+    first = SimpleUploadedFile("data.csv", b"a\n", content_type="text/csv")
+    assert client.post(url, {"file": first}, format="multipart").status_code == 201
+
+    second = SimpleUploadedFile("data.csv", b"b\n", content_type="text/csv")
+    resp = client.post(url, {"file": second}, format="multipart")
+    assert resp.status_code == 400
+
+    third = SimpleUploadedFile("data.csv", b"c\n", content_type="text/csv")
+    resp = client.post(url, {"file": third, "overwrite": "true"}, format="multipart")
+    assert resp.status_code == 201
+    assert (projects_root() / str(project.id) / "data.csv").read_bytes() == b"c\n"
+
+
+def test_stranger_cannot_upload_private(auth_client, user_alice, user_bob, tmp_path, settings):
+    settings.BASE_DIR = tmp_path
+    project = _make_project(user_alice, visibility="private")
+    client = auth_client(user_bob)
+    url = _files_url(project)
+    upload = SimpleUploadedFile("x.csv", b"1\n", content_type="text/csv")
+    assert client.post(url, {"file": upload}, format="multipart").status_code == 404
+
+
+def test_public_non_owner_can_upload(auth_client, user_alice, user_bob, tmp_path, settings):
+    settings.BASE_DIR = tmp_path
+    project = _make_project(user_alice, visibility="public")
+    client = auth_client(user_bob)
+    url = _files_url(project)
+    upload = SimpleUploadedFile("shared.csv", b"1\n", content_type="text/csv")
+    resp = client.post(url, {"file": upload}, format="multipart")
+    assert resp.status_code == 201, resp.content

--- a/gui/workflow_frontend/src/api/projectFilesApi.ts
+++ b/gui/workflow_frontend/src/api/projectFilesApi.ts
@@ -1,0 +1,110 @@
+import { createAuthHeaders } from "./authHeaders";
+
+export const PROJECT_UPLOAD_MAX_BYTES = 50 * 1024 * 1024;
+
+export type ProjectFileInfo = {
+  filename: string;
+  size_bytes: number;
+  modified_at?: number;
+};
+
+export type ProjectFilesListResponse = {
+  status: string;
+  project_id: string;
+  max_bytes: number;
+  files: ProjectFileInfo[];
+};
+
+export type ProjectFileUploadResult = {
+  filename: string;
+  size_bytes: number;
+  overwritten: boolean;
+};
+
+export type ProjectFilesUploadResponse = {
+  status: string;
+  max_bytes: number;
+  uploaded: ProjectFileUploadResult[];
+  errors: { filename: string | null; error: string }[];
+};
+
+async function authHeadersForMultipart(): Promise<Record<string, string>> {
+  const headers = await createAuthHeaders();
+  // Browser must set multipart boundary; JSON Content-Type breaks FormData.
+  delete headers["Content-Type"];
+  return headers;
+}
+
+export async function listProjectFiles(
+  projectId: string
+): Promise<ProjectFilesListResponse> {
+  const headers = await createAuthHeaders();
+  const response = await fetch(`/api/workflow/${projectId}/files/`, {
+    method: "GET",
+    credentials: "include",
+    headers,
+  });
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({}));
+    throw new Error(body.error || `Failed to list files (${response.status})`);
+  }
+  return response.json();
+}
+
+export async function uploadProjectFiles(
+  projectId: string,
+  files: File[],
+  options: { overwrite?: boolean } = {}
+): Promise<ProjectFilesUploadResponse> {
+  const formData = new FormData();
+  for (const file of files) {
+    formData.append("file", file, file.name);
+  }
+  if (options.overwrite) {
+    formData.append("overwrite", "true");
+  }
+
+  const headers = await authHeadersForMultipart();
+  const response = await fetch(`/api/workflow/${projectId}/files/`, {
+    method: "POST",
+    credentials: "include",
+    headers,
+    body: formData,
+  });
+
+  const body = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    const firstError = body.errors?.[0]?.error;
+    throw new Error(
+      firstError || body.error || `Upload failed (${response.status})`
+    );
+  }
+  return body as ProjectFilesUploadResponse;
+}
+
+export async function deleteProjectFile(
+  projectId: string,
+  filename: string
+): Promise<void> {
+  const headers = await createAuthHeaders();
+  const url = `/api/workflow/${projectId}/files/?filename=${encodeURIComponent(
+    filename
+  )}`;
+  const response = await fetch(url, {
+    method: "DELETE",
+    credentials: "include",
+    headers,
+  });
+  if (!response.ok) {
+    const body = await response.json().catch(() => ({}));
+    throw new Error(body.error || `Delete failed (${response.status})`);
+  }
+}
+
+export function formatBytes(sizeInBytes: number): string {
+  if (sizeInBytes < 1024) return `${sizeInBytes} B`;
+  if (sizeInBytes < 1024 * 1024) {
+    return `${(sizeInBytes / 1024).toFixed(1)} KB`;
+  }
+  return `${(sizeInBytes / (1024 * 1024)).toFixed(1)} MB`;
+}

--- a/gui/workflow_frontend/src/views/home/components/ProjectDataUploadModal.tsx
+++ b/gui/workflow_frontend/src/views/home/components/ProjectDataUploadModal.tsx
@@ -1,0 +1,307 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  Box,
+  Button,
+  Checkbox,
+  Flex,
+  FormLabel,
+  HStack,
+  IconButton,
+  Input,
+  List,
+  ListItem,
+  Modal,
+  ModalBody,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  Progress,
+  Text,
+  VStack,
+  useToast,
+} from "@chakra-ui/react";
+import { AttachmentIcon, DeleteIcon } from "@chakra-ui/icons";
+import {
+  PROJECT_UPLOAD_MAX_BYTES,
+  deleteProjectFile,
+  formatBytes,
+  listProjectFiles,
+  ProjectFileInfo,
+  uploadProjectFiles,
+} from "../../../api/projectFilesApi";
+
+type Props = {
+  projectId: string | null;
+  projectName?: string;
+  isOpen: boolean;
+  onClose: () => void;
+};
+
+export function ProjectDataUploadModal({
+  projectId,
+  projectName,
+  isOpen,
+  onClose,
+}: Props) {
+  const toast = useToast();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [files, setFiles] = useState<ProjectFileInfo[]>([]);
+  const [maxBytes, setMaxBytes] = useState(PROJECT_UPLOAD_MAX_BYTES);
+  const [selected, setSelected] = useState<File[]>([]);
+  const [overwrite, setOverwrite] = useState(false);
+  const [loadingList, setLoadingList] = useState(false);
+  const [uploading, setUploading] = useState(false);
+
+  const refresh = useCallback(async () => {
+    if (!projectId) return;
+    setLoadingList(true);
+    try {
+      const data = await listProjectFiles(projectId);
+      setFiles(data.files || []);
+      if (data.max_bytes) setMaxBytes(data.max_bytes);
+    } catch (err: any) {
+      toast({
+        title: "Could not list project files",
+        description: err?.message || String(err),
+        status: "error",
+        duration: 4000,
+        isClosable: true,
+      });
+    } finally {
+      setLoadingList(false);
+    }
+  }, [projectId, toast]);
+
+  useEffect(() => {
+    if (isOpen && projectId) {
+      setSelected([]);
+      setOverwrite(false);
+      void refresh();
+    }
+  }, [isOpen, projectId, refresh]);
+
+  const onPickFiles = (list: FileList | null) => {
+    if (!list || list.length === 0) return;
+    const next: File[] = [];
+    for (let i = 0; i < list.length; i++) {
+      const file = list.item(i);
+      if (!file) continue;
+      if (file.size > maxBytes) {
+        toast({
+          title: "File too large",
+          description: `${file.name} exceeds ${formatBytes(maxBytes)}`,
+          status: "warning",
+          duration: 4000,
+          isClosable: true,
+        });
+        continue;
+      }
+      next.push(file);
+    }
+    setSelected((prev) => [...prev, ...next]);
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  const handleUpload = async () => {
+    if (!projectId || selected.length === 0) return;
+    setUploading(true);
+    try {
+      const result = await uploadProjectFiles(projectId, selected, { overwrite });
+      const okCount = result.uploaded?.length || 0;
+      const errCount = result.errors?.length || 0;
+      if (okCount > 0) {
+        toast({
+          title: errCount ? "Upload partially completed" : "Upload complete",
+          description: `${okCount} file(s) saved to the project folder${
+            errCount ? `; ${errCount} failed` : ""
+          }.`,
+          status: errCount ? "warning" : "success",
+          duration: 4000,
+          isClosable: true,
+        });
+      }
+      if (errCount && okCount === 0) {
+        toast({
+          title: "Upload failed",
+          description: result.errors.map((e) => e.error).join("; "),
+          status: "error",
+          duration: 5000,
+          isClosable: true,
+        });
+      } else if (errCount) {
+        toast({
+          title: "Some files failed",
+          description: result.errors.map((e) => `${e.filename}: ${e.error}`).join("; "),
+          status: "warning",
+          duration: 5000,
+          isClosable: true,
+        });
+      }
+      setSelected([]);
+      await refresh();
+    } catch (err: any) {
+      toast({
+        title: "Upload failed",
+        description: err?.message || String(err),
+        status: "error",
+        duration: 5000,
+        isClosable: true,
+      });
+    } finally {
+      setUploading(false);
+    }
+  };
+
+  const handleDelete = async (filename: string) => {
+    if (!projectId) return;
+    try {
+      await deleteProjectFile(projectId, filename);
+      toast({
+        title: "File deleted",
+        description: filename,
+        status: "success",
+        duration: 2000,
+        isClosable: true,
+      });
+      await refresh();
+    } catch (err: any) {
+      toast({
+        title: "Delete failed",
+        description: err?.message || String(err),
+        status: "error",
+        duration: 4000,
+        isClosable: true,
+      });
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} size="lg">
+      <ModalOverlay />
+      <ModalContent>
+        <ModalHeader>
+          Upload data to project
+          {projectName ? (
+            <Text as="span" fontWeight="normal" fontSize="md" color="gray.600">
+              {" "}
+              — {projectName}
+            </Text>
+          ) : null}
+        </ModalHeader>
+        <ModalBody>
+          <Text fontSize="sm" color="gray.600" mb={3}>
+            Files are saved into this project&apos;s folder (
+            <Text as="span" fontFamily="mono" fontSize="xs">
+              codes/projects/&lt;id&gt;/
+            </Text>
+            ), the same place JupyterLab opens. Max size per file:{" "}
+            {formatBytes(maxBytes)}.
+          </Text>
+
+          <FormLabel fontSize="sm">Select files</FormLabel>
+          <Input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            display="none"
+            onChange={(e) => onPickFiles(e.target.files)}
+          />
+          <Button
+            leftIcon={<AttachmentIcon />}
+            onClick={() => fileInputRef.current?.click()}
+            variant="outline"
+            size="sm"
+            mb={2}
+          >
+            Choose files
+          </Button>
+
+          {selected.length > 0 && (
+            <Box mb={3} p={2} bg="gray.50" borderRadius="md">
+              <Text fontSize="xs" fontWeight="semibold" mb={1}>
+                Ready to upload ({selected.length})
+              </Text>
+              <List spacing={1}>
+                {selected.map((f) => (
+                  <ListItem key={`${f.name}-${f.size}`} fontSize="sm">
+                    {f.name}{" "}
+                    <Text as="span" color="gray.500">
+                      ({formatBytes(f.size)})
+                    </Text>
+                  </ListItem>
+                ))}
+              </List>
+              <Checkbox
+                mt={2}
+                isChecked={overwrite}
+                onChange={(e) => setOverwrite(e.target.checked)}
+                size="sm"
+              >
+                Overwrite existing files with the same name
+              </Checkbox>
+            </Box>
+          )}
+
+          {uploading && <Progress size="xs" isIndeterminate mb={3} />}
+
+          <Flex justify="space-between" align="center" mb={1}>
+            <FormLabel fontSize="sm" mb={0}>
+              Files in project folder
+            </FormLabel>
+            <Button size="xs" variant="ghost" onClick={() => void refresh()} isLoading={loadingList}>
+              Refresh
+            </Button>
+          </Flex>
+          {files.length === 0 ? (
+            <Text fontSize="sm" color="gray.500">
+              {loadingList ? "Loading…" : "No files yet."}
+            </Text>
+          ) : (
+            <VStack align="stretch" spacing={1} maxH="220px" overflowY="auto">
+              {files.map((f) => (
+                <HStack
+                  key={f.filename}
+                  justify="space-between"
+                  px={2}
+                  py={1}
+                  borderWidth={1}
+                  borderColor="gray.100"
+                  borderRadius="md"
+                >
+                  <Box>
+                    <Text fontSize="sm">{f.filename}</Text>
+                    <Text fontSize="xs" color="gray.500">
+                      {formatBytes(f.size_bytes)}
+                    </Text>
+                  </Box>
+                  <IconButton
+                    aria-label={`Delete ${f.filename}`}
+                    icon={<DeleteIcon />}
+                    size="xs"
+                    variant="ghost"
+                    colorScheme="red"
+                    onClick={() => void handleDelete(f.filename)}
+                  />
+                </HStack>
+              ))}
+            </VStack>
+          )}
+        </ModalBody>
+        <ModalFooter>
+          <Button variant="ghost" mr={3} onClick={onClose} isDisabled={uploading}>
+            Close
+          </Button>
+          <Button
+            colorScheme="blue"
+            onClick={() => void handleUpload()}
+            isLoading={uploading}
+            isDisabled={selected.length === 0}
+          >
+            Upload
+          </Button>
+        </ModalFooter>
+      </ModalContent>
+    </Modal>
+  );
+}

--- a/gui/workflow_frontend/src/views/home/components/projectSelector.tsx
+++ b/gui/workflow_frontend/src/views/home/components/projectSelector.tsx
@@ -26,7 +26,7 @@ import {
   Divider,
   useDisclosure,
 } from '@chakra-ui/react';
-import { CheckIcon, WarningIcon, DeleteIcon, EditIcon, InfoOutlineIcon } from '@chakra-ui/icons';
+import { CheckIcon, WarningIcon, DeleteIcon, EditIcon, InfoOutlineIcon, AttachmentIcon } from '@chakra-ui/icons';
 import { FiMenu, FiPlay } from 'react-icons/fi';
 import { useTabContext } from '../../../components/tabs/TabManager';
 import { useAuth } from '../../../auth/authContext';
@@ -36,6 +36,7 @@ import { runWorkflowStream } from '../../../api/workflowRunApi';
 import { WorkflowContextEditor } from '../../../components/WorkflowContextEditor';
 import { AttributionEditor } from './attributionEditor';
 import { AcknowledgmentModal } from './acknowledgmentModal';
+import { ProjectDataUploadModal } from './ProjectDataUploadModal';
 
 const emptyAttribution = (): AttributionDraft => ({
   doi: '',
@@ -77,6 +78,7 @@ export const ProjectSelector = ({
   const [hpcTargetDraft, setHpcTargetDraft] = useState<HpcTarget>('');
   const [attributionDraft, setAttributionDraft] = useState<AttributionDraft>(emptyAttribution());
   const { isOpen: isAckOpen, onOpen: onAckOpen, onClose: onAckClose } = useDisclosure();
+  const { isOpen: isUploadOpen, onOpen: onUploadOpen, onClose: onUploadClose } = useDisclosure();
   const currentProject = selectedProject
     ? projects.find((p) => p.id === selectedProject) ?? null
     : null;
@@ -614,6 +616,24 @@ export const ProjectSelector = ({
               </Tooltip>
             )}
 
+            {selectedProject && currentProject?.can_edit && (
+              <Tooltip label="Upload data to project folder" placement="top">
+                <IconButton
+                  aria-label="Upload data to project"
+                  icon={<AttachmentIcon />}
+                  size="sm"
+                  colorScheme="purple"
+                  variant="outline"
+                  onClick={onUploadOpen}
+                  _hover={{
+                    bg: "purple.50",
+                    borderColor: "purple.400"
+                  }}
+                  marginTop={2}
+                />
+              </Tooltip>
+            )}
+
             {selectedProject && onProjectDelete && currentProject?.can_delete && (
               <Tooltip label="Delete project" placement="top">
                 <IconButton
@@ -653,7 +673,7 @@ export const ProjectSelector = ({
             >
               {getStatusMessage()}
             </Text>
-          )}LogViewDialog
+          )}
           
           {/* Project information (displayed only when selected) */}
           {selectedProject && (
@@ -681,6 +701,13 @@ export const ProjectSelector = ({
         project={currentProject}
         isOpen={isAckOpen}
         onClose={onAckClose}
+      />
+
+      <ProjectDataUploadModal
+        projectId={selectedProject}
+        projectName={currentProject?.name}
+        isOpen={isUploadOpen}
+        onClose={onUploadClose}
       />
 
       <Modal isOpen={isContextOpen} onClose={onContextClose} size="xl">


### PR DESCRIPTION
## Summary
- Adds `GET/POST/DELETE /api/workflow/<id>/files/` to list, upload, and delete files in `codes/projects/<id>/` (same folder JupyterLab opens).
- New **Upload data to project** control in the project panel (editable projects), with overwrite option, size feedback, and file list/delete.
- Raises Django upload memory limits to **50MB** and documents/ships nginx `client_max_body_size 50M` for `/api/` and `/jupyter/` so small CSV uploads no longer hit **413 Request Entity Too Large**.

## Safety
- Path traversal rejected; basename-only writes under the project dir.
- Extension allowlist (csv/zip/h5/nii.gz/…).
- Refuses overwriting `workflow.py`, `workflow.ipynb`, `run.sbatch`.
- Requires project write access (`get_accessible_project(..., write=True)`).

## Deploy notes (host nginx)
Production uses `/etc/nginx/snippets/neuro-workflow-proxy.conf`, which currently has **no** `client_max_body_size` (nginx default **1m** → Mark’s 413). After merge:

```bash
sudo cp gui/nginx/neuro-workflow-proxy.conf /etc/nginx/snippets/neuro-workflow-proxy.conf
sudo nginx -t && sudo systemctl reload nginx
```

Then rebuild/restart frontend (prod static image) and restart backend so Django limits reload.

## Test plan
- [ ] Backend: `pytest django-project/tests/test_project_files.py` (6 tests)
- [ ] UI: select a project you can edit → paperclip **Upload data** → upload a small `.csv` → appears in list and in Jupyter project folder
- [ ] Overwrite off → second upload of same name fails; overwrite on → succeeds
- [ ] JupyterLab Upload of a ~2MB CSV succeeds after nginx reload (no 413)
- [ ] Non-editor / private stranger cannot upload