### PR TITLE
Add Keycloak-gated catalog search (mdb Stage 2)

### DIFF
--- a/deployment/DEPLOY_MDB_CATALOG.md
+++ b/deployment/DEPLOY_MDB_CATALOG.md
@@ -1,0 +1,156 @@
+# Deploy NeuroWorkflow catalog (mdb Stage 2)
+
+How to reproduce the Catalog tab from `main` after this PR. Secrets stay in
+gitignored `.env` files — never commit tokens, keys, or `.env`.
+
+Implementation: `docs/CATALOG_SEARCH.md`. HTTP contract:
+`deployment/MDB_CLIENT_CONTRACT.md`.
+
+mdb itself lives in `oist/bm_mindsdb` (separate compose project). This repo
+only talks to it over HTTP.
+
+---
+
+## What you are wiring
+
+```
+Keycloak user → nginx → NeuroWorkflow /api/catalog/* → mdb-mindsdb:8004
+```
+
+- Public ports stay SSH / 80 / 443. mdb binds **`127.0.0.1:8004`** only.
+- **Do not** add nginx `/mdb`, iframe the mdb UI, or publish `0.0.0.0:8004`.
+- **Do not** set `MDB_ADMIN_TOKEN` in NeuroWorkflow.
+- **Do not** put `MDB_*` in `VITE_*`, `gui/.env`, or the frontend image.
+
+---
+
+## 1. Pin the Docker network (this repo)
+
+`gui/docker-compose.yml` names the backend network:
+
+```yaml
+networks:
+  workflow:
+    name: neuro-workflow_workflow
+```
+
+After `docker compose up` in `gui/`, `docker network ls` should show
+`neuro-workflow_workflow`. Backend hostname on that network is `backend`.
+
+---
+
+## 2. Attach mdb (bm_mindsdb repo, not this one)
+
+On the mdb compose overlay, join the **existing** NeuroWorkflow network. Example
+(hostnames and file names may differ slightly in `oist/bm_mindsdb`):
+
+```yaml
+services:
+  mdb-mindsdb:
+    networks:
+      - default
+      - neuro-workflow_workflow
+
+networks:
+  neuro-workflow_workflow:
+    external: true
+    name: neuro-workflow_workflow
+```
+
+Recreate **mdb-mindsdb only** (keep its volume). Do not recreate the
+NeuroWorkflow backend (ssh-agent). Bind stays `127.0.0.1:8004`.
+
+After attach, from the NeuroWorkflow **backend container**:
+
+```bash
+curl -sS -o /dev/null -w '%{http_code}\n' http://mdb-mindsdb:8004/
+# expect 200
+```
+
+Host check (operators / SSH tunnel):
+
+```bash
+curl -sS -o /dev/null -w '%{http_code}\n' http://127.0.0.1:8004/
+# expect 200
+```
+
+If mdb was recreated, start in-container MindsDB again with the **mdb admin**
+token (SSH / mdb UI). NeuroWorkflow does not start or stop MindsDB.
+
+---
+
+## 3. NeuroWorkflow backend env (gitignored)
+
+Copy placeholders from `gui/workflow_backend/env.template`. In
+**`gui/workflow_backend/.env` only** (never print or commit the token):
+
+```
+MDB_BASE_URL=http://mdb-mindsdb:8004
+MDB_API_TOKEN=<same search token as in the mdb .env>
+# optional:
+# MDB_TIMEOUT=15
+```
+
+Copy `MDB_API_TOKEN` from the mdb environment file on the host. Do not put
+`MDB_ADMIN_TOKEN` here.
+
+`get_mdb_config()` reads process env first, then the bind-mounted `.env`
+(`override=False`), so a later token add can be picked up with gunicorn SIGHUP
+without recreating the backend.
+
+---
+
+## 4. Load code without dropping Slurm ssh-agent
+
+Backend code is bind-mounted in this compose. Prefer:
+
+```bash
+# inside neuro-workflow-backend-1: SIGHUP the gunicorn master (container PID 1)
+python3 -c "import os,signal; os.kill(1, signal.SIGHUP)"
+```
+
+Recreate gunicorn/backend only if the new env vars are not visible after
+SIGHUP. Recreate drops ssh-agent; you would need `ssh-add` again.
+
+Frontend in production is a **built nginx image** (no src mount). Rebuild and
+recreate **frontend only**:
+
+```bash
+cd gui
+docker compose -f docker-compose.yml -f docker-compose.prod.yml build frontend
+docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --no-deps --no-build frontend
+```
+
+MCP: `workflow_mcp.py` is bind-mounted; `docker compose restart mcp` (or
+`--no-deps`) is enough for the four catalog tools.
+
+Do not `compose down`, do not recreate Hub / db / Keycloak for this feature.
+
+---
+
+## 5. Smoke
+
+Unauthenticated API (route exists, Keycloak required):
+
+```bash
+curl -sS -o /dev/null -w '%{http_code}\n' http://127.0.0.1:3000/api/catalog/statistics/
+# 401
+```
+
+Logged-in user in the browser: **Catalog** in the header → `/catalog` →
+statistics chips load → keyword search (e.g. `mouse`) returns rows → open a
+record.
+
+Failures to report to the mdb side: HTTP status and whether it was
+statistics, search, or lookup. Typical causes: 401/403 from mdb (wrong/missing
+search token) or timeout (wrong `MDB_BASE_URL`).
+
+---
+
+## Rollback
+
+- Remove `MDB_BASE_URL` / `MDB_API_TOKEN` from `gui/workflow_backend/.env` and
+  SIGHUP gunicorn (Catalog API returns `catalog_unconfigured`).
+- Revert the frontend image to the previous build if you need the header link
+  gone.
+- Leave mdb running; it does not depend on NeuroWorkflow.

--- a/deployment/MDB_CLIENT_CONTRACT.md
+++ b/deployment/MDB_CLIENT_CONTRACT.md
@@ -1,0 +1,165 @@
+# mdb client contract — NeuroWorkflow catalog
+
+This is the HTTP contract NeuroWorkflow’s **backend** should call. The browser
+must never talk to port 8004 and must never see mdb tokens.
+
+Companion (NeuroWorkflow implementation + UI): `docs/CATALOG_SEARCH.md`.  
+Companion (how to wire the two stacks): `deployment/DEPLOY_MDB_CATALOG.md`.
+
+mdb is a separate repo (`oist/bm_mindsdb`). Do not put mdb source or secrets in
+this repository.
+
+---
+
+## Architecture (fixed)
+
+```
+User browser  →  NeuroWorkflow (Keycloak, nginx 80/443)
+                      ↓  same-origin /api/...  (no mdb token)
+              NeuroWorkflow backend
+                      ↓  Authorization: Bearer <MDB_API_TOKEN>
+              mdb-mindsdb:8004   (Docker network neuro-workflow_workflow)
+```
+
+Only SSH / HTTP / HTTPS should be public; Docker `ports:` must bind
+`127.0.0.1`. **Do not** add nginx `/mdb`, iframe the mdb dashboard, put tokens
+in `VITE_*`, or publish `0.0.0.0:8004`.
+
+`MDB_BASE_URL=http://172.17.0.1:8004` **does not work** while 8004 is
+loopback-only, and it is **not** a public bind. Use a shared Docker network and
+`http://mdb-mindsdb:8004`. Keep host `127.0.0.1:8004` for operators (SSH tunnel).
+
+mdb has no Keycloak. **Catalog admin for NeuroWorkflow: none.** Sync stays
+SSH-only (`MDB_ADMIN_TOKEN` is not used by NW). Daily harvest is
+`MDB_AUTO_SYNC_INTERVAL` inside mdb.
+
+---
+
+## Tokens (backend `.env` only)
+
+| Variable | Who may send it | Used for |
+|---|---|---|
+| `MDB_API_TOKEN` | NW backend only (`gui/workflow_backend/.env`). Never `VITE_*`, never frontend env, never `gui/.env`. Never commit the value. | Stage 2 search / statistics / lookup |
+| `MDB_ADMIN_TOKEN` | Operators (SSH mdb UI / curl). **Not** used by NeuroWorkflow. Never commit. | Sync, ingest, NWB, MindsDB process |
+
+Header: `Authorization: Bearer <token>`.  
+Mutating POST/PUT/PATCH also need `Content-Type: application/json` (415
+otherwise). Empty body → send `{}`.
+
+**Always send `MDB_API_TOKEN` from the proxy**, even on GETs that mdb currently
+leaves ungated (`/api/api_statistics`, keyword `GET /api/catalog_search`). Do
+not depend on ungated holes.
+
+---
+
+## HTTP errors from mdb
+
+| Code | When |
+|---|---|
+| **401** | Token required but missing, or token unset on mdb |
+| **403** | Wrong token (search token on an admin route, or vice versa) |
+| **400** | Bad input (`query`/`id` missing, unsupported `mode`/`table`) |
+| **404** | Dataset / conversation not found |
+| **410** | Retired: `/api/execute_sql`, `/api/predict_*`, … |
+| **415** | Mutating POST without `Content-Type: application/json` |
+| **500** | Generic `{ "status": "error", "error": "Request failed" }` |
+| **503** | Orchestrator not ready, or agent search “not ready” (MindsDB down) |
+
+Auth error JSON: `{ "status": "error", "error": "<message>" }`.
+
+---
+
+## Stage 2 — proxy these (search / catalog UI)
+
+From the NW backend container, `$MDB_BASE_URL` is `http://mdb-mindsdb:8004`.
+Operators on the host use `http://127.0.0.1:8004`.
+
+Catalog sources (internal keys): `dandi`, `cbs`, `brainminds`, `bmb_human`, plus
+local `aws` (display `SRPBS_TS`). Records include `source` and `source_display`.
+
+### Health / counts
+
+```bash
+curl -sS -H "Authorization: Bearer $MDB_API_TOKEN" \
+  "$MDB_BASE_URL/api/api_statistics"
+```
+
+Optional: `GET /api/status` (counts + whether MindsDB is up).
+
+### Keyword search (no MindsDB)
+
+```bash
+curl -sS -X POST "$MDB_BASE_URL/api/catalog_search" \
+  -H "Content-Type: application/json" \
+  -H "Authorization: Bearer $MDB_API_TOKEN" \
+  -d '{"query":"mouse","mode":"keyword","limit":20}'
+```
+
+Optional `source` (e.g. `"dandi"`). `limit` clamped 1–200 (default 50).
+
+Also: `GET $MDB_BASE_URL/api/catalog_search?q=mouse&mode=keyword&limit=20`.
+
+Browse without a query: `GET /api/api_datasets?source=dandi&limit=20`.
+
+### Record lookup
+
+```bash
+curl -sS -H "Authorization: Bearer $MDB_API_TOKEN" \
+  "$MDB_BASE_URL/api/catalog_lookup?table=api_datasets&source=dandi&id=000015"
+```
+
+NeuroWorkflow Stage 2 allows **`table=api_datasets` only**.
+
+---
+
+## Present on mdb, not proxied in Stage 2
+
+Agent / intelligent search and catalog agent chat exist on mdb (`mode=agent`,
+`mode=intelligent`, `/api/mindsdb_agent/chat`). They need MindsDB + OpenAI on
+the mdb side. NeuroWorkflow does **not** expose them in this PR.
+
+Admin routes require `MDB_ADMIN_TOKEN` (search token → 403). Do not proxy these
+to ordinary Keycloak users:
+
+| Method | Path |
+|---|---|
+| POST | `/api/sync_apis` |
+| POST | `/api/ingest_local_catalog` |
+| POST | `/api/process_nwb_file` |
+| POST | `/api/start_mindsdb_server` |
+| POST | `/api/stop_mindsdb_server` |
+| POST | `/api/connect_mindsdb_datasource` |
+| POST | `/api/mindsdb_agent/setup` |
+| POST | `/api/mindsdb_agent/drop` |
+
+Never proxy `/api/execute_sql` or retired predict routes (410). Never call
+MindsDB on 47334 (unpublished, in-container only).
+
+---
+
+## Frozen Stage 2 URL layout
+
+Keycloak-gated. Forward JSON as-is. Do not copy the catalog into Postgres.
+
+| NW (Keycloak) | mdb |
+|---|---|
+| `GET  /api/catalog/statistics/` | `GET /api/api_statistics` |
+| `POST /api/catalog/search/` | `POST /api/catalog_search` (**`mode=keyword` only**) |
+| `GET  /api/catalog/lookup/` | `GET /api/catalog_lookup` |
+| `GET  /api/catalog/datasets/` | `GET /api/api_datasets` |
+
+**Not in this PR:** `/api/catalog/chat`, `/api/catalog/sync`, agent/intelligent
+modes, `GET /api/local_catalog/…`.
+
+---
+
+## Frozen answers
+
+1. **URL layout** — table above.
+2. **Catalog admin** — **none**. No Sync button in NeuroWorkflow.
+3. **Docker network** — mdb joins existing **`neuro-workflow_workflow`** as
+   hostname `mdb-mindsdb`. `MDB_BASE_URL=http://mdb-mindsdb:8004`. Keep host
+   `127.0.0.1:8004`. Attach **mdb**, not the NW backend (avoids gunicorn
+   recreate / Slurm ssh-agent drop).
+4. **Stage 2 scope** — keyword + statistics + lookup + browse only.
+5. **`MDB_*`** — `gui/workflow_backend/.env` only; values are never committed.

--- a/docs/CATALOG_SEARCH.md
+++ b/docs/CATALOG_SEARCH.md
@@ -4,8 +4,8 @@ NeuroWorkflow users search public neuroscience dataset catalogs (DANDI, CBS,
 Brain/MINDS, BMB human, SRPBS_TS/`aws`) **inside the app**. The browser never
 talks to mdb. Introduced as Stage 2 of the mdb ↔ NeuroWorkflow contract.
 
-Companion (ops, tokens, mdb paths): `deployment/MDB_CLIENT_CONTRACT.md` on the
-control/docs tree. This file is the NeuroWorkflow implementation.
+Companion (HTTP contract): `deployment/MDB_CLIENT_CONTRACT.md`.  
+Companion (network, env, SIGHUP, frontend rebuild): `deployment/DEPLOY_MDB_CATALOG.md`.
 
 ## Architecture
 
@@ -106,15 +106,17 @@ pnpm test   # or npm test — vitest catalogApi
 pnpm exec tsc -b
 ```
 
-## Deploy (not part of the Stage 2 PR merge)
+## Deploy
 
-Do this only after mdb stage 1 (mdb joins `neuro-workflow_workflow`) and an
-explicit ops OK:
+See `deployment/DEPLOY_MDB_CATALOG.md` for the full recipe. Short version:
 
-1. From the **backend container**: `curl -sS -o /dev/null -w '%{http_code}\n' http://mdb-mindsdb:8004/` → 200
-2. Set `MDB_BASE_URL` and `MDB_API_TOKEN` in `gui/workflow_backend/.env` (never `VITE_*`)
-3. Prefer gunicorn SIGHUP so ssh-agent is preserved; recreate backend only if env is not bind-mounted
-4. Rebuild/recreate **frontend only** (`--no-deps`) so `/catalog` is in the prod bundle
-5. Do not publish 8004, do not add nginx `/mdb`
+1. mdb joins Docker network `neuro-workflow_workflow` as hostname `mdb-mindsdb`
+   (mdb compose overlay; keep `127.0.0.1:8004`). From the NW backend container,
+   `GET http://mdb-mindsdb:8004/` → 200.
+2. Set `MDB_BASE_URL` and `MDB_API_TOKEN` in `gui/workflow_backend/.env` only
+   (never commit the token, never `VITE_*`).
+3. SIGHUP gunicorn (keep ssh-agent). Rebuild/recreate **frontend only**.
+4. Do not publish 8004, do not add nginx `/mdb`, do not set `MDB_ADMIN_TOKEN`
+   in NeuroWorkflow.
 
 Host `127.0.0.1:8004` remains for operators (SSH tunnel).

--- a/docs/CATALOG_SEARCH.md
+++ b/docs/CATALOG_SEARCH.md
@@ -1,0 +1,120 @@
+# Catalog search (mdb Stage 2)
+
+NeuroWorkflow users search public neuroscience dataset catalogs (DANDI, CBS,
+Brain/MINDS, BMB human, SRPBS_TS/`aws`) **inside the app**. The browser never
+talks to mdb. Introduced as Stage 2 of the mdb ↔ NeuroWorkflow contract.
+
+Companion (ops, tokens, mdb paths): `deployment/MDB_CLIENT_CONTRACT.md` on the
+control/docs tree. This file is the NeuroWorkflow implementation.
+
+## Architecture
+
+```
+User browser  →  NeuroWorkflow (Keycloak, nginx 80/443)
+                      ↓  same-origin /api/catalog/*  (user JWT only)
+              NeuroWorkflow backend  (MDB_API_TOKEN)
+                      ↓  Authorization: Bearer <search token>
+              mdb-mindsdb:8004   (private Docker network — stage 1)
+```
+
+- No nginx `/mdb`, no public 8004, no iframe of the mdb dashboard.
+- `MDB_*` lives only in `gui/workflow_backend/.env` (never `VITE_*`).
+- Catalog is not copied into Postgres.
+- Not a generic reverse proxy: user input never becomes a URL or mdb path.
+
+## Routes
+
+| NW (Keycloak required) | mdb |
+|---|---|
+| `GET  /api/catalog/statistics/` | `GET /api/api_statistics` |
+| `POST /api/catalog/search/` | `POST /api/catalog_search` (`mode` forced to `keyword`) |
+| `GET  /api/catalog/lookup/` | `GET /api/catalog_lookup` (`table=api_datasets` only) |
+| `GET  /api/catalog/datasets/` | `GET /api/api_datasets` |
+
+Trailing slashes match Django `APPEND_SLASH`. POST search must use the slash
+or the body is dropped on redirect.
+
+**Not implemented (Stage 2):** catalog chat, agent/intelligent search, sync,
+`MDB_ADMIN_TOKEN`, `/api/local_catalog/…` BIDS paths.
+
+Allowed `source` values: `dandi`, `cbs`, `brainminds`, `bmb_human`, `aws`
+(UI label **SRPBS_TS**). Lookup `table` must be `api_datasets`. Search `limit`
+is clamped 1–200 (default 50).
+
+## Error codes
+
+JSON body: `{ "status": "error", "code": "<code>", "error": "<message>" }`.
+
+| code | HTTP | When |
+|---|---|---|
+| `catalog_unconfigured` | 503 | `MDB_BASE_URL` or `MDB_API_TOKEN` missing |
+| `catalog_unavailable` | 503 / 502 | mdb down, timeout, or mdb 503/5xx |
+| `catalog_auth` | 502 | mdb 401/403 (generic message; no token text) |
+| `catalog_not_found` | 404 | mdb 404 |
+| `invalid_query` / `invalid_mode` / `invalid_source` / `invalid_table` / `invalid_id` / `invalid_limit` | 400 | bad client input |
+
+Unauthenticated callers get 401 from Keycloak/DRF.
+
+## Environment
+
+`gui/workflow_backend/env.template`:
+
+```
+MDB_BASE_URL=http://mdb-mindsdb:8004
+MDB_API_TOKEN=
+MDB_TIMEOUT=15
+```
+
+`MDB_ADMIN_TOKEN` is unused in NeuroWorkflow Stage 2 (sync stays SSH-only).
+
+`get_mdb_config()` reads process env first, then the bind-mounted backend
+`.env` via python-dotenv (`override=False`) so tokens can be added later and
+picked up with gunicorn SIGHUP **without** recreating the backend (ssh-agent).
+Never log token values.
+
+## UI
+
+Header **Catalog** → `/catalog`.
+
+- Stats strip and source chips from `source_counts`
+- Empty `q` → browse `GET /datasets/`; non-empty → `POST /search/`
+- Bookmarkable `?q=&source=&limit=`
+- Row click → lookup drawer: DOI / paper / DANDI links, copy id, copy JSON
+- States: loading, empty, unconfigured, unavailable, auth, not found
+
+The frontend calls only `/api/catalog/*` with `createAuthHeaders()`.
+
+## MCP
+
+Four tools on the workflow MCP server forward the **user JWT** to Django
+(same pattern as `list_projects`). They are keyword catalog only — not the
+MindsDB agent:
+
+- `catalog_statistics`
+- `catalog_search(query, source?, limit?)`
+- `catalog_lookup(source, id)`
+- `catalog_datasets(source?, limit?)`
+
+## Tests
+
+```bash
+cd gui/workflow_backend
+poetry run pytest django-project/tests/test_catalog.py -q
+
+cd gui/workflow_frontend
+pnpm test   # or npm test — vitest catalogApi
+pnpm exec tsc -b
+```
+
+## Deploy (not part of the Stage 2 PR merge)
+
+Do this only after mdb stage 1 (mdb joins `neuro-workflow_workflow`) and an
+explicit ops OK:
+
+1. From the **backend container**: `curl -sS -o /dev/null -w '%{http_code}\n' http://mdb-mindsdb:8004/` → 200
+2. Set `MDB_BASE_URL` and `MDB_API_TOKEN` in `gui/workflow_backend/.env` (never `VITE_*`)
+3. Prefer gunicorn SIGHUP so ssh-agent is preserved; recreate backend only if env is not bind-mounted
+4. Rebuild/recreate **frontend only** (`--no-deps`) so `/catalog` is in the prod bundle
+5. Do not publish 8004, do not add nginx `/mdb`
+
+Host `127.0.0.1:8004` remains for operators (SSH tunnel).

--- a/gui/.env.example
+++ b/gui/.env.example
@@ -24,6 +24,9 @@ HOST_PROJECT_PATH=/path/to/neuro-workflow/gui/workflow_backend/django-project
 # JupyterHub
 # JUPYTERHUB_API_TOKEN=dev-token-change-in-production
 
+# mdb catalog tokens belong in gui/workflow_backend/.env only
+# (MDB_BASE_URL / MDB_API_TOKEN). Never put them here or in VITE_*.
+
 # Keycloak admin credentials (change for production!)
 # KEYCLOAK_ADMIN=admin
 # KEYCLOAK_ADMIN_PASSWORD=<strong-password>

--- a/gui/README.md
+++ b/gui/README.md
@@ -21,6 +21,11 @@ Add 2 more .env files based on the templates.
 - ./gui/workflow_backend/.env
 - ./gui/workflow_frontend/.env
 
+Catalog search (optional): set `MDB_BASE_URL` and `MDB_API_TOKEN` in
+`gui/workflow_backend/.env` only. See `docs/CATALOG_SEARCH.md` and
+`deployment/DEPLOY_MDB_CATALOG.md`. Never put mdb tokens in `VITE_*` or
+`gui/.env`.
+
 Start the Docker containers using docker-compose
 
 ```bash

--- a/gui/docker-compose.yml
+++ b/gui/docker-compose.yml
@@ -41,6 +41,7 @@ services:
       - db
     restart: unless-stopped
     networks:
+      # mdb-mindsdb joins this network as hostname mdb-mindsdb.
       - workflow
       - jupyterhub-network
 
@@ -138,5 +139,8 @@ volumes:
 
 networks:
   workflow:
+    # Pin the name so a separate bm_mindsdb compose can join it as
+    # external network neuro-workflow_workflow (hostname mdb-mindsdb).
+    name: neuro-workflow_workflow
   jupyterhub-network:
     name: jupyterhub-network

--- a/gui/env.template
+++ b/gui/env.template
@@ -16,3 +16,6 @@ ANTHROPIC_API_KEY="sk-ant-xxx"
 ANTHROPIC_MODEL=""
 
 JUPYTERHUB_API_TOKEN=dev-token-change-in-production
+
+# mdb catalog (MDB_BASE_URL, MDB_API_TOKEN) goes in workflow_backend/.env,
+# never in this Compose-level file and never as VITE_*.

--- a/gui/mcp_server/workflow_mcp.py
+++ b/gui/mcp_server/workflow_mcp.py
@@ -4,6 +4,7 @@ import os
 import secrets
 import time
 from typing import Any
+from urllib.parse import urlencode
 
 import httpx
 from fastmcp import FastMCP
@@ -1045,6 +1046,110 @@ async def save_report(workflow_id: str, report_text: str, filename: str = "repor
     if data is None:
         return {"status": "error", "error": f"Failed to save report for workflow {workflow_id}"}
     return {"status": "success", "result": data}
+
+
+# ---------------------------------------------------------------------------
+# Catalog search (Stage 2 keyword catalog via Django /api/catalog/*)
+#
+# Keyword / statistics / lookup / browse only. Not the MindsDB agent, not
+# catalog chat, and not admin sync. The user's Keycloak JWT is forwarded
+# to Django; Django attaches the mdb search token.
+# ---------------------------------------------------------------------------
+
+
+@mcp.tool()
+async def catalog_statistics() -> dict[str, Any]:
+    """Dataset counts for the public neuroscience catalog (keyword catalog only).
+
+    Returns total_datasets, source_counts (dandi, cbs, brainminds, bmb_human, …),
+    optional sync_status, and timestamp. This is NeuroWorkflow Stage 2 keyword
+    catalog search — not the MindsDB agent or catalog chat.
+
+    The backend may return HTTP-mapped errors as
+    {status: "error", code: "catalog_unconfigured"|"catalog_unavailable"|…}.
+    """
+    url = f"{DJANGO_API_URL}/catalog/statistics/"
+    data = await _make_get_request(url)
+    if data is None:
+        return {"status": "error", "error": "Failed to fetch catalog statistics"}
+    return data
+
+
+@mcp.tool()
+async def catalog_search(
+    query: str, source: str | None = None, limit: int | None = None
+) -> dict[str, Any]:
+    """Keyword-search public catalog datasets (DANDI, CBS, Brain/MINDS, …).
+
+    Stage 2 keyword catalog only — not MindsDB agent/intelligent search.
+    The NeuroWorkflow backend forces mode=keyword.
+
+    Args:
+        query: Search string (required).
+        source: Optional catalog source: dandi, cbs, brainminds, bmb_human, or aws.
+        limit: Optional result cap (1–200; backend default 50).
+
+    Returns status, query, results (dataset_id, name, description, source, …),
+    and count.
+    """
+    payload: dict[str, Any] = {"query": query}
+    if source:
+        payload["source"] = source
+    if limit is not None:
+        payload["limit"] = limit
+    url = f"{DJANGO_API_URL}/catalog/search/"
+    data = await _make_post_request(url, payload)
+    if data is None:
+        return {"status": "error", "error": "Failed to search the catalog"}
+    return data
+
+
+@mcp.tool()
+async def catalog_lookup(source: str, id: str) -> dict[str, Any]:
+    """Look up one catalog dataset by source and dataset id (keyword catalog).
+
+    Stage 2 only: table is always api_datasets. Not local BIDS paths and not
+    the MindsDB agent.
+
+    Args:
+        source: Catalog source (dandi, cbs, brainminds, bmb_human, aws).
+        id: Dataset identifier (e.g. DANDI accession 000015).
+
+    Returns the dataset record plus requested_id / normalized_id when present.
+    """
+    qs = urlencode({"source": source, "id": id, "table": "api_datasets"})
+    url = f"{DJANGO_API_URL}/catalog/lookup/?{qs}"
+    data = await _make_get_request(url)
+    if data is None:
+        return {"status": "error", "error": f"Failed to look up catalog dataset {id}"}
+    return data
+
+
+@mcp.tool()
+async def catalog_datasets(
+    source: str | None = None, limit: int | None = None
+) -> dict[str, Any]:
+    """Browse catalog datasets without a keyword query (keyword catalog).
+
+    Stage 2 browse of api_datasets. Not the MindsDB agent.
+
+    Args:
+        source: Optional catalog source: dandi, cbs, brainminds, bmb_human, or aws.
+        limit: Optional page size (1–200).
+
+    Returns count, datasets, and timestamp.
+    """
+    params: dict[str, Any] = {}
+    if source:
+        params["source"] = source
+    if limit is not None:
+        params["limit"] = limit
+    qs = urlencode(params)
+    url = f"{DJANGO_API_URL}/catalog/datasets/" + (f"?{qs}" if qs else "")
+    data = await _make_get_request(url)
+    if data is None:
+        return {"status": "error", "error": "Failed to list catalog datasets"}
+    return data
 
 
 # ---------------------------------------------------------------------------

--- a/gui/workflow_backend/django-project/app/catalog/apps.py
+++ b/gui/workflow_backend/django-project/app/catalog/apps.py
@@ -1,0 +1,6 @@
+from django.apps import AppConfig
+
+
+class CatalogConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "app.catalog"

--- a/gui/workflow_backend/django-project/app/catalog/client.py
+++ b/gui/workflow_backend/django-project/app/catalog/client.py
@@ -1,0 +1,214 @@
+import logging
+import os
+from pathlib import Path
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+ALLOWED_SOURCES = frozenset({"dandi", "cbs", "brainminds", "bmb_human", "aws"})
+ALLOWED_LOOKUP_TABLES = frozenset({"api_datasets"})
+DEFAULT_LOOKUP_TABLE = "api_datasets"
+LIMIT_MIN = 1
+LIMIT_MAX = 200
+LIMIT_DEFAULT = 50
+
+MDB_PATH_STATISTICS = "/api/api_statistics"
+MDB_PATH_SEARCH = "/api/catalog_search"
+MDB_PATH_LOOKUP = "/api/catalog_lookup"
+MDB_PATH_DATASETS = "/api/api_datasets"
+ALLOWED_MDB_PATHS = frozenset(
+    {
+        MDB_PATH_STATISTICS,
+        MDB_PATH_SEARCH,
+        MDB_PATH_LOOKUP,
+        MDB_PATH_DATASETS,
+    }
+)
+
+_DOCKER_ENV_PATH = Path("/django-app/.env")
+_DEFAULT_TIMEOUT = 15
+
+
+class CatalogError(Exception):
+    def __init__(self, status_code, code, error, payload=None):
+        self.status_code = status_code
+        self.code = code
+        self.error = error
+        self.payload = payload
+        super().__init__(error)
+
+
+def _read_mdb_env():
+    base_url = (os.environ.get("MDB_BASE_URL") or "").strip().rstrip("/")
+    token = (os.environ.get("MDB_API_TOKEN") or "").strip()
+    timeout_raw = (os.environ.get("MDB_TIMEOUT") or "").strip()
+    try:
+        timeout = int(timeout_raw) if timeout_raw else _DEFAULT_TIMEOUT
+    except ValueError:
+        timeout = _DEFAULT_TIMEOUT
+    return base_url, token, timeout
+
+
+def _workflow_backend_env_path():
+    for parent in Path(__file__).resolve().parents:
+        if parent.name == "workflow_backend":
+            return parent / ".env"
+    return None
+
+
+def _load_mdb_dotenv():
+    from dotenv import load_dotenv
+
+    if _DOCKER_ENV_PATH.is_file():
+        load_dotenv(_DOCKER_ENV_PATH, override=False)
+
+    backend_env = _workflow_backend_env_path()
+    if backend_env is not None and backend_env.is_file():
+        load_dotenv(backend_env, override=False)
+
+
+def get_mdb_config():
+    base_url, token, timeout = _read_mdb_env()
+    if not base_url or not token:
+        _load_mdb_dotenv()
+        base_url, token, timeout = _read_mdb_env()
+    return base_url, token, timeout
+
+
+def clamp_limit(value):
+    if value is None or value == "":
+        return LIMIT_DEFAULT
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError) as exc:
+        raise CatalogError(
+            400,
+            "invalid_limit",
+            "limit must be an integer",
+        ) from exc
+    return max(LIMIT_MIN, min(LIMIT_MAX, parsed))
+
+
+def validate_source(source):
+    if source is None:
+        return None
+    if isinstance(source, str):
+        source = source.strip()
+    if source == "":
+        return None
+    if source not in ALLOWED_SOURCES:
+        raise CatalogError(400, "invalid_source", "Unknown source")
+    return source
+
+
+def validate_lookup_table(table):
+    if table is None:
+        return DEFAULT_LOOKUP_TABLE
+    if isinstance(table, str):
+        table = table.strip()
+    if table == "":
+        return DEFAULT_LOOKUP_TABLE
+    if table not in ALLOWED_LOOKUP_TABLES:
+        raise CatalogError(400, "invalid_table", "Unknown lookup table")
+    return table
+
+
+def _parse_json_body(response):
+    try:
+        return response.json()
+    except ValueError:
+        return None
+
+
+def _mdb_error_text(body, fallback):
+    if isinstance(body, dict):
+        error = body.get("error")
+        if isinstance(error, str) and error.strip():
+            return error
+    return fallback
+
+
+def mdb_request(method, path, *, params=None, json_body=None):
+    if path not in ALLOWED_MDB_PATHS:
+        raise CatalogError(500, "catalog_internal", "Invalid catalog path")
+
+    base_url, token, timeout = get_mdb_config()
+    if not base_url or not token:
+        raise CatalogError(
+            503,
+            "catalog_unconfigured",
+            "Catalog service is not configured",
+        )
+
+    url = f"{base_url}{path}"
+    headers = {"Authorization": f"Bearer {token}"}
+    method = method.upper()
+    request_kwargs = {"headers": headers, "params": params}
+    if method == "POST":
+        headers["Content-Type"] = "application/json"
+        request_kwargs["json"] = json_body if json_body is not None else {}
+
+    try:
+        with httpx.Client(timeout=timeout, follow_redirects=False) as client:
+            response = client.request(method, url, **request_kwargs)
+    except httpx.RequestError:
+        logger.warning("mdb request failed: %s %s (network)", method, path)
+        raise CatalogError(
+            503,
+            "catalog_unavailable",
+            "Catalog service is unavailable",
+        ) from None
+
+    status_code = response.status_code
+    if 200 <= status_code < 300:
+        body = _parse_json_body(response)
+        if body is None:
+            raise CatalogError(
+                502,
+                "catalog_unavailable",
+                "Catalog service is unavailable",
+            )
+        return body
+
+    body = _parse_json_body(response)
+    payload = body if isinstance(body, dict) else None
+
+    if status_code in (401, 403):
+        raise CatalogError(
+            502,
+            "catalog_auth",
+            "Catalog authentication failed",
+            payload=payload,
+        )
+    if status_code == 503:
+        raise CatalogError(
+            503,
+            "catalog_unavailable",
+            "Catalog service is unavailable",
+            payload=payload,
+        )
+    if status_code in (400, 404):
+        fallback = "Bad request" if status_code == 400 else "Not found"
+        code = "catalog_bad_request" if status_code == 400 else "catalog_not_found"
+        raise CatalogError(
+            status_code,
+            code,
+            _mdb_error_text(body, fallback),
+            payload=payload,
+        )
+    if status_code >= 500:
+        raise CatalogError(
+            502,
+            "catalog_unavailable",
+            "Catalog service is unavailable",
+            payload=payload,
+        )
+
+    fallback = "Catalog request failed"
+    raise CatalogError(
+        status_code,
+        "catalog_error",
+        _mdb_error_text(body, fallback),
+        payload=payload,
+    )

--- a/gui/workflow_backend/django-project/app/catalog/urls.py
+++ b/gui/workflow_backend/django-project/app/catalog/urls.py
@@ -1,0 +1,17 @@
+from django.urls import path
+
+from .views import (
+    CatalogDatasetsView,
+    CatalogLookupView,
+    CatalogSearchView,
+    CatalogStatisticsView,
+)
+
+app_name = "catalog"
+
+urlpatterns = [
+    path("statistics/", CatalogStatisticsView.as_view(), name="catalog-statistics"),
+    path("search/", CatalogSearchView.as_view(), name="catalog-search"),
+    path("lookup/", CatalogLookupView.as_view(), name="catalog-lookup"),
+    path("datasets/", CatalogDatasetsView.as_view(), name="catalog-datasets"),
+]

--- a/gui/workflow_backend/django-project/app/catalog/views.py
+++ b/gui/workflow_backend/django-project/app/catalog/views.py
@@ -1,0 +1,142 @@
+from django.utils.decorators import method_decorator
+from django.views.decorators.csrf import csrf_exempt
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from app.auth.authentication import KeycloakAuthentication
+
+from .client import (
+    CatalogError,
+    MDB_PATH_DATASETS,
+    MDB_PATH_LOOKUP,
+    MDB_PATH_SEARCH,
+    MDB_PATH_STATISTICS,
+    clamp_limit,
+    mdb_request,
+    validate_lookup_table,
+    validate_source,
+)
+
+
+def _error_response(exc):
+    return Response(
+        {"status": "error", "code": exc.code, "error": exc.error},
+        status=exc.status_code,
+    )
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class CatalogStatisticsView(APIView):
+    authentication_classes = [KeycloakAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        try:
+            data = mdb_request("GET", MDB_PATH_STATISTICS)
+        except CatalogError as exc:
+            return _error_response(exc)
+        return Response(data)
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class CatalogSearchView(APIView):
+    authentication_classes = [KeycloakAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        body = request.data if isinstance(request.data, dict) else {}
+        query = body.get("query")
+        if not isinstance(query, str) or not query.strip():
+            return Response(
+                {
+                    "status": "error",
+                    "code": "invalid_query",
+                    "error": "query is required",
+                },
+                status=400,
+            )
+
+        mode = body.get("mode")
+        if mode is not None and mode != "keyword":
+            return Response(
+                {
+                    "status": "error",
+                    "code": "invalid_mode",
+                    "error": "Only keyword search is supported",
+                },
+                status=400,
+            )
+
+        try:
+            source = validate_source(body.get("source"))
+            limit = clamp_limit(body.get("limit"))
+            upstream = {
+                "query": query.strip(),
+                "mode": "keyword",
+                "limit": limit,
+            }
+            if source is not None:
+                upstream["source"] = source
+            data = mdb_request("POST", MDB_PATH_SEARCH, json_body=upstream)
+        except CatalogError as exc:
+            return _error_response(exc)
+        return Response(data)
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class CatalogLookupView(APIView):
+    authentication_classes = [KeycloakAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        record_id = request.query_params.get("id")
+        if record_id is None or not str(record_id).strip():
+            return Response(
+                {
+                    "status": "error",
+                    "code": "invalid_id",
+                    "error": "id is required",
+                },
+                status=400,
+            )
+
+        try:
+            table = validate_lookup_table(request.query_params.get("table"))
+            source_raw = request.query_params.get("source")
+            if source_raw is None or not str(source_raw).strip():
+                source = "dandi"
+            else:
+                source = validate_source(source_raw)
+            params = {
+                "table": table,
+                "source": source,
+                "id": str(record_id).strip(),
+            }
+            data = mdb_request("GET", MDB_PATH_LOOKUP, params=params)
+        except CatalogError as exc:
+            return _error_response(exc)
+        return Response(data)
+
+
+@method_decorator(csrf_exempt, name="dispatch")
+class CatalogDatasetsView(APIView):
+    authentication_classes = [KeycloakAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        try:
+            source = validate_source(request.query_params.get("source"))
+            params = {}
+            if source is not None:
+                params["source"] = source
+            if "limit" in request.query_params:
+                params["limit"] = clamp_limit(request.query_params.get("limit"))
+            data = mdb_request(
+                "GET",
+                MDB_PATH_DATASETS,
+                params=params or None,
+            )
+        except CatalogError as exc:
+            return _error_response(exc)
+        return Response(data)

--- a/gui/workflow_backend/django-project/config/settings.py
+++ b/gui/workflow_backend/django-project/config/settings.py
@@ -61,6 +61,7 @@ LOCAL_APPS = [
     "app.workflow.apps.WorkflowConfig",
     "app.metadata.apps.MetadataConfig",
     "app.chat.apps.ChatConfig",
+    "app.catalog.apps.CatalogConfig",
 ]
 
 INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS

--- a/gui/workflow_backend/django-project/config/urls.py
+++ b/gui/workflow_backend/django-project/config/urls.py
@@ -29,6 +29,7 @@ urlpatterns = [
     path("api/workflow/", include("app.workflow.urls")),
     path("api/metadata/", include("app.metadata.urls")),
     path("api/chat/", include("app.chat.urls")),
+    path("api/catalog/", include("app.catalog.urls")),
     path("api/viewer/<uuid:project_id>/<path:subpath>", viewer_file),
 ]
 

--- a/gui/workflow_backend/django-project/tests/test_catalog.py
+++ b/gui/workflow_backend/django-project/tests/test_catalog.py
@@ -1,0 +1,262 @@
+"""Tests for the NeuroWorkflow catalog proxy (mdb-mindsdb).
+
+The proxy authenticates the Django user, then calls mdb with a dedicated
+search token. User JWTs must never be forwarded; only keyword search is
+allowed; mdb errors are mapped to generic catalog codes.
+"""
+import httpx
+import pytest
+from django.urls import reverse
+
+pytestmark = pytest.mark.django_db
+
+MDB_BASE = "http://mdb-mindsdb:8004"
+MDB_TOKEN = "mdb-search-token"
+USER_JWT = "user-jwt-must-not-leak"
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, payload=None):
+        self.status_code = status_code
+        self._payload = {} if payload is None else payload
+
+    def json(self):
+        return self._payload
+
+
+class FakeHttpxClient:
+    """Records the outgoing mdb request and returns a canned response."""
+
+    captured = None
+    called = False
+    response = None
+    error = None
+
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+    @classmethod
+    def reset(cls, response=None, error=None):
+        cls.captured = None
+        cls.called = False
+        cls.response = response if response is not None else FakeResponse()
+        cls.error = error
+
+    def request(self, method, url, headers=None, params=None, json=None):
+        type(self).called = True
+        type(self).captured = {
+            "method": method,
+            "url": url,
+            "headers": dict(headers or {}),
+            "params": params,
+            "json": json,
+        }
+        if type(self).error is not None:
+            raise type(self).error
+        return type(self).response
+
+    def close(self):
+        pass
+
+
+@pytest.fixture
+def mdb_configured(monkeypatch):
+    monkeypatch.setattr(
+        "app.catalog.client.get_mdb_config",
+        lambda: (MDB_BASE, MDB_TOKEN, 15),
+    )
+
+
+@pytest.fixture
+def fake_httpx(monkeypatch):
+    FakeHttpxClient.reset()
+    monkeypatch.setattr("app.catalog.client.httpx.Client", FakeHttpxClient)
+    return FakeHttpxClient
+
+
+def _error(resp):
+    body = resp.json()
+    assert body["status"] == "error"
+    return body
+
+
+def test_statistics_requires_auth(auth_client):
+    resp = auth_client().get(reverse("catalog:catalog-statistics"))
+    assert resp.status_code == 401
+
+
+def test_statistics_unconfigured(auth_client, user_alice, monkeypatch, fake_httpx):
+    monkeypatch.setattr(
+        "app.catalog.client.get_mdb_config",
+        lambda: ("", "", 15),
+    )
+    resp = auth_client(user_alice).get(reverse("catalog:catalog-statistics"))
+    assert resp.status_code == 503
+    assert _error(resp)["code"] == "catalog_unconfigured"
+    assert fake_httpx.called is False
+
+
+def test_search_rejects_agent_mode_before_httpx(
+    auth_client, user_alice, mdb_configured, fake_httpx
+):
+    resp = auth_client(user_alice).post(
+        reverse("catalog:catalog-search"),
+        {"query": "mouse", "mode": "agent", "limit": 20},
+        format="json",
+    )
+    assert resp.status_code == 400
+    assert _error(resp)["code"] == "invalid_mode"
+    assert fake_httpx.called is False
+
+
+def test_search_sends_keyword_mode_clamped_limit_and_search_token(
+    auth_client, user_alice, mdb_configured, fake_httpx
+):
+    fake_httpx.reset(response=FakeResponse(200, {"hits": []}))
+    client = auth_client(user_alice)
+    # Token is request.auth only — sending Bearer would hit Keycloak JWKS.
+    client.force_authenticate(user=user_alice, token=USER_JWT)
+    resp = client.post(
+        reverse("catalog:catalog-search"),
+        {"query": "mouse", "limit": 999},
+        format="json",
+    )
+    assert resp.status_code == 200
+    captured = fake_httpx.captured
+    assert captured["method"] == "POST"
+    assert captured["url"].endswith("/api/catalog_search")
+    assert captured["json"]["mode"] == "keyword"
+    assert captured["json"]["limit"] == 200
+    assert captured["json"]["query"] == "mouse"
+    headers = captured["headers"]
+    assert headers["Authorization"] == f"Bearer {MDB_TOKEN}"
+    assert headers["Content-Type"] == "application/json"
+    assert USER_JWT not in headers.values()
+    assert all(USER_JWT not in str(value) for value in headers.values())
+
+
+@pytest.mark.parametrize("table", ["local_catalog_datasets", "metadata_entries"])
+def test_lookup_rejects_forbidden_tables(
+    auth_client, user_alice, mdb_configured, fake_httpx, table
+):
+    resp = auth_client(user_alice).get(
+        reverse("catalog:catalog-lookup"),
+        {"id": "123", "table": table},
+    )
+    assert resp.status_code == 400
+    assert _error(resp)["code"] == "invalid_table"
+    assert fake_httpx.called is False
+
+
+def test_lookup_missing_id(auth_client, user_alice, mdb_configured, fake_httpx):
+    resp = auth_client(user_alice).get(reverse("catalog:catalog-lookup"))
+    assert resp.status_code == 400
+    assert _error(resp)["code"] == "invalid_id"
+    assert fake_httpx.called is False
+
+
+def test_search_rejects_unknown_source(
+    auth_client, user_alice, mdb_configured, fake_httpx
+):
+    resp = auth_client(user_alice).post(
+        reverse("catalog:catalog-search"),
+        {"query": "mouse", "source": "not-a-source"},
+        format="json",
+    )
+    assert resp.status_code == 400
+    assert _error(resp)["code"] == "invalid_source"
+    assert fake_httpx.called is False
+
+
+def test_datasets_rejects_unknown_source(
+    auth_client, user_alice, mdb_configured, fake_httpx
+):
+    resp = auth_client(user_alice).get(
+        reverse("catalog:catalog-datasets"),
+        {"source": "not-a-source"},
+    )
+    assert resp.status_code == 400
+    assert _error(resp)["code"] == "invalid_source"
+    assert fake_httpx.called is False
+
+
+def test_lookup_maps_mdb_404(auth_client, user_alice, mdb_configured, fake_httpx):
+    fake_httpx.reset(
+        response=FakeResponse(
+            404, {"status": "error", "error": "not found"}
+        )
+    )
+    resp = auth_client(user_alice).get(
+        reverse("catalog:catalog-lookup"),
+        {"id": "missing-id"},
+    )
+    assert resp.status_code == 404
+    assert _error(resp)["code"] == "catalog_not_found"
+
+
+def test_maps_mdb_503(auth_client, user_alice, mdb_configured, fake_httpx):
+    fake_httpx.reset(
+        response=FakeResponse(503, {"status": "error", "error": "down"})
+    )
+    resp = auth_client(user_alice).get(reverse("catalog:catalog-statistics"))
+    assert resp.status_code == 503
+    assert _error(resp)["code"] == "catalog_unavailable"
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [httpx.TimeoutException("timed out"), httpx.ConnectError("refused")],
+)
+def test_maps_httpx_network_errors(
+    auth_client, user_alice, mdb_configured, fake_httpx, exc
+):
+    fake_httpx.reset(error=exc)
+    resp = auth_client(user_alice).get(reverse("catalog:catalog-statistics"))
+    assert resp.status_code == 503
+    assert _error(resp)["code"] == "catalog_unavailable"
+
+
+def test_maps_mdb_401_without_leaking_token(
+    auth_client, user_alice, mdb_configured, fake_httpx
+):
+    leak = "invalid token secret-mdb-token-abc"
+    fake_httpx.reset(response=FakeResponse(401, {"error": leak}))
+    resp = auth_client(user_alice).get(reverse("catalog:catalog-statistics"))
+    assert resp.status_code == 502
+    body = _error(resp)
+    assert body["code"] == "catalog_auth"
+    assert body["error"] == "Catalog authentication failed"
+    assert leak not in body["error"]
+    assert "secret-mdb-token-abc" not in resp.content.decode()
+
+
+def test_statistics_success_forwards_json(
+    auth_client, user_alice, mdb_configured, fake_httpx
+):
+    payload = {"status": "ok", "counts": {"dandi": 12}, "extra": [1, 2]}
+    fake_httpx.reset(response=FakeResponse(200, payload))
+    resp = auth_client(user_alice).get(reverse("catalog:catalog-statistics"))
+    assert resp.status_code == 200
+    assert resp.json() == payload
+
+
+def test_datasets_get_forwards_query_params_and_token(
+    auth_client, user_alice, mdb_configured, fake_httpx
+):
+    fake_httpx.reset(response=FakeResponse(200, {"datasets": []}))
+    resp = auth_client(user_alice).get(
+        reverse("catalog:catalog-datasets"),
+        {"source": "dandi", "limit": 20},
+    )
+    assert resp.status_code == 200
+    captured = fake_httpx.captured
+    assert captured["method"] == "GET"
+    assert captured["url"].endswith("/api/api_datasets")
+    assert captured["params"] == {"source": "dandi", "limit": 20}
+    assert captured["headers"]["Authorization"] == f"Bearer {MDB_TOKEN}"

--- a/gui/workflow_backend/env.template
+++ b/gui/workflow_backend/env.template
@@ -60,3 +60,10 @@ PYTHONENV=/usr/bin/python3
 # LOCAL_RAG_TIMEOUT=90   # /global_query can take 30–90s; increase if RAG is slow
 # LOCAL_RAG_MAX_CHUNKS=10
 # LOCAL_RAG_SOURCE_NAME=Local RAG
+
+# --- mdb catalog (Stage 2; backend only, never VITE_*) ---
+# MDB_BASE_URL=http://mdb-mindsdb:8004
+# MDB_API_TOKEN=
+# MDB_TIMEOUT=15
+# MDB_ADMIN_TOKEN is unused in NeuroWorkflow Stage 2 (sync stays SSH-only).
+

--- a/gui/workflow_frontend/package.json
+++ b/gui/workflow_frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "vitest run",
     "preview": "vite preview",
     "api:build": "aspida --config aspida.config.cjs",
     "api:watch": "aspida --config aspida.config.cjs --watch",

--- a/gui/workflow_frontend/src/api/catalogApi.test.ts
+++ b/gui/workflow_frontend/src/api/catalogApi.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  CatalogApiError,
+  dandiUrl,
+  fetchCatalogStatistics,
+  listCatalogDatasets,
+  lookupCatalog,
+  parseError,
+  searchCatalog,
+  sourceDisplayName,
+  toCatalogHits,
+} from "./catalogApi";
+
+vi.mock("./authHeaders", () => ({
+  createAuthHeaders: vi.fn(async () => ({
+    "Content-Type": "application/json",
+  })),
+}));
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+  } as Response;
+}
+
+describe("parseError", () => {
+  it("maps 503 catalog_unconfigured", async () => {
+    await expect(
+      parseError(
+        jsonResponse(503, {
+          status: "error",
+          code: "catalog_unconfigured",
+          error: "Catalog service is not configured",
+        })
+      )
+    ).rejects.toMatchObject({
+      name: "CatalogApiError",
+      status: 503,
+      code: "catalog_unconfigured",
+      message: "Catalog service is not configured",
+    });
+  });
+
+  it("maps 503 catalog_unavailable", async () => {
+    await expect(
+      parseError(
+        jsonResponse(503, {
+          status: "error",
+          code: "catalog_unavailable",
+          error: "Catalog service is unavailable",
+        })
+      )
+    ).rejects.toMatchObject({
+      name: "CatalogApiError",
+      status: 503,
+      code: "catalog_unavailable",
+      message: "Catalog service is unavailable",
+    });
+  });
+
+  it("maps 502 catalog_auth", async () => {
+    await expect(
+      parseError(
+        jsonResponse(502, {
+          status: "error",
+          code: "catalog_auth",
+          error: "Catalog authentication failed",
+        })
+      )
+    ).rejects.toMatchObject({
+      name: "CatalogApiError",
+      status: 502,
+      code: "catalog_auth",
+      message: "Catalog authentication failed",
+    });
+  });
+
+  it("maps 404 catalog_not_found", async () => {
+    await expect(
+      parseError(
+        jsonResponse(404, {
+          status: "error",
+          code: "catalog_not_found",
+          error: "Not found",
+        })
+      )
+    ).rejects.toMatchObject({
+      name: "CatalogApiError",
+      status: 404,
+      code: "catalog_not_found",
+      message: "Not found",
+    });
+  });
+
+  it("does not throw when the response is ok", async () => {
+    await expect(parseError(jsonResponse(200, { status: "ok" }))).resolves.toBe(
+      undefined
+    );
+  });
+});
+
+describe("sourceDisplayName", () => {
+  it("maps aws to SRPBS_TS", () => {
+    expect(sourceDisplayName("aws")).toBe("SRPBS_TS");
+    expect(sourceDisplayName("aws", "Amazon")).toBe("SRPBS_TS");
+  });
+
+  it("prefers source_display, then the raw source", () => {
+    expect(sourceDisplayName("dandi", "DANDI")).toBe("DANDI");
+    expect(sourceDisplayName("cbs")).toBe("cbs");
+  });
+});
+
+describe("dandiUrl", () => {
+  it("builds the public DANDI archive URL", () => {
+    expect(dandiUrl("000003")).toBe("https://dandiarchive.org/dandiset/000003");
+  });
+});
+
+describe("toCatalogHits", () => {
+  it("maps browse datasets[] onto CatalogHit with name fallback", () => {
+    const hits = toCatalogHits({
+      datasets: [
+        {
+          dataset_id: "000003",
+          source: "dandi",
+          description: "example",
+        },
+      ],
+    });
+    expect(hits).toHaveLength(1);
+    expect(hits[0].name).toBe("000003");
+    expect(hits[0].dataset_id).toBe("000003");
+    expect(hits[0].source).toBe("dandi");
+  });
+
+  it("maps search results[] onto CatalogHit", () => {
+    const hits = toCatalogHits({
+      results: [{ dataset_id: "abc", name: "Mouse", source: "cbs" }],
+    });
+    expect(hits[0].name).toBe("Mouse");
+    expect(hits[0].source).toBe("cbs");
+  });
+});
+
+describe("catalog fetch helpers", () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("throws CatalogApiError from fetchCatalogStatistics on 503 unconfigured", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue(
+        jsonResponse(503, {
+          status: "error",
+          code: "catalog_unconfigured",
+          error: "Catalog service is not configured",
+        })
+      )
+    );
+    await expect(fetchCatalogStatistics()).rejects.toBeInstanceOf(
+      CatalogApiError
+    );
+    await expect(fetchCatalogStatistics()).rejects.toMatchObject({
+      status: 503,
+      code: "catalog_unconfigured",
+    });
+  });
+
+  it("POSTs keyword search to /api/catalog/search/", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      jsonResponse(200, {
+        status: "ok",
+        mode: "keyword",
+        query: "mouse",
+        results: [],
+        count: 0,
+      })
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await searchCatalog({ query: "mouse", source: "dandi", limit: 20 });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/catalog/search/");
+    expect(init.method).toBe("POST");
+    expect(JSON.parse(String(init.body))).toEqual({
+      query: "mouse",
+      source: "dandi",
+      limit: 20,
+    });
+  });
+
+  it("GETs datasets and lookup through /api/catalog/", async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        jsonResponse(200, { count: 0, datasets: [], timestamp: "now" })
+      )
+      .mockResolvedValueOnce(
+        jsonResponse(200, { record: { dataset_id: "000003" }, requested_id: "000003" })
+      );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await listCatalogDatasets({ source: "dandi", limit: 50 });
+    await lookupCatalog({ source: "dandi", id: "000003" });
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      "/api/catalog/datasets/?source=dandi&limit=50"
+    );
+    expect(String(fetchMock.mock.calls[1][0])).toBe(
+      "/api/catalog/lookup/?id=000003&source=dandi"
+    );
+  });
+});

--- a/gui/workflow_frontend/src/api/catalogApi.ts
+++ b/gui/workflow_frontend/src/api/catalogApi.ts
@@ -1,0 +1,299 @@
+import { createAuthHeaders } from "./authHeaders";
+import { API_BASE_URL } from "../config/urls";
+
+export type CatalogErrorCode =
+  | "catalog_unconfigured"
+  | "catalog_unavailable"
+  | "catalog_auth"
+  | "catalog_not_found"
+  | string;
+
+export interface CatalogErrorBody {
+  status: "error";
+  code: CatalogErrorCode;
+  error: string;
+}
+
+export interface CatalogSyncStatus {
+  last_sync?: string | null;
+  status?: string | null;
+  datasets_count?: number;
+  error_message?: string | null;
+}
+
+export interface CatalogStatistics {
+  total_datasets: number;
+  source_counts: Record<string, number>;
+  sync_status?: Record<string, CatalogSyncStatus>;
+  timestamp?: string;
+}
+
+export interface CatalogHit {
+  dataset_doi: string | null;
+  dataset_id: string;
+  description: string | null;
+  is_draft: boolean;
+  name: string;
+  primary_paper_title: string | null;
+  primary_paper_url: string | null;
+  source: string;
+  source_display: string | null;
+  synced_at: string | null;
+  table: string | null;
+}
+
+export interface CatalogSearchResponse {
+  status: string;
+  mode?: string;
+  query?: string;
+  source?: string | null;
+  results: CatalogHit[];
+  count: number;
+  timestamp?: string;
+}
+
+export interface DatasetRow {
+  dataset_id: string;
+  name?: string | null;
+  description?: string | null;
+  is_draft?: boolean;
+  source: string;
+  source_display?: string | null;
+  dataset_doi?: string | null;
+  primary_paper_title?: string | null;
+  primary_paper_url?: string | null;
+  synced_at?: string | null;
+  [key: string]: unknown;
+}
+
+export interface CatalogDatasetsResponse {
+  count: number;
+  datasets: DatasetRow[];
+  timestamp?: string;
+}
+
+export interface CatalogLookupResponse {
+  record: Record<string, unknown>;
+  requested_id?: string;
+  normalized_id?: string;
+  [key: string]: unknown;
+}
+
+export class CatalogApiError extends Error {
+  status: number;
+  code: CatalogErrorCode;
+
+  constructor(status: number, code: CatalogErrorCode, message: string) {
+    super(message);
+    this.name = "CatalogApiError";
+    this.status = status;
+    this.code = code;
+  }
+}
+
+export function sourceDisplayName(
+  source: string,
+  source_display?: string | null
+): string {
+  if (source === "aws") return "SRPBS_TS";
+  if (source_display) return source_display;
+  return source;
+}
+
+export function dandiUrl(id: string): string {
+  return `https://dandiarchive.org/dandiset/${id}`;
+}
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (value !== null && typeof value === "object" && !Array.isArray(value)) {
+    return value as Record<string, unknown>;
+  }
+  return {};
+}
+
+function asString(value: unknown, fallback = ""): string {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  return fallback;
+}
+
+function asOptionalString(value: unknown): string | null {
+  if (value === null || value === undefined) return null;
+  const text = asString(value);
+  return text || null;
+}
+
+function asBoolean(value: unknown): boolean {
+  return value === true || value === "true";
+}
+
+function asNumber(value: unknown, fallback = 0): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return fallback;
+}
+
+export function normalizeHit(raw: unknown): CatalogHit {
+  const row = asRecord(raw);
+  const datasetId = asString(row.dataset_id);
+  return {
+    dataset_doi: asOptionalString(row.dataset_doi),
+    dataset_id: datasetId,
+    description: asOptionalString(row.description),
+    is_draft: asBoolean(row.is_draft),
+    name: asOptionalString(row.name) || datasetId,
+    primary_paper_title: asOptionalString(row.primary_paper_title),
+    primary_paper_url: asOptionalString(row.primary_paper_url),
+    source: asString(row.source),
+    source_display: asOptionalString(row.source_display),
+    synced_at: asOptionalString(row.synced_at),
+    table: asOptionalString(row.table),
+  };
+}
+
+/** Normalize browse (`datasets[]`) or search (`results[]`) into CatalogHit[]. */
+export function toCatalogHits(data: unknown): CatalogHit[] {
+  const body = asRecord(data);
+  if (Array.isArray(body.results)) {
+    return body.results.map(normalizeHit);
+  }
+  if (Array.isArray(body.datasets)) {
+    return body.datasets.map(normalizeHit);
+  }
+  return [];
+}
+
+export async function parseError(res: Response): Promise<void> {
+  if (res.ok) return;
+
+  let code: CatalogErrorCode = "catalog_error";
+  let message = `Catalog request failed (${res.status})`;
+  try {
+    const body = (await res.json()) as Partial<CatalogErrorBody>;
+    if (typeof body.code === "string" && body.code) {
+      code = body.code;
+    }
+    if (typeof body.error === "string" && body.error) {
+      message = body.error;
+    }
+  } catch {
+    // keep defaults when the body is not JSON
+  }
+  throw new CatalogApiError(res.status, code, message);
+}
+
+async function catalogFetch(
+  path: string,
+  init: RequestInit = {}
+): Promise<unknown> {
+  const headers = await createAuthHeaders();
+  const res = await fetch(`${API_BASE_URL}${path}`, {
+    ...init,
+    headers: { ...headers, ...(init.headers as Record<string, string> | undefined) },
+  });
+  await parseError(res);
+  return res.json();
+}
+
+export async function fetchCatalogStatistics(): Promise<CatalogStatistics> {
+  const data = asRecord(await catalogFetch("/catalog/statistics/"));
+  const sourceCountsRaw = asRecord(data.source_counts);
+  const source_counts: Record<string, number> = {};
+  for (const [key, value] of Object.entries(sourceCountsRaw)) {
+    source_counts[key] = asNumber(value);
+  }
+
+  let sync_status: Record<string, CatalogSyncStatus> | undefined;
+  if (data.sync_status && typeof data.sync_status === "object") {
+    sync_status = {};
+    for (const [key, value] of Object.entries(asRecord(data.sync_status))) {
+      const row = asRecord(value);
+      sync_status[key] = {
+        last_sync: asOptionalString(row.last_sync),
+        status: asOptionalString(row.status),
+        datasets_count:
+          row.datasets_count === undefined
+            ? undefined
+            : asNumber(row.datasets_count),
+        error_message: asOptionalString(row.error_message),
+      };
+    }
+  }
+
+  return {
+    total_datasets: asNumber(data.total_datasets),
+    source_counts,
+    sync_status,
+    timestamp: asOptionalString(data.timestamp) ?? undefined,
+  };
+}
+
+export async function searchCatalog(options: {
+  query: string;
+  source?: string;
+  limit?: number;
+}): Promise<CatalogSearchResponse> {
+  const body: { query: string; source?: string; limit?: number } = {
+    query: options.query,
+  };
+  if (options.source) body.source = options.source;
+  if (options.limit !== undefined) body.limit = options.limit;
+
+  const data = asRecord(
+    await catalogFetch("/catalog/search/", {
+      method: "POST",
+      body: JSON.stringify(body),
+    })
+  );
+  const results = toCatalogHits(data);
+  return {
+    status: asString(data.status, "ok"),
+    mode: asOptionalString(data.mode) ?? undefined,
+    query: asOptionalString(data.query) ?? undefined,
+    source: asOptionalString(data.source),
+    results,
+    count: asNumber(data.count, results.length),
+    timestamp: asOptionalString(data.timestamp) ?? undefined,
+  };
+}
+
+export async function lookupCatalog(options: {
+  id: string;
+  source?: string;
+}): Promise<CatalogLookupResponse> {
+  const params = new URLSearchParams({ id: options.id });
+  if (options.source) params.set("source", options.source);
+  const data = asRecord(
+    await catalogFetch(`/catalog/lookup/?${params.toString()}`)
+  );
+  return {
+    ...data,
+    record: asRecord(data.record),
+    requested_id: asOptionalString(data.requested_id) ?? undefined,
+    normalized_id: asOptionalString(data.normalized_id) ?? undefined,
+  };
+}
+
+export async function listCatalogDatasets(options?: {
+  source?: string;
+  limit?: number;
+}): Promise<CatalogDatasetsResponse> {
+  const params = new URLSearchParams();
+  if (options?.source) params.set("source", options.source);
+  if (options?.limit !== undefined) params.set("limit", String(options.limit));
+  const qs = params.toString();
+  const data = asRecord(
+    await catalogFetch(`/catalog/datasets/${qs ? `?${qs}` : ""}`)
+  );
+  const datasets = Array.isArray(data.datasets)
+    ? (data.datasets as DatasetRow[])
+    : [];
+  return {
+    count: asNumber(data.count, datasets.length),
+    datasets,
+    timestamp: asOptionalString(data.timestamp) ?? undefined,
+  };
+}

--- a/gui/workflow_frontend/src/components/tabs/TabManager.tsx
+++ b/gui/workflow_frontend/src/components/tabs/TabManager.tsx
@@ -9,6 +9,7 @@ import CreateFlowPj from '../../views/file/createView';
 import BoxUpload from '../../views/box/uploadView';
 import NotFoundView from '../../views/notFound/notFound';
 import CustomDatabaseManager from '../../views/home/components/CustomDatabaseManager';
+import CatalogView from '../../views/catalog/catalogView';
 import UserProfileView from '../../views/user/userProfileView';
 import ChatbotArea from '../../views/home/components/chatbotView';
 import { useViewerStore, type ViewerSnapshot } from '../../stores/viewerStore';
@@ -241,6 +242,7 @@ export const TabManager: React.FC = () => {
                     <Route path="/file/new" element={<CreateFlowPj />} />
                     <Route path="/box/upload" element={<BoxUpload />} />
                     <Route path="/settings/databases" element={<CustomDatabaseManager />} />
+                    <Route path="/catalog" element={<CatalogView />} />
                     <Route path="/user" element={<UserProfileView />} />
                     <Route path="/*" element={<NotFoundView />} />
                   </Routes>

--- a/gui/workflow_frontend/src/shared/header/header.tsx
+++ b/gui/workflow_frontend/src/shared/header/header.tsx
@@ -170,6 +170,17 @@ const Header: React.FC = () => {
           </MenuList>
         </Menu>
 
+        <Button
+          as={RouterLink}
+          to="/catalog"
+          variant="ghost"
+          size="md"
+          mx={2}
+          color={headerColor}
+        >
+          Catalog
+        </Button>
+
         {/* Settings Menu */}
         <Menu>
           <MenuButton

--- a/gui/workflow_frontend/src/shared/keyWordSearch/keyWordSearch.tsx
+++ b/gui/workflow_frontend/src/shared/keyWordSearch/keyWordSearch.tsx
@@ -17,6 +17,7 @@ interface KeywordSearchProps {
   variant?: string;
   bgColor?: string;
   borderRadius?: string;
+  initialKeyword?: string;
 }
 
 const KeywordSearch: React.FC<KeywordSearchProps> = ({
@@ -27,8 +28,9 @@ const KeywordSearch: React.FC<KeywordSearchProps> = ({
   variant = 'filled',
   bgColor,
   borderRadius = 'md',
+  initialKeyword = '',
 }) => {
-  const [keyword, setKeyword] = useState<string>('');
+  const [keyword, setKeyword] = useState<string>(initialKeyword ?? '');
   const bg = useColorModeValue('gray.100', 'gray.700');
   const inputBg = bgColor || bg;
 

--- a/gui/workflow_frontend/src/views/catalog/catalogView.tsx
+++ b/gui/workflow_frontend/src/views/catalog/catalogView.tsx
@@ -1,0 +1,685 @@
+import React, { useCallback, useEffect, useMemo, useState } from "react";
+import {
+  Alert,
+  AlertIcon,
+  Badge,
+  Box,
+  Button,
+  Drawer,
+  DrawerBody,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerOverlay,
+  Flex,
+  Heading,
+  HStack,
+  Link,
+  Select,
+  Spinner,
+  Table,
+  TableContainer,
+  Tbody,
+  Td,
+  Text,
+  Th,
+  Thead,
+  Tr,
+  useColorModeValue,
+  useDisclosure,
+  useToast,
+  VStack,
+  Wrap,
+  WrapItem,
+} from "@chakra-ui/react";
+import { ExternalLinkIcon } from "@chakra-ui/icons";
+import { useSearchParams } from "react-router-dom";
+import {
+  CatalogApiError,
+  dandiUrl,
+  fetchCatalogStatistics,
+  listCatalogDatasets,
+  lookupCatalog,
+  searchCatalog,
+  sourceDisplayName,
+  toCatalogHits,
+  type CatalogHit,
+  type CatalogStatistics,
+} from "../../api/catalogApi";
+import KeywordSearch from "../../shared/keyWordSearch/keyWordSearch";
+
+const LIMIT_OPTIONS = [20, 50, 100] as const;
+const DEFAULT_LIMIT = 50;
+const SOURCE_ORDER = ["dandi", "cbs", "brainminds", "bmb_human", "aws"];
+const DRAWER_PRIMARY_KEYS = new Set([
+  "name",
+  "description",
+  "source",
+  "source_display",
+  "dataset_id",
+  "dataset_doi",
+  "primary_paper_url",
+  "primary_paper_title",
+]);
+
+function parseLimit(raw: string | null): number {
+  const parsed = Number(raw);
+  if (LIMIT_OPTIONS.includes(parsed as (typeof LIMIT_OPTIONS)[number])) {
+    return parsed;
+  }
+  return DEFAULT_LIMIT;
+}
+
+function catalogErrorMessage(err: unknown): string {
+  if (err instanceof CatalogApiError) {
+    switch (err.code) {
+      case "catalog_unconfigured":
+      case "unconfigured":
+        return "Catalog is not connected on this server yet.";
+      case "catalog_unavailable":
+      case "unavailable":
+        return "Catalog is temporarily unavailable.";
+      case "catalog_auth":
+        return "Catalog authentication failed.";
+      case "catalog_not_found":
+        return "Dataset not found.";
+      default:
+        return err.message || "Catalog request failed.";
+    }
+  }
+  if (err instanceof Error && err.message) return err.message;
+  return "Catalog request failed.";
+}
+
+function formatTimestamp(value: string | null | undefined): string {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return date.toLocaleString();
+}
+
+function truncateText(value: string | null, max = 80): string {
+  if (!value) return "—";
+  if (value.length <= max) return value;
+  return `${value.slice(0, max)}…`;
+}
+
+function isHttpUrl(value: string): boolean {
+  return /^https?:\/\//i.test(value);
+}
+
+function doiHref(doi: string): string {
+  if (isHttpUrl(doi)) return doi;
+  return `https://doi.org/${doi.replace(/^doi:/i, "")}`;
+}
+
+function hitToRecord(hit: CatalogHit): Record<string, unknown> {
+  return { ...hit };
+}
+
+function stringField(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  if (typeof value === "string") return value;
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  return "";
+}
+
+function formatFieldValue(value: unknown): string {
+  if (value === null || value === undefined) return "—";
+  if (typeof value === "string") return value || "—";
+  if (typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}
+
+function sortSourceCounts(
+  counts: Record<string, number>
+): Array<[string, number]> {
+  return Object.entries(counts).sort(([a], [b]) => {
+    const ia = SOURCE_ORDER.indexOf(a);
+    const ib = SOURCE_ORDER.indexOf(b);
+    if (ia === -1 && ib === -1) return a.localeCompare(b);
+    if (ia === -1) return 1;
+    if (ib === -1) return -1;
+    return ia - ib;
+  });
+}
+
+const CatalogView: React.FC = () => {
+  const [searchParams, setSearchParams] = useSearchParams();
+  const query = searchParams.get("q") ?? "";
+  const source = searchParams.get("source") ?? "";
+  const limit = parseLimit(searchParams.get("limit"));
+
+  const [stats, setStats] = useState<CatalogStatistics | null>(null);
+  const [statsError, setStatsError] = useState<unknown>(null);
+  const [statsLoading, setStatsLoading] = useState(true);
+
+  const [hits, setHits] = useState<CatalogHit[]>([]);
+  const [resultsError, setResultsError] = useState<unknown>(null);
+  const [resultsLoading, setResultsLoading] = useState(true);
+
+  const [selectedHit, setSelectedHit] = useState<CatalogHit | null>(null);
+  const [lookupRecord, setLookupRecord] = useState<Record<string, unknown> | null>(
+    null
+  );
+  const [lookupError, setLookupError] = useState<unknown>(null);
+  const [lookupLoading, setLookupLoading] = useState(false);
+
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const toast = useToast();
+
+  const pageBg = useColorModeValue("#f7f7f8", "gray.900");
+  const cardBg = useColorModeValue("white", "gray.800");
+  const borderColor = useColorModeValue("gray.200", "gray.700");
+  const muted = useColorModeValue("gray.600", "gray.400");
+  const hoverBg = useColorModeValue("gray.50", "gray.700");
+  const headerBg = useColorModeValue("gray.50", "gray.700");
+
+  const updateParams = useCallback(
+    (next: { q?: string; source?: string; limit?: number }) => {
+      const params = new URLSearchParams(searchParams);
+      if (next.q !== undefined) {
+        if (next.q) params.set("q", next.q);
+        else params.delete("q");
+      }
+      if (next.source !== undefined) {
+        if (next.source) params.set("source", next.source);
+        else params.delete("source");
+      }
+      if (next.limit !== undefined) {
+        if (next.limit !== DEFAULT_LIMIT) params.set("limit", String(next.limit));
+        else params.delete("limit");
+      }
+      setSearchParams(params);
+    },
+    [searchParams, setSearchParams]
+  );
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setStatsLoading(true);
+      setStatsError(null);
+      try {
+        const data = await fetchCatalogStatistics();
+        if (!cancelled) setStats(data);
+      } catch (err) {
+        if (!cancelled) {
+          setStats(null);
+          setStatsError(err);
+        }
+      } finally {
+        if (!cancelled) setStatsLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      setResultsLoading(true);
+      setResultsError(null);
+      try {
+        const data = query.trim()
+          ? await searchCatalog({
+              query: query.trim(),
+              source: source || undefined,
+              limit,
+            })
+          : await listCatalogDatasets({
+              source: source || undefined,
+              limit,
+            });
+        if (!cancelled) setHits(toCatalogHits(data));
+      } catch (err) {
+        if (!cancelled) {
+          setHits([]);
+          setResultsError(err);
+        }
+      } finally {
+        if (!cancelled) setResultsLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [query, source, limit]);
+
+  const sourceChips = useMemo(
+    () => (stats ? sortSourceCounts(stats.source_counts) : []),
+    [stats]
+  );
+
+  const pageError = resultsError ?? (hits.length === 0 ? statsError : null);
+  const record = lookupRecord ?? (selectedHit ? hitToRecord(selectedHit) : {});
+  const drawerTitle =
+    stringField(record, "name") ||
+    stringField(record, "dataset_id") ||
+    selectedHit?.name ||
+    selectedHit?.dataset_id ||
+    "Dataset";
+  const drawerDescription =
+    stringField(record, "description") || selectedHit?.description || "";
+  const drawerSource =
+    stringField(record, "source") || selectedHit?.source || "";
+  const drawerSourceDisplay =
+    stringField(record, "source_display") || selectedHit?.source_display || "";
+  const drawerId =
+    stringField(record, "dataset_id") || selectedHit?.dataset_id || "";
+  const drawerDoi =
+    stringField(record, "dataset_doi") || selectedHit?.dataset_doi || "";
+  const drawerPaperUrl =
+    stringField(record, "primary_paper_url") ||
+    selectedHit?.primary_paper_url ||
+    "";
+  const drawerPaperTitle =
+    stringField(record, "primary_paper_title") ||
+    selectedHit?.primary_paper_title ||
+    "";
+
+  const remainingFields = Object.entries(record).filter(
+    ([key]) => !DRAWER_PRIMARY_KEYS.has(key)
+  );
+
+  const handleSearch = useCallback(
+    (keyword: string) => {
+      updateParams({ q: keyword.trim() });
+    },
+    [updateParams]
+  );
+
+  const openRow = async (hit: CatalogHit) => {
+    setSelectedHit(hit);
+    setLookupRecord(null);
+    setLookupError(null);
+    setLookupLoading(true);
+    onOpen();
+    try {
+      const data = await lookupCatalog({
+        source: hit.source || undefined,
+        id: hit.dataset_id,
+      });
+      setLookupRecord(data.record);
+    } catch (err) {
+      setLookupError(err);
+    } finally {
+      setLookupLoading(false);
+    }
+  };
+
+  const copyText = async (label: string, value: string) => {
+    try {
+      await navigator.clipboard.writeText(value);
+      toast({
+        title: `${label} copied`,
+        status: "success",
+        duration: 2000,
+        isClosable: true,
+      });
+    } catch {
+      toast({
+        title: `Could not copy ${label}`,
+        status: "error",
+        duration: 3000,
+        isClosable: true,
+      });
+    }
+  };
+
+  const lastUpdatedHint = (() => {
+    if (!stats) return null;
+    const parts: string[] = [];
+    if (stats.timestamp) {
+      parts.push(`Last updated ${formatTimestamp(stats.timestamp)}`);
+    }
+    if (stats.sync_status) {
+      const syncBits = Object.entries(stats.sync_status).map(([src, row]) => {
+        const label = sourceDisplayName(src);
+        const status = row.status || "unknown";
+        const when = row.last_sync ? ` ${formatTimestamp(row.last_sync)}` : "";
+        return `${label}: ${status}${when}`;
+      });
+      if (syncBits.length) parts.push(syncBits.join(" · "));
+    }
+    return parts.length ? parts.join(" — ") : null;
+  })();
+
+  return (
+    <Box height="100%" width="100%" overflow="auto" bg={pageBg}>
+      <VStack
+        spacing={5}
+        width="100%"
+        p={6}
+        maxWidth="1200px"
+        mx="auto"
+        align="stretch"
+      >
+        <Box>
+          <Heading size="lg">Catalog</Heading>
+          <Text mt={1} color={muted}>
+            Search public neuroscience datasets (DANDI, CBS, Brain/MINDS, …)
+          </Text>
+        </Box>
+
+        <Box
+          bg={cardBg}
+          borderWidth="1px"
+          borderColor={borderColor}
+          borderRadius="md"
+          p={4}
+        >
+          {statsLoading ? (
+            <HStack>
+              <Spinner size="sm" />
+              <Text fontSize="sm" color={muted}>
+                Loading catalog statistics…
+              </Text>
+            </HStack>
+          ) : stats ? (
+            <VStack align="stretch" spacing={3}>
+              <Wrap spacing={2}>
+                <WrapItem>
+                  <Button
+                    size="sm"
+                    variant={source === "" ? "solid" : "outline"}
+                    colorScheme="blue"
+                    onClick={() => updateParams({ source: "" })}
+                  >
+                    All ({stats.total_datasets})
+                  </Button>
+                </WrapItem>
+                {sourceChips.map(([src, count]) => (
+                  <WrapItem key={src}>
+                    <Button
+                      size="sm"
+                      variant={source === src ? "solid" : "outline"}
+                      colorScheme="blue"
+                      onClick={() => updateParams({ source: src })}
+                    >
+                      {sourceDisplayName(src)} ({count})
+                    </Button>
+                  </WrapItem>
+                ))}
+              </Wrap>
+              {lastUpdatedHint && (
+                <Text fontSize="xs" color={muted}>
+                  {lastUpdatedHint}
+                </Text>
+              )}
+            </VStack>
+          ) : statsError ? (
+            <Alert status="warning" borderRadius="md">
+              <AlertIcon />
+              {catalogErrorMessage(statsError)}
+            </Alert>
+          ) : (
+            <Text fontSize="sm" color={muted}>
+              Catalog statistics are unavailable.
+            </Text>
+          )}
+        </Box>
+
+        <Flex gap={3} wrap="wrap" align="center">
+          <Box flex="1" minW="240px">
+            <KeywordSearch
+              key={query}
+              initialKeyword={query}
+              onSearch={handleSearch}
+              placeholder="Search datasets…"
+              size="md"
+            />
+          </Box>
+          <HStack>
+            <Text fontSize="sm" color={muted} whiteSpace="nowrap">
+              Limit
+            </Text>
+            <Select
+              size="md"
+              width="100px"
+              value={String(limit)}
+              onChange={(event) =>
+                updateParams({ limit: parseLimit(event.target.value) })
+              }
+              bg={cardBg}
+            >
+              {LIMIT_OPTIONS.map((value) => (
+                <option key={value} value={value}>
+                  {value}
+                </option>
+              ))}
+            </Select>
+          </HStack>
+        </Flex>
+
+        {resultsLoading && (
+          <HStack
+            bg={cardBg}
+            borderWidth="1px"
+            borderColor={borderColor}
+            borderRadius="md"
+            p={6}
+            justify="center"
+          >
+            <Spinner />
+            <Text color={muted}>Loading datasets…</Text>
+          </HStack>
+        )}
+
+        {!resultsLoading && pageError && (
+          <Alert status="error" borderRadius="md">
+            <AlertIcon />
+            {catalogErrorMessage(pageError)}
+          </Alert>
+        )}
+
+        {!resultsLoading && !pageError && hits.length === 0 && (
+          <Alert status="info" borderRadius="md">
+            <AlertIcon />
+            {query.trim()
+              ? "No datasets matched this search."
+              : "No datasets are available in the catalog."}
+          </Alert>
+        )}
+
+        {!resultsLoading && !pageError && hits.length > 0 && (
+          <Box
+            bg={cardBg}
+            borderWidth="1px"
+            borderColor={borderColor}
+            borderRadius="md"
+            overflow="hidden"
+          >
+            <TableContainer>
+              <Table variant="simple" size="md">
+                <Thead bg={headerBg}>
+                  <Tr>
+                    <Th>Source</Th>
+                    <Th>ID</Th>
+                    <Th>Name</Th>
+                    <Th>Draft</Th>
+                    <Th>Description</Th>
+                    <Th>Synced</Th>
+                  </Tr>
+                </Thead>
+                <Tbody>
+                  {hits.map((hit) => (
+                    <Tr
+                      key={`${hit.source}:${hit.dataset_id}:${hit.table ?? ""}`}
+                      cursor="pointer"
+                      _hover={{ bg: hoverBg }}
+                      onClick={() => {
+                        void openRow(hit);
+                      }}
+                    >
+                      <Td>
+                        <Badge>
+                          {sourceDisplayName(hit.source, hit.source_display)}
+                        </Badge>
+                      </Td>
+                      <Td fontFamily="mono" fontSize="sm">
+                        {hit.dataset_id}
+                      </Td>
+                      <Td>{hit.name}</Td>
+                      <Td>
+                        {hit.is_draft ? (
+                          <Badge colorScheme="orange">Draft</Badge>
+                        ) : (
+                          <Text color={muted}>—</Text>
+                        )}
+                      </Td>
+                      <Td maxW="360px">
+                        <Text whiteSpace="nowrap" isTruncated title={hit.description ?? ""}>
+                          {truncateText(hit.description, 80)}
+                        </Text>
+                      </Td>
+                      <Td whiteSpace="nowrap" color={muted} fontSize="sm">
+                        {formatTimestamp(hit.synced_at)}
+                      </Td>
+                    </Tr>
+                  ))}
+                </Tbody>
+              </Table>
+            </TableContainer>
+          </Box>
+        )}
+      </VStack>
+
+      <Drawer isOpen={isOpen} placement="right" onClose={onClose} size="lg">
+        <DrawerOverlay />
+        <DrawerContent bg={cardBg}>
+          <DrawerCloseButton />
+          <DrawerHeader borderBottomWidth="1px" borderColor={borderColor}>
+            <VStack align="stretch" spacing={2} pr={6}>
+              <Heading size="md">{drawerTitle}</Heading>
+              <HStack>
+                {drawerSource && (
+                  <Badge colorScheme="blue">
+                    {sourceDisplayName(drawerSource, drawerSourceDisplay)}
+                  </Badge>
+                )}
+                {lookupLoading && <Spinner size="sm" />}
+              </HStack>
+            </VStack>
+          </DrawerHeader>
+          <DrawerBody>
+            <VStack align="stretch" spacing={4} py={2}>
+              {lookupError && (
+                <Alert status="error" borderRadius="md">
+                  <AlertIcon />
+                  {catalogErrorMessage(lookupError)}
+                </Alert>
+              )}
+
+              <Box>
+                <Text
+                  fontSize="xs"
+                  textTransform="uppercase"
+                  color={muted}
+                  mb={1}
+                >
+                  Description
+                </Text>
+                <Text whiteSpace="pre-wrap">
+                  {drawerDescription || "No description."}
+                </Text>
+              </Box>
+
+              <Box>
+                <Text
+                  fontSize="xs"
+                  textTransform="uppercase"
+                  color={muted}
+                  mb={2}
+                >
+                  Links
+                </Text>
+                <VStack align="stretch" spacing={1}>
+                  {drawerDoi && (
+                    <Link href={doiHref(drawerDoi)} isExternal>
+                      {drawerDoi} <ExternalLinkIcon mx="2px" />
+                    </Link>
+                  )}
+                  {drawerPaperUrl && (
+                    <Link href={drawerPaperUrl} isExternal>
+                      {drawerPaperTitle || drawerPaperUrl}{" "}
+                      <ExternalLinkIcon mx="2px" />
+                    </Link>
+                  )}
+                  {drawerSource === "dandi" && drawerId && (
+                    <Link href={dandiUrl(drawerId)} isExternal>
+                      DANDI archive <ExternalLinkIcon mx="2px" />
+                    </Link>
+                  )}
+                  {!drawerDoi && !drawerPaperUrl && drawerSource !== "dandi" && (
+                    <Text color={muted}>No external links.</Text>
+                  )}
+                </VStack>
+              </Box>
+
+              {remainingFields.length > 0 && (
+                <Box>
+                  <Text
+                    fontSize="xs"
+                    textTransform="uppercase"
+                    color={muted}
+                    mb={2}
+                  >
+                    Details
+                  </Text>
+                  <VStack align="stretch" spacing={2}>
+                    {remainingFields.map(([key, value]) => (
+                      <Flex key={key} gap={3} wrap="wrap">
+                        <Text
+                          fontWeight="semibold"
+                          minW="160px"
+                          fontSize="sm"
+                          color={muted}
+                        >
+                          {key}
+                        </Text>
+                        <Text flex="1" fontSize="sm" wordBreak="break-word">
+                          {formatFieldValue(value)}
+                        </Text>
+                      </Flex>
+                    ))}
+                  </VStack>
+                </Box>
+              )}
+            </VStack>
+          </DrawerBody>
+          <DrawerFooter borderTopWidth="1px" borderColor={borderColor}>
+            <HStack>
+              <Button
+                onClick={() => {
+                  void copyText("Dataset id", drawerId);
+                }}
+                isDisabled={!drawerId}
+              >
+                Copy dataset id
+              </Button>
+              <Button
+                onClick={() => {
+                  void copyText("JSON", JSON.stringify(record, null, 2));
+                }}
+              >
+                Copy JSON
+              </Button>
+            </HStack>
+          </DrawerFooter>
+        </DrawerContent>
+      </Drawer>
+    </Box>
+  );
+};
+
+export default CatalogView;

--- a/gui/workflow_frontend/vitest.config.ts
+++ b/gui/workflow_frontend/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary
- Keycloak-gated `/api/catalog/{statistics,search,lookup,datasets}/` proxy to private mdb (keyword search only; search token never in the browser).
- Catalog UI at `/catalog` plus four MCP tools on the same surface.
- Rebuild-from-main ops: pin Docker network `neuro-workflow_workflow`, HTTP contract (`deployment/MDB_CLIENT_CONTRACT.md`), and deploy runbook (`deployment/DEPLOY_MDB_CATALOG.md`). `MDB_API_TOKEN` stays in gitignored `gui/workflow_backend/.env` (never `VITE_*`, never committed).
- No public 8004, no nginx `/mdb`, no catalog copy into Postgres, no sync/chat/agent routes, no `MDB_ADMIN_TOKEN` in NeuroWorkflow.

## Test plan
- [ ] `cd gui/workflow_backend && poetry run pytest django-project/tests/test_catalog.py -q`
- [ ] `cd gui/workflow_frontend && npm test && npx tsc -b`
- [ ] Confirm frontend `src/` has no `8004` / `VITE_MDB`
- [ ] Follow `deployment/DEPLOY_MDB_CATALOG.md`: mdb joins `neuro-workflow_workflow` as `mdb-mindsdb`; backend `curl http://mdb-mindsdb:8004/` → 200
- [ ] Set `MDB_BASE_URL` + `MDB_API_TOKEN` in backend `.env` only, SIGHUP gunicorn, rebuild frontend only, then login → Catalog → search `mouse` → open a DANDI row
