### PR TITLE
Add type-to-find search on the project workspace list

### DIFF
--- a/deployment/task8-project-search-progress.log
+++ b/deployment/task8-project-search-progress.log
@@ -86,3 +86,39 @@ Verify:
 - 6 vitest passed.
 - Combobox types clean.
 
+
+## Step 7 — Commit and open PR
+Date: 2026-09-01
+
+Done:
+- Commit b7e4f032 Let users type-to-find a project instead of scrolling a native select.
+- Pushed origin/feat/project-type-to-find
+- PR: https://github.com/oist/neuro-workflow/pull/91
+- No force-push. No live deploy.
+
+## Step 8 — Close-out
+Date: 2026-09-01
+
+Files changed:
+- gui/workflow_frontend/package.json
+- gui/workflow_frontend/pnpm-lock.yaml
+- gui/workflow_frontend/vitest.config.ts
+- gui/workflow_frontend/src/views/home/components/projectFilter.ts
+- gui/workflow_frontend/src/views/home/components/projectFilter.test.ts
+- gui/workflow_frontend/src/views/home/components/projectSelector.tsx
+- deployment/task8-project-search-progress.log
+
+Tests:
+- vitest projectFilter.test.ts: 6 passed
+
+Live UI:
+- Cannot UI-verify the new combobox on https://neuro-workflow.dbrain.jp/ without a frontend deploy. That was an explicit ship-target choice (PR only).
+- Baseline: live Project Workspace is still a native <select> with ~45 projects, ~166px wide, names truncated, no type-to-filter field.
+
+Non-goals left alone:
+- Server-side search / pagination
+- Project visibility, rename, create-project page
+- Live deploy
+- Chakra v3 upgrade
+- Other <Select>s (HPC Target, create form)
+

--- a/deployment/task8-project-search-progress.log
+++ b/deployment/task8-project-search-progress.log
@@ -122,3 +122,138 @@ Non-goals left alone:
 - Chakra v3 upgrade
 - Other <Select>s (HPC Target, create form)
 
+
+## Audit Step 1 — Plan-match matrix
+Date: 2026-09-01
+Plan: task_8_audit_fix (plan-match audit and integrity close-out)
+Worktree: /home/nw-kirill/neuro-workflow-project-search
+Branch: feat/project-type-to-find
+PR: https://github.com/oist/neuro-workflow/pull/91
+
+Compared original plan project_type-to-find_cb62c30e.plan.md + this log + worktree.
+Original plan file was not edited.
+
+### Original plan bullets
+
+Worktree from origin/main, not task4 or /data
+- Status: implemented
+- Evidence: HEAD started at e1218777; branch feat/project-type-to-find.
+
+chakra-react-select@5 (not v6); React 19 / Chakra 2
+- Status: implemented
+- Evidence: package.json "chakra-react-select": "5"; lockfile 5.1.1; peers @chakra-ui/react 2.x, react >=18.
+
+projectFilter.ts: ProjectOption, toProjectOptions, match name/description/visibility, no React
+- Status: implemented with visibility GAP (Audit Step 2)
+- Evidence: name + description substring work. visibility uses includes() so short tokens like "p"/"lic" can match. Tests leak: "private" also hits description "private sandbox".
+
+Vitest: empty query, fMRI name, description-only, public/private, no-match
+- Status: implemented; visibility cases need honest fixtures (Audit Step 2)
+
+ProjectCombobox: isSearchable, isClearable, placeholder, aria-label, size sm
+- Status: implemented
+- Evidence: projectSelector.tsx ProjectCombobox props.
+
+filterOption via matchProjectFilterOption
+- Status: implemented
+
+Option UI: name, visibility badge, one-line description; noOptionsMessage
+- Status: implemented
+
+menuPortalTarget document.body, high z-index, minW 220px, selected label ellipsis
+- Status: implemented; menu color vs white island GAP (Audit Step 3)
+
+onChange id | '' ; HomeView falsy unload
+- Status: implemented
+- Evidence: onProjectChange(option ? option.value : ''); handleProjectChange if (!projectId).
+
+Backspace must not unload the open workflow
+- Status: GAP (Audit Step 3)
+- Evidence: isClearable without backspaceRemovesValue={false}; react-select defaults backspaceRemovesValue true.
+
+HPC Target Select unchanged
+- Status: implemented
+
+Ship: GitHub PR only, no live deploy
+- Status: implemented
+- Evidence: PR #91; dbrain.jp still native select.
+
+Non-goals left alone (server search, Chakra v3, other Selects, live deploy)
+- Status: implemented (still non-goals)
+
+### Gaps scheduled for later audit steps only
+1. Visibility word/prefix matching + honest tests (Step 2)
+2. backspaceRemovesValue false + island-colored menu (Step 3)
+
+Verify:
+- This section appended after Step 8; earlier sections not rewritten.
+- No application code changed in this step.
+
+
+## Audit Step 2 — Visibility as a word; honest tests
+Date: 2026-09-01
+
+Done:
+- projectFilter.ts: visibility matches only exact public/private or prefix of that word with length >= 3. Name and description stay substring. No includes() on the enum.
+- projectFilter.test.ts: private fixture description no longer contains "private". Added prefix tests (pub/priv) and short "p" does not select public projects via visibility.
+- Existing fMRI / description / empty / no-match cases kept.
+
+Verify: vitest in Audit Step 4.
+
+
+## Audit Step 3 — Combobox Backspace and island-colored menu
+Date: 2026-09-01
+
+Done:
+- projectSelector.tsx: backspaceRemovesValue={false}; isClearable kept (X still unloads).
+- chakraStyles menu / menuList / option: white background, gray border, gray.800 text to match the hardcoded white island.
+- HPC Target Select and HomeView unchanged.
+
+Verify: vitest in Audit Step 4.
+
+
+## Audit Step 4 — Isolated verification
+Date: 2026-09-01
+
+Commands (cwd gui/workflow_frontend, host Node v18 so pnpm@9):
+- npx --yes pnpm@9 test
+
+First run: FAIL 1/8
+- "does not treat a short p as a visibility filter" expected only id 2.
+- fMRI description "Bold maps..." still matches substring "p" (name/description, not visibility). Plan allows that.
+
+Fix (this audit only): assert id 3 (public, no "p" in name/description) is not in results.
+
+Second run: PASS 8/8
+- Test Files  1 passed (1)
+- Tests  8 passed (8)
+- Duration  602ms
+
+Live dbrain.jp: baseline only (native select until a frontend deploy). No deploy this step.
+
+
+## Audit Step 6 — Close-out
+Date: 2026-09-01
+
+Files changed:
+- gui/workflow_frontend/src/views/home/components/projectFilter.ts
+- gui/workflow_frontend/src/views/home/components/projectFilter.test.ts
+- gui/workflow_frontend/src/views/home/components/projectSelector.tsx
+- deployment/task8-project-search-progress.log
+
+Gaps closed:
+1. Visibility is exact public/private or prefix length >= 3; tests no longer leak via description.
+2. backspaceRemovesValue={false}; X still clears via isClearable.
+3. Portaled menu forced to white island palette.
+
+Tests: pnpm test (vitest run) 8 passed.
+
+Cannot UI-verify on dbrain.jp without a deploy. Live site remains native select (expected).
+
+Original non-goals left alone:
+- No server-side project search
+- No Chakra v3
+- No other <Select>s
+- No live Docker rebuild / no writes under /data/neuro-workflow
+- No second PR; ship remains PR #91
+

--- a/deployment/task8-project-search-progress.log
+++ b/deployment/task8-project-search-progress.log
@@ -1,0 +1,88 @@
+# Task 8 — Project search / type-to-find
+Branch: feat/project-type-to-find
+Base: origin/main (e1218777 Merge pull request #87)
+Worktree: /home/nw-kirill/neuro-workflow-project-search
+This file is append-only. Do not rewrite earlier sections.
+
+## Step 1 — Worktree and progress log
+Date: 2026-09-01
+
+Done:
+- Fetched origin/main from /home/nw-kirill/neuro-workflow-catalog.
+- Created worktree /home/nw-kirill/neuro-workflow-project-search on branch feat/project-type-to-find tracking origin/main.
+- HEAD: e1218777 Merge pull request #87 from oist/feat/node-figure-display
+- Created this progress log.
+
+Verify:
+- git status: feat/project-type-to-find...origin/main
+- Did not touch /data/neuro-workflow.
+- Did not start from feat/node-palette-my-shared.
+
+
+## Step 2 — Add chakra-react-select@5
+Date: 2026-09-01
+
+Done:
+- In gui/workflow_frontend: npx pnpm@9 add chakra-react-select@5 (host Node 18; pnpm 11 needs Node 22).
+- Installed chakra-react-select 5.1.1 (not v6).
+- peerDependencies: @chakra-ui/react 2.x, react >=18 (accepts 19), react-dom >=18.
+- Depends on react-select ^5.10.2.
+- package.json + pnpm-lock.yaml updated. node_modules not to be committed.
+
+Verify:
+- package.json dependency is "chakra-react-select": "5"
+- lockfile has chakra-react-select@5.1.1
+
+
+## Step 3 — Pure filter helper
+Date: 2026-09-01
+
+Done:
+- Added gui/workflow_frontend/src/views/home/components/projectFilter.ts
+  - ProjectOption: value (id), label (name), description, visibility
+  - toProjectOptions, matchProjectOption (label + description + public/private)
+  - filterProjectOptions, matchProjectFilterOption (react-select adapter)
+- No React in this file.
+
+## Step 4 — Vitest for the helper
+Date: 2026-09-01
+
+Done:
+- Added gui/workflow_frontend/src/views/home/components/projectFilter.test.ts
+  - empty query, name substring fMRI, description-only hit, public/private, no match
+- origin/main had vitest as a devDependency but no vitest.config.ts or "test" script.
+  Added the same include (src/**/*.test.ts) and "test": "vitest run" so Step 6 can run.
+  Without this, the tests could not be executed.
+
+Verify: pnpm test / vitest in Step 6.
+
+
+## Step 5 — Replace native project Select
+Date: 2026-09-01
+
+Done:
+- projectSelector.tsx: Project Workspace list is chakra-react-select (alias ProjectCombobox).
+  isSearchable, isClearable, placeholder Search projects..., aria-label Choose a project, size sm.
+  filterOption = matchProjectFilterOption (name + description + visibility).
+  Option menu: name, Public/Private badge, one-line description.
+  noOptionsMessage: No matching projects.
+  menuPortalTarget document.body, menuPortal zIndex 1500, menuList minWidth 320px.
+  Closed control Box flex 1 minW 220px; selected label ellipsizes.
+- Chakra Select for HPC Target in the edit modal is unchanged.
+
+Verify: vitest + tsc in Step 6.
+
+
+## Step 6 — Isolated verification
+Date: 2026-09-01
+
+Done:
+- Frontend: pnpm test (vitest run) — 6 passed (projectFilter.test.ts).
+- tsc -p tsconfig.app.json --noEmit: no errors in projectSelector.tsx, projectFilter.ts, or projectFilter.test.ts.
+  Pre-existing missing modules on this tree (zustand, @chakra-ui/theme-tools) were not introduced by this work and were not fixed.
+- Live /data/neuro-workflow and dbrain.jp were not modified.
+
+Verify:
+- 6 vitest passed.
+- Combobox types clean.
+

--- a/gui/workflow_frontend/package.json
+++ b/gui/workflow_frontend/package.json
@@ -10,7 +10,8 @@
     "preview": "vite preview",
     "api:build": "aspida --config aspida.config.cjs",
     "api:watch": "aspida --config aspida.config.cjs --watch",
-    "dev:docker": "vite --config vite.config.docker.ts"
+    "dev:docker": "vite --config vite.config.docker.ts",
+    "test": "vitest run"
   },
   "dependencies": {
     "@aspida/fetch": "^1.14.0",
@@ -20,6 +21,7 @@
     "@emotion/styled": "^11.14.0",
     "@xyflow/react": "^12.5.5",
     "aspida": "^1.14.0",
+    "chakra-react-select": "5",
     "framer-motion": "^12.7.4",
     "keycloak-js": "^26.2.3",
     "next-themes": "^0.4.6",

--- a/gui/workflow_frontend/pnpm-lock.yaml
+++ b/gui/workflow_frontend/pnpm-lock.yaml
@@ -13,46 +13,49 @@ importers:
         version: 1.14.0(aspida@1.14.0)
       '@chakra-ui/icons':
         specifier: ^2.2.4
-        version: 2.2.4(@chakra-ui/react@2.8.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
+        version: 2.2.4(@chakra-ui/react@2.8.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@chakra-ui/react':
         specifier: ^2.8.0
-        version: 2.8.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 2.8.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@emotion/react':
         specifier: ^11.14.0
-        version: 11.14.0(@types/react@19.1.1)(react@19.1.0)
+        version: 11.14.0(@types/react@19.1.1)(react@19.2.6)
       '@emotion/styled':
         specifier: ^11.14.0
-        version: 11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0)
+        version: 11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6)
       '@xyflow/react':
         specifier: ^12.5.5
-        version: 12.5.5(@types/react@19.1.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 12.5.5(@types/react@19.1.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       aspida:
         specifier: ^1.14.0
         version: 1.14.0
+      chakra-react-select:
+        specifier: '5'
+        version: 5.1.1(@chakra-ui/react@2.8.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       framer-motion:
         specifier: ^12.7.4
-        version: 12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       keycloak-js:
         specifier: ^26.2.3
         version: 26.2.4
       next-themes:
         specifier: ^0.4.6
-        version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       react:
-        specifier: ^19.0.0
-        version: 19.1.0
+        specifier: 19.2.6
+        version: 19.2.6
       react-dom:
-        specifier: ^19.0.0
-        version: 19.1.0(react@19.1.0)
+        specifier: 19.2.6
+        version: 19.2.6(react@19.2.6)
       react-icons:
         specifier: ^5.5.0
-        version: 5.5.0(react@19.1.0)
+        version: 5.5.0(react@19.2.6)
       react-router-dom:
         specifier: ^7.5.0
-        version: 7.5.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 7.5.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       zundo:
         specifier: ^2.3.0
-        version: 2.3.0(zustand@4.5.6(@types/react@19.1.1)(react@19.1.0))
+        version: 2.3.0(zustand@4.5.6(@types/react@19.1.1)(react@19.2.6))
     devDependencies:
       '@aspida/axios':
         specifier: ^1.14.0
@@ -928,6 +931,15 @@ packages:
     resolution: {integrity: sha512-ZAoA40rNMPwSm+AeHpCq8STiNAwzWLJuP8Xv4CHIc9wv/PSuExjMrmjfYNj682vW0OOiZ1HKxzvjQr9XZIisQA==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
+  '@floating-ui/core@1.8.0':
+    resolution: {integrity: sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ==}
+
+  '@floating-ui/dom@1.8.0':
+    resolution: {integrity: sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg==}
+
+  '@floating-ui/utils@0.2.12':
+    resolution: {integrity: sha512-HpCo8tmWzLVad5s2d19EhAz5zqrrQ6s69qd6moPMQvkOuSwDT1YgRfWSVuc4ennqrgv3OHppiOGMQ7oC13yIww==}
+
   '@humanfs/core@0.19.1':
     resolution: {integrity: sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==}
     engines: {node: '>=18.18.0'}
@@ -1015,67 +1027,56 @@ packages:
     resolution: {integrity: sha512-y/qUMOpJxBMy8xCXD++jeu8t7kzjlOCkoxxajL58G62PJGBZVl/Gwpm7JK9+YvlB701rcQTzjUZ1JgUoPTnoQA==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.40.0':
     resolution: {integrity: sha512-GoCsPibtVdJFPv/BOIvBKO/XmwZLwaNWdyD8TKlXuqp0veo2sHE+A/vpMQ5iSArRUz/uaoj4h5S6Pn0+PdhRjg==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.40.0':
     resolution: {integrity: sha512-L5ZLphTjjAD9leJzSLI7rr8fNqJMlGDKlazW2tX4IUF9P7R5TMQPElpH82Q7eNIDQnQlAyiNVfRPfP2vM5Avvg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.40.0':
     resolution: {integrity: sha512-ATZvCRGCDtv1Y4gpDIXsS+wfFeFuLwVxyUBSLawjgXK2tRE6fnsQEkE4csQQYWlBlsFztRzCnBvWVfcae/1qxQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.40.0':
     resolution: {integrity: sha512-wG9e2XtIhd++QugU5MD9i7OnpaVb08ji3P1y/hNbxrQ3sYEelKJOq1UJ5dXczeo6Hj2rfDEL5GdtkMSVLa/AOg==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.40.0':
     resolution: {integrity: sha512-vgXfWmj0f3jAUvC7TZSU/m/cOE558ILWDzS7jBhiCAFpY2WEBn5jqgbqvmzlMjtp8KlLcBlXVD2mkTSEQE6Ixw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.40.0':
     resolution: {integrity: sha512-uJkYTugqtPZBS3Z136arevt/FsKTF/J9dEMTX/cwR7lsAW4bShzI2R0pJVw+hcBTWF4dxVckYh72Hk3/hWNKvA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.40.0':
     resolution: {integrity: sha512-rKmSj6EXQRnhSkE22+WvrqOqRtk733x3p5sWpZilhmjnkHkpeCgWsFFo0dGnUGeA+OZjRl3+VYq+HyCOEuwcxQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.40.0':
     resolution: {integrity: sha512-SpnYlAfKPOoVsQqmTFJ0usx0z84bzGOS9anAC0AZ3rdSo3snecihbhFTlJZ8XMwzqAcodjFU4+/SM311dqE5Sw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.40.0':
     resolution: {integrity: sha512-RcDGMtqF9EFN8i2RYN2W+64CdHruJ5rPqrlYw+cgM3uOVPSsnAQps7cpjXe9be/yDp8UC7VLoCoKC8J3Kn2FkQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.40.0':
     resolution: {integrity: sha512-HZvjpiUmSNx5zFgwtQAV1GaGazT2RWvqeDi0hV+AtC8unqqDSsaFjPxfsO6qPtKRRg25SisACWnJ37Yio8ttaw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.40.0':
     resolution: {integrity: sha512-UtZQQI5k/b8d7d3i9AZmA/t+Q4tk3hOC0tMOMSq2GlMYOfxbesxG4mJSeDp0EHs30N9bsfwUvs3zF4v/RzOeTQ==}
@@ -1150,6 +1151,11 @@ packages:
     resolution: {integrity: sha512-XGJkWF41Qq305SKWEILa1O8vzhb3aOo3ogBlSmiqNko/WmRb6QIaweuZCXjKygVDXpzXb5wyxKTSOsmkuqj+Qw==}
     peerDependencies:
       '@types/react': ^19.0.0
+
+  '@types/react-transition-group@4.4.12':
+    resolution: {integrity: sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==}
+    peerDependencies:
+      '@types/react': '*'
 
   '@types/react@19.1.1':
     resolution: {integrity: sha512-ePapxDL7qrgqSF67s0h9m412d9DbXyC1n59O2st+9rjuuamWsZuD2w55rqY12CbzsZ7uVXb5Nw0gEp9Z8MMutQ==}
@@ -1341,6 +1347,14 @@ packages:
     resolution: {integrity: sha512-mCuXncKXk5iCLhfhwTc0izo0gtEmpz5CtG2y8GiOINBlMVS6v8TMRc5TaLWKS6692m9+dVVfzgeVxR5UxWHTYw==}
     engines: {node: '>=12'}
 
+  chakra-react-select@5.1.1:
+    resolution: {integrity: sha512-edHbC7Vnzw055f8jtAJzs7K/NXOt8q9AEqJmA/VANZzJeEPwhZ5JtjZBpXa/WORndEhiD2NSYcKrGL+73S306w==}
+    peerDependencies:
+      '@chakra-ui/react': 2.x
+      '@emotion/react': ^11.8.1
+      react: '>=18'
+      react-dom: '>=18'
+
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
     engines: {node: '>=10'}
@@ -1463,6 +1477,9 @@ packages:
 
   detect-node-es@1.1.0:
     resolution: {integrity: sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==}
+
+  dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
 
   dotenv@16.5.0:
     resolution: {integrity: sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==}
@@ -1822,6 +1839,9 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  memoize-one@6.0.0:
+    resolution: {integrity: sha512-rkpe71W0N0c0Xz6QD0eJETuWAJGnJ9afsl1srmwPrI+yBCkge5EycXXbYRyvL29zZVUWQCY7InPRCv3GDXuZNw==}
+
   merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
     engines: {node: '>= 8'}
@@ -1957,10 +1977,10 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
 
-  react-dom@19.1.0:
-    resolution: {integrity: sha512-Xs1hdnE+DyKgeHJeJznQmYMIBG3TKIHJJT95Q58nHLSrElKlGQqDTR2HQ9fx5CN/Gk6Vh/kupBTDLU11/nDk/g==}
+  react-dom@19.2.6:
+    resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
     peerDependencies:
-      react: ^19.1.0
+      react: ^19.2.6
 
   react-fast-compare@3.2.1:
     resolution: {integrity: sha512-xTYf9zFim2pEif/Fw16dBiXpe0hoy5PxcD8+OwBnTtNLfIm3g6WxhKNurY+6OmdH1u6Ta/W/Vl6vjbYP1MFnDg==}
@@ -2023,6 +2043,12 @@ packages:
       react-dom:
         optional: true
 
+  react-select@5.10.2:
+    resolution: {integrity: sha512-Z33nHdEFWq9tfnfVXaiM12rbJmk+QjFEztWLtmXqQhz6Al4UZZ9xc0wiatmGtUOCCnHN0WizL3tCMYRENX4rVQ==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
     engines: {node: '>=10'}
@@ -2033,8 +2059,14 @@ packages:
       '@types/react':
         optional: true
 
-  react@19.1.0:
-    resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
+  react-transition-group@4.4.5:
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
+
+  react@19.2.6:
+    resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
     engines: {node: '>=0.10.0'}
 
   readdirp@3.6.0:
@@ -2065,8 +2097,8 @@ packages:
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
-  scheduler@0.26.0:
-    resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
@@ -2207,6 +2239,15 @@ packages:
     peerDependencies:
       '@types/react': '*'
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-isomorphic-layout-effect@1.2.1:
+    resolution: {integrity: sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
     peerDependenciesMeta:
       '@types/react':
         optional: true
@@ -2482,579 +2523,579 @@ snapshots:
       '@babel/helper-string-parser': 7.25.9
       '@babel/helper-validator-identifier': 7.25.9
 
-  '@chakra-ui/accordion@2.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/accordion@2.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/descendant': 3.1.0(react@19.1.0)
-      '@chakra-ui/icon': 3.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/react-context': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-controllable-state': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.1.0)
+      '@chakra-ui/descendant': 3.1.0(react@19.2.6)
+      '@chakra-ui/icon': 3.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/react-context': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-controllable-state': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.2.6)
       '@chakra-ui/shared-utils': 2.0.5
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/transition': 2.1.0(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      framer-motion: 12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/transition': 2.1.0(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      framer-motion: 12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/alert@2.2.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/alert@2.2.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/icon': 3.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/react-context': 2.1.0(react@19.1.0)
+      '@chakra-ui/icon': 3.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/react-context': 2.1.0(react@19.2.6)
       '@chakra-ui/shared-utils': 2.0.5
-      '@chakra-ui/spinner': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/spinner': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
   '@chakra-ui/anatomy@2.2.0': {}
 
-  '@chakra-ui/avatar@2.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/avatar@2.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/image': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/react-children-utils': 2.0.6(react@19.1.0)
-      '@chakra-ui/react-context': 2.1.0(react@19.1.0)
+      '@chakra-ui/image': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/react-children-utils': 2.0.6(react@19.2.6)
+      '@chakra-ui/react-context': 2.1.0(react@19.2.6)
       '@chakra-ui/shared-utils': 2.0.5
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/breadcrumb@2.2.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/breadcrumb@2.2.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/react-children-utils': 2.0.6(react@19.1.0)
-      '@chakra-ui/react-context': 2.1.0(react@19.1.0)
+      '@chakra-ui/react-children-utils': 2.0.6(react@19.2.6)
+      '@chakra-ui/react-context': 2.1.0(react@19.2.6)
       '@chakra-ui/shared-utils': 2.0.5
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
   '@chakra-ui/breakpoint-utils@2.0.8':
     dependencies:
       '@chakra-ui/shared-utils': 2.0.5
 
-  '@chakra-ui/button@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/button@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/react-context': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.1.0)
+      '@chakra-ui/react-context': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.2.6)
       '@chakra-ui/shared-utils': 2.0.5
-      '@chakra-ui/spinner': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/spinner': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/card@2.2.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/card@2.2.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@chakra-ui/shared-utils': 2.0.5
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/checkbox@2.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/checkbox@2.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/form-control': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/react-context': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-types': 2.0.7(react@19.1.0)
-      '@chakra-ui/react-use-callback-ref': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-controllable-state': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-safe-layout-effect': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-update-effect': 2.1.0(react@19.1.0)
+      '@chakra-ui/form-control': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/react-context': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-types': 2.0.7(react@19.2.6)
+      '@chakra-ui/react-use-callback-ref': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-controllable-state': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-safe-layout-effect': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-update-effect': 2.1.0(react@19.2.6)
       '@chakra-ui/shared-utils': 2.0.5
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/visually-hidden': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/visually-hidden': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@zag-js/focus-visible': 0.10.5
-      react: 19.1.0
+      react: 19.2.6
 
-  '@chakra-ui/clickable@2.1.0(react@19.1.0)':
+  '@chakra-ui/clickable@2.1.0(react@19.2.6)':
     dependencies:
-      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.1.0)
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.2.6)
       '@chakra-ui/shared-utils': 2.0.5
-      react: 19.1.0
+      react: 19.2.6
 
-  '@chakra-ui/close-button@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/close-button@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/icon': 3.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/icon': 3.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/color-mode@2.2.0(react@19.1.0)':
+  '@chakra-ui/color-mode@2.2.0(react@19.2.6)':
     dependencies:
-      '@chakra-ui/react-use-safe-layout-effect': 2.1.0(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/react-use-safe-layout-effect': 2.1.0(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/control-box@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/control-box@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/counter@2.1.0(react@19.1.0)':
+  '@chakra-ui/counter@2.1.0(react@19.2.6)':
     dependencies:
       '@chakra-ui/number-utils': 2.0.7
-      '@chakra-ui/react-use-callback-ref': 2.1.0(react@19.1.0)
+      '@chakra-ui/react-use-callback-ref': 2.1.0(react@19.2.6)
       '@chakra-ui/shared-utils': 2.0.5
-      react: 19.1.0
+      react: 19.2.6
 
-  '@chakra-ui/css-reset@2.2.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/css-reset@2.2.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@emotion/react': 11.14.0(@types/react@19.1.1)(react@19.1.0)
-      react: 19.1.0
+      '@emotion/react': 11.14.0(@types/react@19.1.1)(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/descendant@3.1.0(react@19.1.0)':
+  '@chakra-ui/descendant@3.1.0(react@19.2.6)':
     dependencies:
-      '@chakra-ui/react-context': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/react-context': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.2.6)
+      react: 19.2.6
 
   '@chakra-ui/dom-utils@2.1.0': {}
 
-  '@chakra-ui/editable@3.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/editable@3.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/react-context': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-types': 2.0.7(react@19.1.0)
-      '@chakra-ui/react-use-callback-ref': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-controllable-state': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-focus-on-pointer-down': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-safe-layout-effect': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-update-effect': 2.1.0(react@19.1.0)
+      '@chakra-ui/react-context': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-types': 2.0.7(react@19.2.6)
+      '@chakra-ui/react-use-callback-ref': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-controllable-state': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-focus-on-pointer-down': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-safe-layout-effect': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-update-effect': 2.1.0(react@19.2.6)
       '@chakra-ui/shared-utils': 2.0.5
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
   '@chakra-ui/event-utils@2.0.8': {}
 
-  '@chakra-ui/focus-lock@2.1.0(@types/react@19.1.1)(react@19.1.0)':
+  '@chakra-ui/focus-lock@2.1.0(@types/react@19.1.1)(react@19.2.6)':
     dependencies:
       '@chakra-ui/dom-utils': 2.1.0
-      react: 19.1.0
-      react-focus-lock: 2.13.6(@types/react@19.1.1)(react@19.1.0)
+      react: 19.2.6
+      react-focus-lock: 2.13.6(@types/react@19.1.1)(react@19.2.6)
     transitivePeerDependencies:
       - '@types/react'
 
-  '@chakra-ui/form-control@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/form-control@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/icon': 3.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/react-context': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-types': 2.0.7(react@19.1.0)
-      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.1.0)
+      '@chakra-ui/icon': 3.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/react-context': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-types': 2.0.7(react@19.2.6)
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.2.6)
       '@chakra-ui/shared-utils': 2.0.5
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/hooks@2.2.0(react@19.1.0)':
+  '@chakra-ui/hooks@2.2.0(react@19.2.6)':
     dependencies:
-      '@chakra-ui/react-utils': 2.0.12(react@19.1.0)
+      '@chakra-ui/react-utils': 2.0.12(react@19.2.6)
       '@chakra-ui/utils': 2.0.15
       compute-scroll-into-view: 1.0.20
       copy-to-clipboard: 3.3.3
-      react: 19.1.0
+      react: 19.2.6
 
-  '@chakra-ui/icon@3.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/icon@3.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@chakra-ui/shared-utils': 2.0.5
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/icons@2.2.4(@chakra-ui/react@2.8.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/icons@2.2.4(@chakra-ui/react@2.8.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/react': 2.8.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/react': 2.8.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/image@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/image@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/react-use-safe-layout-effect': 2.1.0(react@19.1.0)
+      '@chakra-ui/react-use-safe-layout-effect': 2.1.0(react@19.2.6)
       '@chakra-ui/shared-utils': 2.0.5
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/input@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/input@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/form-control': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
+      '@chakra-ui/form-control': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@chakra-ui/object-utils': 2.1.0
-      '@chakra-ui/react-children-utils': 2.0.6(react@19.1.0)
-      '@chakra-ui/react-context': 2.1.0(react@19.1.0)
+      '@chakra-ui/react-children-utils': 2.0.6(react@19.2.6)
+      '@chakra-ui/react-context': 2.1.0(react@19.2.6)
       '@chakra-ui/shared-utils': 2.0.5
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/layout@2.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/layout@2.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@chakra-ui/breakpoint-utils': 2.0.8
-      '@chakra-ui/icon': 3.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
+      '@chakra-ui/icon': 3.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@chakra-ui/object-utils': 2.1.0
-      '@chakra-ui/react-children-utils': 2.0.6(react@19.1.0)
-      '@chakra-ui/react-context': 2.1.0(react@19.1.0)
+      '@chakra-ui/react-children-utils': 2.0.6(react@19.2.6)
+      '@chakra-ui/react-context': 2.1.0(react@19.2.6)
       '@chakra-ui/shared-utils': 2.0.5
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
   '@chakra-ui/lazy-utils@2.0.5': {}
 
-  '@chakra-ui/live-region@2.1.0(react@19.1.0)':
+  '@chakra-ui/live-region@2.1.0(react@19.2.6)':
     dependencies:
-      react: 19.1.0
+      react: 19.2.6
 
-  '@chakra-ui/media-query@3.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/media-query@3.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@chakra-ui/breakpoint-utils': 2.0.8
-      '@chakra-ui/react-env': 3.1.0(react@19.1.0)
+      '@chakra-ui/react-env': 3.1.0(react@19.2.6)
       '@chakra-ui/shared-utils': 2.0.5
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/menu@2.2.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/menu@2.2.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/clickable': 2.1.0(react@19.1.0)
-      '@chakra-ui/descendant': 3.1.0(react@19.1.0)
+      '@chakra-ui/clickable': 2.1.0(react@19.2.6)
+      '@chakra-ui/descendant': 3.1.0(react@19.2.6)
       '@chakra-ui/lazy-utils': 2.0.5
-      '@chakra-ui/popper': 3.1.0(react@19.1.0)
-      '@chakra-ui/react-children-utils': 2.0.6(react@19.1.0)
-      '@chakra-ui/react-context': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-animation-state': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-controllable-state': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-disclosure': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-focus-effect': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-outside-click': 2.2.0(react@19.1.0)
-      '@chakra-ui/react-use-update-effect': 2.1.0(react@19.1.0)
+      '@chakra-ui/popper': 3.1.0(react@19.2.6)
+      '@chakra-ui/react-children-utils': 2.0.6(react@19.2.6)
+      '@chakra-ui/react-context': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-animation-state': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-controllable-state': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-disclosure': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-focus-effect': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-outside-click': 2.2.0(react@19.2.6)
+      '@chakra-ui/react-use-update-effect': 2.1.0(react@19.2.6)
       '@chakra-ui/shared-utils': 2.0.5
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/transition': 2.1.0(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      framer-motion: 12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/transition': 2.1.0(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      framer-motion: 12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/modal@2.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(@types/react@19.1.1)(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/modal@2.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(@types/react@19.1.1)(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/close-button': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/focus-lock': 2.1.0(@types/react@19.1.1)(react@19.1.0)
-      '@chakra-ui/portal': 2.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/react-context': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-types': 2.0.7(react@19.1.0)
-      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.1.0)
+      '@chakra-ui/close-button': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/focus-lock': 2.1.0(@types/react@19.1.1)(react@19.2.6)
+      '@chakra-ui/portal': 2.1.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/react-context': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-types': 2.0.7(react@19.2.6)
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.2.6)
       '@chakra-ui/shared-utils': 2.0.5
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/transition': 2.1.0(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/transition': 2.1.0(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       aria-hidden: 1.2.4
-      framer-motion: 12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      react-remove-scroll: 2.6.3(@types/react@19.1.1)(react@19.1.0)
+      framer-motion: 12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-remove-scroll: 2.6.3(@types/react@19.1.1)(react@19.2.6)
     transitivePeerDependencies:
       - '@types/react'
 
-  '@chakra-ui/number-input@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/number-input@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/counter': 2.1.0(react@19.1.0)
-      '@chakra-ui/form-control': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/icon': 3.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/react-context': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-types': 2.0.7(react@19.1.0)
-      '@chakra-ui/react-use-callback-ref': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-event-listener': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-interval': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-safe-layout-effect': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-update-effect': 2.1.0(react@19.1.0)
+      '@chakra-ui/counter': 2.1.0(react@19.2.6)
+      '@chakra-ui/form-control': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/icon': 3.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/react-context': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-types': 2.0.7(react@19.2.6)
+      '@chakra-ui/react-use-callback-ref': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-event-listener': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-interval': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-safe-layout-effect': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-update-effect': 2.1.0(react@19.2.6)
       '@chakra-ui/shared-utils': 2.0.5
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
   '@chakra-ui/number-utils@2.0.7': {}
 
   '@chakra-ui/object-utils@2.1.0': {}
 
-  '@chakra-ui/pin-input@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/pin-input@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/descendant': 3.1.0(react@19.1.0)
-      '@chakra-ui/react-children-utils': 2.0.6(react@19.1.0)
-      '@chakra-ui/react-context': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-controllable-state': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.1.0)
+      '@chakra-ui/descendant': 3.1.0(react@19.2.6)
+      '@chakra-ui/react-children-utils': 2.0.6(react@19.2.6)
+      '@chakra-ui/react-context': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-controllable-state': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.2.6)
       '@chakra-ui/shared-utils': 2.0.5
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/popover@2.2.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/popover@2.2.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/close-button': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
+      '@chakra-ui/close-button': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@chakra-ui/lazy-utils': 2.0.5
-      '@chakra-ui/popper': 3.1.0(react@19.1.0)
-      '@chakra-ui/react-context': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-types': 2.0.7(react@19.1.0)
-      '@chakra-ui/react-use-animation-state': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-disclosure': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-focus-effect': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-focus-on-pointer-down': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.1.0)
+      '@chakra-ui/popper': 3.1.0(react@19.2.6)
+      '@chakra-ui/react-context': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-types': 2.0.7(react@19.2.6)
+      '@chakra-ui/react-use-animation-state': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-disclosure': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-focus-effect': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-focus-on-pointer-down': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.2.6)
       '@chakra-ui/shared-utils': 2.0.5
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      framer-motion: 12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      framer-motion: 12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/popper@3.1.0(react@19.1.0)':
+  '@chakra-ui/popper@3.1.0(react@19.2.6)':
     dependencies:
-      '@chakra-ui/react-types': 2.0.7(react@19.1.0)
-      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.1.0)
+      '@chakra-ui/react-types': 2.0.7(react@19.2.6)
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.2.6)
       '@popperjs/core': 2.11.8
-      react: 19.1.0
+      react: 19.2.6
 
-  '@chakra-ui/portal@2.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/portal@2.1.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/react-context': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-safe-layout-effect': 2.1.0(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
+      '@chakra-ui/react-context': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-safe-layout-effect': 2.1.0(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
 
-  '@chakra-ui/progress@2.2.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/progress@2.2.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/react-context': 2.1.0(react@19.1.0)
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/react-context': 2.1.0(react@19.2.6)
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/provider@2.4.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/provider@2.4.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/css-reset': 2.2.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/portal': 2.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/react-env': 3.1.0(react@19.1.0)
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
+      '@chakra-ui/css-reset': 2.2.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/portal': 2.1.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/react-env': 3.1.0(react@19.2.6)
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
       '@chakra-ui/utils': 2.0.15
-      '@emotion/react': 11.14.0(@types/react@19.1.1)(react@19.1.0)
-      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
+      '@emotion/react': 11.14.0(@types/react@19.1.1)(react@19.2.6)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
 
-  '@chakra-ui/radio@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/radio@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/form-control': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/react-context': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-types': 2.0.7(react@19.1.0)
-      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.1.0)
+      '@chakra-ui/form-control': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/react-context': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-types': 2.0.7(react@19.2.6)
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.2.6)
       '@chakra-ui/shared-utils': 2.0.5
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
       '@zag-js/focus-visible': 0.10.5
-      react: 19.1.0
+      react: 19.2.6
 
-  '@chakra-ui/react-children-utils@2.0.6(react@19.1.0)':
+  '@chakra-ui/react-children-utils@2.0.6(react@19.2.6)':
     dependencies:
-      react: 19.1.0
+      react: 19.2.6
 
-  '@chakra-ui/react-context@2.1.0(react@19.1.0)':
+  '@chakra-ui/react-context@2.1.0(react@19.2.6)':
     dependencies:
-      react: 19.1.0
+      react: 19.2.6
 
-  '@chakra-ui/react-env@3.1.0(react@19.1.0)':
+  '@chakra-ui/react-env@3.1.0(react@19.2.6)':
     dependencies:
-      '@chakra-ui/react-use-safe-layout-effect': 2.1.0(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/react-use-safe-layout-effect': 2.1.0(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/react-types@2.0.7(react@19.1.0)':
+  '@chakra-ui/react-types@2.0.7(react@19.2.6)':
     dependencies:
-      react: 19.1.0
+      react: 19.2.6
 
-  '@chakra-ui/react-use-animation-state@2.1.0(react@19.1.0)':
-    dependencies:
-      '@chakra-ui/dom-utils': 2.1.0
-      '@chakra-ui/react-use-event-listener': 2.1.0(react@19.1.0)
-      react: 19.1.0
-
-  '@chakra-ui/react-use-callback-ref@2.1.0(react@19.1.0)':
-    dependencies:
-      react: 19.1.0
-
-  '@chakra-ui/react-use-controllable-state@2.1.0(react@19.1.0)':
-    dependencies:
-      '@chakra-ui/react-use-callback-ref': 2.1.0(react@19.1.0)
-      react: 19.1.0
-
-  '@chakra-ui/react-use-disclosure@2.1.0(react@19.1.0)':
-    dependencies:
-      '@chakra-ui/react-use-callback-ref': 2.1.0(react@19.1.0)
-      react: 19.1.0
-
-  '@chakra-ui/react-use-event-listener@2.1.0(react@19.1.0)':
-    dependencies:
-      '@chakra-ui/react-use-callback-ref': 2.1.0(react@19.1.0)
-      react: 19.1.0
-
-  '@chakra-ui/react-use-focus-effect@2.1.0(react@19.1.0)':
+  '@chakra-ui/react-use-animation-state@2.1.0(react@19.2.6)':
     dependencies:
       '@chakra-ui/dom-utils': 2.1.0
-      '@chakra-ui/react-use-event-listener': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-safe-layout-effect': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-update-effect': 2.1.0(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/react-use-event-listener': 2.1.0(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/react-use-focus-on-pointer-down@2.1.0(react@19.1.0)':
+  '@chakra-ui/react-use-callback-ref@2.1.0(react@19.2.6)':
     dependencies:
-      '@chakra-ui/react-use-event-listener': 2.1.0(react@19.1.0)
-      react: 19.1.0
+      react: 19.2.6
 
-  '@chakra-ui/react-use-interval@2.1.0(react@19.1.0)':
+  '@chakra-ui/react-use-controllable-state@2.1.0(react@19.2.6)':
     dependencies:
-      '@chakra-ui/react-use-callback-ref': 2.1.0(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/react-use-callback-ref': 2.1.0(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/react-use-latest-ref@2.1.0(react@19.1.0)':
+  '@chakra-ui/react-use-disclosure@2.1.0(react@19.2.6)':
     dependencies:
-      react: 19.1.0
+      '@chakra-ui/react-use-callback-ref': 2.1.0(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/react-use-merge-refs@2.1.0(react@19.1.0)':
+  '@chakra-ui/react-use-event-listener@2.1.0(react@19.2.6)':
     dependencies:
-      react: 19.1.0
+      '@chakra-ui/react-use-callback-ref': 2.1.0(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/react-use-outside-click@2.2.0(react@19.1.0)':
+  '@chakra-ui/react-use-focus-effect@2.1.0(react@19.2.6)':
     dependencies:
-      '@chakra-ui/react-use-callback-ref': 2.1.0(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/dom-utils': 2.1.0
+      '@chakra-ui/react-use-event-listener': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-safe-layout-effect': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-update-effect': 2.1.0(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/react-use-pan-event@2.1.0(react@19.1.0)':
+  '@chakra-ui/react-use-focus-on-pointer-down@2.1.0(react@19.2.6)':
+    dependencies:
+      '@chakra-ui/react-use-event-listener': 2.1.0(react@19.2.6)
+      react: 19.2.6
+
+  '@chakra-ui/react-use-interval@2.1.0(react@19.2.6)':
+    dependencies:
+      '@chakra-ui/react-use-callback-ref': 2.1.0(react@19.2.6)
+      react: 19.2.6
+
+  '@chakra-ui/react-use-latest-ref@2.1.0(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+
+  '@chakra-ui/react-use-merge-refs@2.1.0(react@19.2.6)':
+    dependencies:
+      react: 19.2.6
+
+  '@chakra-ui/react-use-outside-click@2.2.0(react@19.2.6)':
+    dependencies:
+      '@chakra-ui/react-use-callback-ref': 2.1.0(react@19.2.6)
+      react: 19.2.6
+
+  '@chakra-ui/react-use-pan-event@2.1.0(react@19.2.6)':
     dependencies:
       '@chakra-ui/event-utils': 2.0.8
-      '@chakra-ui/react-use-latest-ref': 2.1.0(react@19.1.0)
+      '@chakra-ui/react-use-latest-ref': 2.1.0(react@19.2.6)
       framesync: 6.1.2
-      react: 19.1.0
+      react: 19.2.6
 
-  '@chakra-ui/react-use-previous@2.1.0(react@19.1.0)':
+  '@chakra-ui/react-use-previous@2.1.0(react@19.2.6)':
     dependencies:
-      react: 19.1.0
+      react: 19.2.6
 
-  '@chakra-ui/react-use-safe-layout-effect@2.1.0(react@19.1.0)':
+  '@chakra-ui/react-use-safe-layout-effect@2.1.0(react@19.2.6)':
     dependencies:
-      react: 19.1.0
+      react: 19.2.6
 
-  '@chakra-ui/react-use-size@2.1.0(react@19.1.0)':
+  '@chakra-ui/react-use-size@2.1.0(react@19.2.6)':
     dependencies:
       '@zag-js/element-size': 0.10.5
-      react: 19.1.0
+      react: 19.2.6
 
-  '@chakra-ui/react-use-timeout@2.1.0(react@19.1.0)':
+  '@chakra-ui/react-use-timeout@2.1.0(react@19.2.6)':
     dependencies:
-      '@chakra-ui/react-use-callback-ref': 2.1.0(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/react-use-callback-ref': 2.1.0(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/react-use-update-effect@2.1.0(react@19.1.0)':
+  '@chakra-ui/react-use-update-effect@2.1.0(react@19.2.6)':
     dependencies:
-      react: 19.1.0
+      react: 19.2.6
 
-  '@chakra-ui/react-utils@2.0.12(react@19.1.0)':
+  '@chakra-ui/react-utils@2.0.12(react@19.2.6)':
     dependencies:
       '@chakra-ui/utils': 2.0.15
-      react: 19.1.0
+      react: 19.2.6
 
-  '@chakra-ui/react@2.8.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/react@2.8.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/accordion': 2.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/alert': 2.2.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/avatar': 2.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/breadcrumb': 2.2.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/button': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/card': 2.2.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/checkbox': 2.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/close-button': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/control-box': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/counter': 2.1.0(react@19.1.0)
-      '@chakra-ui/css-reset': 2.2.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/editable': 3.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/focus-lock': 2.1.0(@types/react@19.1.1)(react@19.1.0)
-      '@chakra-ui/form-control': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/hooks': 2.2.0(react@19.1.0)
-      '@chakra-ui/icon': 3.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/image': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/input': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/layout': 2.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/live-region': 2.1.0(react@19.1.0)
-      '@chakra-ui/media-query': 3.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/menu': 2.2.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/modal': 2.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(@types/react@19.1.1)(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/number-input': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/pin-input': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/popover': 2.2.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/popper': 3.1.0(react@19.1.0)
-      '@chakra-ui/portal': 2.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/progress': 2.2.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/provider': 2.4.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/radio': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/react-env': 3.1.0(react@19.1.0)
-      '@chakra-ui/select': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/skeleton': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/skip-nav': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/slider': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/spinner': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/stat': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/stepper': 2.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
+      '@chakra-ui/accordion': 2.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/alert': 2.2.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/avatar': 2.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/breadcrumb': 2.2.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/button': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/card': 2.2.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/checkbox': 2.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/close-button': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/control-box': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/counter': 2.1.0(react@19.2.6)
+      '@chakra-ui/css-reset': 2.2.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/editable': 3.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/focus-lock': 2.1.0(@types/react@19.1.1)(react@19.2.6)
+      '@chakra-ui/form-control': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/hooks': 2.2.0(react@19.2.6)
+      '@chakra-ui/icon': 3.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/image': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/input': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/layout': 2.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/live-region': 2.1.0(react@19.2.6)
+      '@chakra-ui/media-query': 3.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/menu': 2.2.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/modal': 2.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(@types/react@19.1.1)(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/number-input': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/pin-input': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/popover': 2.2.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/popper': 3.1.0(react@19.2.6)
+      '@chakra-ui/portal': 2.1.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/progress': 2.2.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/provider': 2.4.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/radio': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/react-env': 3.1.0(react@19.2.6)
+      '@chakra-ui/select': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/skeleton': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/skip-nav': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/slider': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/spinner': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/stat': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/stepper': 2.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@chakra-ui/styled-system': 2.9.1
-      '@chakra-ui/switch': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/table': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/tabs': 2.2.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/tag': 3.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/textarea': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
+      '@chakra-ui/switch': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/table': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/tabs': 2.2.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/tag': 3.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/textarea': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@chakra-ui/theme': 3.2.0(@chakra-ui/styled-system@2.9.1)
       '@chakra-ui/theme-utils': 2.0.19
-      '@chakra-ui/toast': 7.0.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/tooltip': 2.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/transition': 2.1.0(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)
+      '@chakra-ui/toast': 7.0.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/tooltip': 2.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/transition': 2.1.0(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@chakra-ui/utils': 2.0.15
-      '@chakra-ui/visually-hidden': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@emotion/react': 11.14.0(@types/react@19.1.1)(react@19.1.0)
-      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0)
-      framer-motion: 12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
+      '@chakra-ui/visually-hidden': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@emotion/react': 11.14.0(@types/react@19.1.1)(react@19.2.6)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6)
+      framer-motion: 12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:
       - '@types/react'
 
-  '@chakra-ui/select@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/select@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/form-control': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
+      '@chakra-ui/form-control': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@chakra-ui/shared-utils': 2.0.5
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
   '@chakra-ui/shared-utils@2.0.5': {}
 
-  '@chakra-ui/skeleton@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/skeleton@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/media-query': 3.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/react-use-previous': 2.1.0(react@19.1.0)
+      '@chakra-ui/media-query': 3.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/react-use-previous': 2.1.0(react@19.2.6)
       '@chakra-ui/shared-utils': 2.0.5
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/skip-nav@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/skip-nav@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/slider@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/slider@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@chakra-ui/number-utils': 2.0.7
-      '@chakra-ui/react-context': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-types': 2.0.7(react@19.1.0)
-      '@chakra-ui/react-use-callback-ref': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-controllable-state': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-latest-ref': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-pan-event': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-size': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-update-effect': 2.1.0(react@19.1.0)
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/react-context': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-types': 2.0.7(react@19.2.6)
+      '@chakra-ui/react-use-callback-ref': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-controllable-state': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-latest-ref': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-pan-event': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-size': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-update-effect': 2.1.0(react@19.2.6)
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/spinner@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/spinner@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@chakra-ui/shared-utils': 2.0.5
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/stat@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/stat@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/icon': 3.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/react-context': 2.1.0(react@19.1.0)
+      '@chakra-ui/icon': 3.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/react-context': 2.1.0(react@19.2.6)
       '@chakra-ui/shared-utils': 2.0.5
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/stepper@2.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/stepper@2.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/icon': 3.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/react-context': 2.1.0(react@19.1.0)
+      '@chakra-ui/icon': 3.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/react-context': 2.1.0(react@19.2.6)
       '@chakra-ui/shared-utils': 2.0.5
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
   '@chakra-ui/styled-system@2.9.1':
     dependencies:
@@ -3062,61 +3103,61 @@ snapshots:
       csstype: 3.1.3
       lodash.mergewith: 4.6.2
 
-  '@chakra-ui/switch@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/switch@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/checkbox': 2.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
+      '@chakra-ui/checkbox': 2.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@chakra-ui/shared-utils': 2.0.5
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      framer-motion: 12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      framer-motion: 12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/color-mode': 2.2.0(react@19.1.0)
+      '@chakra-ui/color-mode': 2.2.0(react@19.2.6)
       '@chakra-ui/object-utils': 2.1.0
-      '@chakra-ui/react-utils': 2.0.12(react@19.1.0)
+      '@chakra-ui/react-utils': 2.0.12(react@19.2.6)
       '@chakra-ui/styled-system': 2.9.1
       '@chakra-ui/theme-utils': 2.0.19
       '@chakra-ui/utils': 2.0.15
-      '@emotion/react': 11.14.0(@types/react@19.1.1)(react@19.1.0)
-      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0)
-      react: 19.1.0
+      '@emotion/react': 11.14.0(@types/react@19.1.1)(react@19.2.6)
+      '@emotion/styled': 11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6)
+      react: 19.2.6
       react-fast-compare: 3.2.1
 
-  '@chakra-ui/table@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/table@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/react-context': 2.1.0(react@19.1.0)
+      '@chakra-ui/react-context': 2.1.0(react@19.2.6)
       '@chakra-ui/shared-utils': 2.0.5
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/tabs@2.2.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/tabs@2.2.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/clickable': 2.1.0(react@19.1.0)
-      '@chakra-ui/descendant': 3.1.0(react@19.1.0)
+      '@chakra-ui/clickable': 2.1.0(react@19.2.6)
+      '@chakra-ui/descendant': 3.1.0(react@19.2.6)
       '@chakra-ui/lazy-utils': 2.0.5
-      '@chakra-ui/react-children-utils': 2.0.6(react@19.1.0)
-      '@chakra-ui/react-context': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-controllable-state': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-safe-layout-effect': 2.1.0(react@19.1.0)
+      '@chakra-ui/react-children-utils': 2.0.6(react@19.2.6)
+      '@chakra-ui/react-context': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-controllable-state': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-safe-layout-effect': 2.1.0(react@19.2.6)
       '@chakra-ui/shared-utils': 2.0.5
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/tag@3.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/tag@3.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/icon': 3.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/react-context': 2.1.0(react@19.1.0)
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/icon': 3.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/react-context': 2.1.0(react@19.2.6)
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
-  '@chakra-ui/textarea@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/textarea@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/form-control': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
+      '@chakra-ui/form-control': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
       '@chakra-ui/shared-utils': 2.0.5
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
   '@chakra-ui/theme-tools@2.1.0(@chakra-ui/styled-system@2.9.1)':
     dependencies:
@@ -3139,42 +3180,42 @@ snapshots:
       '@chakra-ui/styled-system': 2.9.1
       '@chakra-ui/theme-tools': 2.1.0(@chakra-ui/styled-system@2.9.1)
 
-  '@chakra-ui/toast@7.0.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/toast@7.0.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/alert': 2.2.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/close-button': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/portal': 2.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/react-context': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-timeout': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-update-effect': 2.1.0(react@19.1.0)
+      '@chakra-ui/alert': 2.2.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/close-button': 2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/portal': 2.1.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/react-context': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-timeout': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-update-effect': 2.1.0(react@19.2.6)
       '@chakra-ui/shared-utils': 2.0.5
       '@chakra-ui/styled-system': 2.9.1
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
       '@chakra-ui/theme': 3.2.0(@chakra-ui/styled-system@2.9.1)
-      framer-motion: 12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
+      framer-motion: 12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
 
-  '@chakra-ui/tooltip@2.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/tooltip@2.3.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@chakra-ui/dom-utils': 2.1.0
-      '@chakra-ui/popper': 3.1.0(react@19.1.0)
-      '@chakra-ui/portal': 2.1.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      '@chakra-ui/react-types': 2.0.7(react@19.1.0)
-      '@chakra-ui/react-use-disclosure': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-event-listener': 2.1.0(react@19.1.0)
-      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.1.0)
+      '@chakra-ui/popper': 3.1.0(react@19.2.6)
+      '@chakra-ui/portal': 2.1.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@chakra-ui/react-types': 2.0.7(react@19.2.6)
+      '@chakra-ui/react-use-disclosure': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-event-listener': 2.1.0(react@19.2.6)
+      '@chakra-ui/react-use-merge-refs': 2.1.0(react@19.2.6)
       '@chakra-ui/shared-utils': 2.0.5
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      framer-motion: 12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      framer-motion: 12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
 
-  '@chakra-ui/transition@2.1.0(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/transition@2.1.0(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@chakra-ui/shared-utils': 2.0.5
-      framer-motion: 12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      framer-motion: 12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
   '@chakra-ui/utils@2.0.15':
     dependencies:
@@ -3183,10 +3224,10 @@ snapshots:
       framesync: 6.1.2
       lodash.mergewith: 4.6.2
 
-  '@chakra-ui/visually-hidden@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0))(react@19.1.0)':
+  '@chakra-ui/visually-hidden@2.1.0(@chakra-ui/system@2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0))(react@19.1.0)
-      react: 19.1.0
+      '@chakra-ui/system': 2.6.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(react@19.2.6)
+      react: 19.2.6
 
   '@emotion/babel-plugin@11.13.5':
     dependencies:
@@ -3220,17 +3261,17 @@ snapshots:
 
   '@emotion/memoize@0.9.0': {}
 
-  '@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0)':
+  '@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6)':
     dependencies:
       '@babel/runtime': 7.27.0
       '@emotion/babel-plugin': 11.13.5
       '@emotion/cache': 11.14.0
       '@emotion/serialize': 1.3.3
-      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.1.0)
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.6)
       '@emotion/utils': 1.4.2
       '@emotion/weak-memoize': 0.4.0
       hoist-non-react-statics: 3.3.2
-      react: 19.1.0
+      react: 19.2.6
     optionalDependencies:
       '@types/react': 19.1.1
     transitivePeerDependencies:
@@ -3246,16 +3287,16 @@ snapshots:
 
   '@emotion/sheet@1.4.0': {}
 
-  '@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.1.0))(@types/react@19.1.1)(react@19.1.0)':
+  '@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6)':
     dependencies:
       '@babel/runtime': 7.27.0
       '@emotion/babel-plugin': 11.13.5
       '@emotion/is-prop-valid': 1.3.1
-      '@emotion/react': 11.14.0(@types/react@19.1.1)(react@19.1.0)
+      '@emotion/react': 11.14.0(@types/react@19.1.1)(react@19.2.6)
       '@emotion/serialize': 1.3.3
-      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.1.0)
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.6)
       '@emotion/utils': 1.4.2
-      react: 19.1.0
+      react: 19.2.6
     optionalDependencies:
       '@types/react': 19.1.1
     transitivePeerDependencies:
@@ -3263,9 +3304,9 @@ snapshots:
 
   '@emotion/unitless@0.10.0': {}
 
-  '@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@19.1.0)':
+  '@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@19.2.6)':
     dependencies:
-      react: 19.1.0
+      react: 19.2.6
 
   '@emotion/utils@1.4.2': {}
 
@@ -3393,6 +3434,17 @@ snapshots:
     dependencies:
       '@eslint/core': 0.13.0
       levn: 0.4.1
+
+  '@floating-ui/core@1.8.0':
+    dependencies:
+      '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/dom@1.8.0':
+    dependencies:
+      '@floating-ui/core': 1.8.0
+      '@floating-ui/utils': 0.2.12
+
+  '@floating-ui/utils@0.2.12': {}
 
   '@humanfs/core@0.19.1': {}
 
@@ -3564,6 +3616,10 @@ snapshots:
     dependencies:
       '@types/react': 19.1.1
 
+  '@types/react-transition-group@4.4.12(@types/react@19.1.1)':
+    dependencies:
+      '@types/react': 19.1.1
+
   '@types/react@19.1.1':
     dependencies:
       csstype: 3.1.3
@@ -3696,13 +3752,13 @@ snapshots:
       loupe: 3.1.3
       tinyrainbow: 2.0.0
 
-  '@xyflow/react@12.5.5(@types/react@19.1.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@xyflow/react@12.5.5(@types/react@19.1.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@xyflow/system': 0.0.55
       classcat: 5.0.5
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      zustand: 4.5.6(@types/react@19.1.1)(react@19.1.0)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      zustand: 4.5.6(@types/react@19.1.1)(react@19.2.6)
     transitivePeerDependencies:
       - '@types/react'
       - immer
@@ -3821,6 +3877,17 @@ snapshots:
       loupe: 3.1.3
       pathval: 2.0.0
 
+  chakra-react-select@5.1.1(@chakra-ui/react@2.8.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      '@chakra-ui/react': 2.8.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@emotion/styled@11.14.0(@emotion/react@11.14.0(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(react@19.2.6))(@types/react@19.1.1)(framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6))(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      '@emotion/react': 11.14.0(@types/react@19.1.1)(react@19.2.6)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-select: 5.10.2(@types/react@19.1.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+    transitivePeerDependencies:
+      - '@types/react'
+      - supports-color
+
   chalk@4.1.2:
     dependencies:
       ansi-styles: 4.3.0
@@ -3935,6 +4002,11 @@ snapshots:
   delayed-stream@1.0.0: {}
 
   detect-node-es@1.1.0: {}
+
+  dom-helpers@5.2.1:
+    dependencies:
+      '@babel/runtime': 7.27.0
+      csstype: 3.1.3
 
   dotenv@16.5.0: {}
 
@@ -4134,15 +4206,15 @@ snapshots:
       hasown: 2.0.2
       mime-types: 2.1.35
 
-  framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  framer-motion@12.7.4(@emotion/is-prop-valid@1.3.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       motion-dom: 12.7.4
       motion-utils: 12.7.2
       tslib: 2.8.1
     optionalDependencies:
       '@emotion/is-prop-valid': 1.3.1
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
 
   framesync@6.1.2:
     dependencies:
@@ -4295,6 +4367,8 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  memoize-one@6.0.0: {}
+
   merge2@1.4.1: {}
 
   micromatch@4.0.8:
@@ -4330,10 +4404,10 @@ snapshots:
 
   natural-compare@1.4.0: {}
 
-  next-themes@0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  next-themes@0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
 
   node-releases@2.0.19: {}
 
@@ -4405,82 +4479,108 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  react-clientside-effect@1.2.7(react@19.1.0):
+  react-clientside-effect@1.2.7(react@19.2.6):
     dependencies:
       '@babel/runtime': 7.27.0
-      react: 19.1.0
+      react: 19.2.6
 
-  react-dom@19.1.0(react@19.1.0):
+  react-dom@19.2.6(react@19.2.6):
     dependencies:
-      react: 19.1.0
-      scheduler: 0.26.0
+      react: 19.2.6
+      scheduler: 0.27.0
 
   react-fast-compare@3.2.1: {}
 
-  react-focus-lock@2.13.6(@types/react@19.1.1)(react@19.1.0):
+  react-focus-lock@2.13.6(@types/react@19.1.1)(react@19.2.6):
     dependencies:
       '@babel/runtime': 7.27.0
       focus-lock: 1.3.6
       prop-types: 15.8.1
-      react: 19.1.0
-      react-clientside-effect: 1.2.7(react@19.1.0)
-      use-callback-ref: 1.3.3(@types/react@19.1.1)(react@19.1.0)
-      use-sidecar: 1.1.3(@types/react@19.1.1)(react@19.1.0)
+      react: 19.2.6
+      react-clientside-effect: 1.2.7(react@19.2.6)
+      use-callback-ref: 1.3.3(@types/react@19.1.1)(react@19.2.6)
+      use-sidecar: 1.1.3(@types/react@19.1.1)(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.1.1
 
-  react-icons@5.5.0(react@19.1.0):
+  react-icons@5.5.0(react@19.2.6):
     dependencies:
-      react: 19.1.0
+      react: 19.2.6
 
   react-is@16.13.1: {}
 
   react-refresh@0.14.2: {}
 
-  react-remove-scroll-bar@2.3.8(@types/react@19.1.1)(react@19.1.0):
+  react-remove-scroll-bar@2.3.8(@types/react@19.1.1)(react@19.2.6):
     dependencies:
-      react: 19.1.0
-      react-style-singleton: 2.2.3(@types/react@19.1.1)(react@19.1.0)
+      react: 19.2.6
+      react-style-singleton: 2.2.3(@types/react@19.1.1)(react@19.2.6)
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.1.1
 
-  react-remove-scroll@2.6.3(@types/react@19.1.1)(react@19.1.0):
+  react-remove-scroll@2.6.3(@types/react@19.1.1)(react@19.2.6):
     dependencies:
-      react: 19.1.0
-      react-remove-scroll-bar: 2.3.8(@types/react@19.1.1)(react@19.1.0)
-      react-style-singleton: 2.2.3(@types/react@19.1.1)(react@19.1.0)
+      react: 19.2.6
+      react-remove-scroll-bar: 2.3.8(@types/react@19.1.1)(react@19.2.6)
+      react-style-singleton: 2.2.3(@types/react@19.1.1)(react@19.2.6)
       tslib: 2.8.1
-      use-callback-ref: 1.3.3(@types/react@19.1.1)(react@19.1.0)
-      use-sidecar: 1.1.3(@types/react@19.1.1)(react@19.1.0)
+      use-callback-ref: 1.3.3(@types/react@19.1.1)(react@19.2.6)
+      use-sidecar: 1.1.3(@types/react@19.1.1)(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.1.1
 
-  react-router-dom@7.5.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  react-router-dom@7.5.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
-      react-router: 7.5.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-router: 7.5.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
 
-  react-router@7.5.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+  react-router@7.5.0(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
       '@types/cookie': 0.6.0
       cookie: 1.0.2
-      react: 19.1.0
+      react: 19.2.6
       set-cookie-parser: 2.7.1
       turbo-stream: 2.4.0
     optionalDependencies:
-      react-dom: 19.1.0(react@19.1.0)
+      react-dom: 19.2.6(react@19.2.6)
 
-  react-style-singleton@2.2.3(@types/react@19.1.1)(react@19.1.0):
+  react-select@5.10.2(@types/react@19.1.1)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      '@babel/runtime': 7.27.0
+      '@emotion/cache': 11.14.0
+      '@emotion/react': 11.14.0(@types/react@19.1.1)(react@19.2.6)
+      '@floating-ui/dom': 1.8.0
+      '@types/react-transition-group': 4.4.12(@types/react@19.1.1)
+      memoize-one: 6.0.0
+      prop-types: 15.8.1
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-transition-group: 4.4.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      use-isomorphic-layout-effect: 1.2.1(@types/react@19.1.1)(react@19.2.6)
+    transitivePeerDependencies:
+      - '@types/react'
+      - supports-color
+
+  react-style-singleton@2.2.3(@types/react@19.1.1)(react@19.2.6):
     dependencies:
       get-nonce: 1.0.1
-      react: 19.1.0
+      react: 19.2.6
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.1.1
 
-  react@19.1.0: {}
+  react-transition-group@4.4.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      '@babel/runtime': 7.27.0
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
+  react@19.2.6: {}
 
   readdirp@3.6.0:
     dependencies:
@@ -4528,7 +4628,7 @@ snapshots:
     dependencies:
       queue-microtask: 1.2.3
 
-  scheduler@0.26.0: {}
+  scheduler@0.27.0: {}
 
   semver@6.3.1: {}
 
@@ -4622,24 +4722,30 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  use-callback-ref@1.3.3(@types/react@19.1.1)(react@19.1.0):
+  use-callback-ref@1.3.3(@types/react@19.1.1)(react@19.2.6):
     dependencies:
-      react: 19.1.0
+      react: 19.2.6
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.1.1
 
-  use-sidecar@1.1.3(@types/react@19.1.1)(react@19.1.0):
+  use-isomorphic-layout-effect@1.2.1(@types/react@19.1.1)(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+    optionalDependencies:
+      '@types/react': 19.1.1
+
+  use-sidecar@1.1.3(@types/react@19.1.1)(react@19.2.6):
     dependencies:
       detect-node-es: 1.1.0
-      react: 19.1.0
+      react: 19.2.6
       tslib: 2.8.1
     optionalDependencies:
       '@types/react': 19.1.1
 
-  use-sync-external-store@1.5.0(react@19.1.0):
+  use-sync-external-store@1.5.0(react@19.2.6):
     dependencies:
-      react: 19.1.0
+      react: 19.2.6
 
   vite-node@3.1.1(@types/node@22.15.21):
     dependencies:
@@ -4737,13 +4843,13 @@ snapshots:
 
   yocto-queue@0.1.0: {}
 
-  zundo@2.3.0(zustand@4.5.6(@types/react@19.1.1)(react@19.1.0)):
+  zundo@2.3.0(zustand@4.5.6(@types/react@19.1.1)(react@19.2.6)):
     dependencies:
-      zustand: 4.5.6(@types/react@19.1.1)(react@19.1.0)
+      zustand: 4.5.6(@types/react@19.1.1)(react@19.2.6)
 
-  zustand@4.5.6(@types/react@19.1.1)(react@19.1.0):
+  zustand@4.5.6(@types/react@19.1.1)(react@19.2.6):
     dependencies:
-      use-sync-external-store: 1.5.0(react@19.1.0)
+      use-sync-external-store: 1.5.0(react@19.2.6)
     optionalDependencies:
       '@types/react': 19.1.1
-      react: 19.1.0
+      react: 19.2.6

--- a/gui/workflow_frontend/src/views/home/components/projectFilter.test.ts
+++ b/gui/workflow_frontend/src/views/home/components/projectFilter.test.ts
@@ -16,7 +16,7 @@ const projects = [
   {
     id: "2",
     name: "Test_project",
-    description: "private sandbox for kirill",
+    description: "sandbox for kirill",
     visibility: "private" as const,
   },
   {
@@ -56,7 +56,7 @@ describe("filterProjectOptions", () => {
     expect(matchProjectOption(options[1], "Bold maps")).toBe(false);
   });
 
-  it("matches visibility public vs private", () => {
+  it("matches visibility public vs private as a word", () => {
     expect(filterProjectOptions(options, "public").map((o) => o.value)).toEqual([
       "1",
       "3",
@@ -64,6 +64,20 @@ describe("filterProjectOptions", () => {
     expect(filterProjectOptions(options, "private").map((o) => o.value)).toEqual([
       "2",
     ]);
+  });
+
+  it("matches visibility prefixes of length 3 or more", () => {
+    expect(filterProjectOptions(options, "pub").map((o) => o.value)).toEqual([
+      "1",
+      "3",
+    ]);
+    expect(filterProjectOptions(options, "priv").map((o) => o.value)).toEqual(["2"]);
+  });
+
+  it("does not treat a short p as a visibility filter", () => {
+    const result = filterProjectOptions(options, "p");
+    // Ring Attractor is public and has no "p" in name/description.
+    expect(result.map((o) => o.value)).not.toContain("3");
   });
 
   it("returns nothing when nothing matches", () => {

--- a/gui/workflow_frontend/src/views/home/components/projectFilter.test.ts
+++ b/gui/workflow_frontend/src/views/home/components/projectFilter.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from "vitest";
+import {
+  filterProjectOptions,
+  matchProjectOption,
+  toProjectOptions,
+  type ProjectOption,
+} from "./projectFilter";
+
+const projects = [
+  {
+    id: "1",
+    name: "Human fMRI analysis Visualization",
+    description: "Bold maps from resting-state scans",
+    visibility: "public" as const,
+  },
+  {
+    id: "2",
+    name: "Test_project",
+    description: "private sandbox for kirill",
+    visibility: "private" as const,
+  },
+  {
+    id: "3",
+    name: "Ring Attractor (Hatsuta)",
+    description: "",
+    visibility: "public" as const,
+  },
+];
+
+const options: ProjectOption[] = toProjectOptions(projects);
+
+describe("toProjectOptions", () => {
+  it("maps id to value and name to label", () => {
+    expect(options[0]).toEqual({
+      value: "1",
+      label: "Human fMRI analysis Visualization",
+      description: "Bold maps from resting-state scans",
+      visibility: "public",
+    });
+  });
+});
+
+describe("filterProjectOptions", () => {
+  it("returns all options for an empty query", () => {
+    expect(filterProjectOptions(options, "  ")).toEqual(options);
+  });
+
+  it("matches a name substring", () => {
+    const result = filterProjectOptions(options, "fMRI");
+    expect(result.map((o) => o.value)).toEqual(["1"]);
+  });
+
+  it("matches a description that is not in the name", () => {
+    const result = filterProjectOptions(options, "Bold maps");
+    expect(result.map((o) => o.value)).toEqual(["1"]);
+    expect(matchProjectOption(options[1], "Bold maps")).toBe(false);
+  });
+
+  it("matches visibility public vs private", () => {
+    expect(filterProjectOptions(options, "public").map((o) => o.value)).toEqual([
+      "1",
+      "3",
+    ]);
+    expect(filterProjectOptions(options, "private").map((o) => o.value)).toEqual([
+      "2",
+    ]);
+  });
+
+  it("returns nothing when nothing matches", () => {
+    expect(filterProjectOptions(options, "zzzz-no-such-project")).toEqual([]);
+  });
+});

--- a/gui/workflow_frontend/src/views/home/components/projectFilter.ts
+++ b/gui/workflow_frontend/src/views/home/components/projectFilter.ts
@@ -1,0 +1,53 @@
+export type ProjectVisibility = "public" | "private";
+
+export type ProjectOption = {
+  value: string;
+  label: string;
+  description?: string;
+  visibility: ProjectVisibility;
+};
+
+type ProjectLike = {
+  id: string;
+  name: string;
+  description?: string | null;
+  visibility: ProjectVisibility;
+};
+
+export function toProjectOptions(projects: ProjectLike[]): ProjectOption[] {
+  return projects.map((project) => ({
+    value: project.id,
+    label: project.name,
+    description: project.description ?? undefined,
+    visibility: project.visibility,
+  }));
+}
+
+export function matchProjectOption(option: ProjectOption, query: string): boolean {
+  const q = query.trim().toLowerCase();
+  if (!q) {
+    return true;
+  }
+  if (option.label.toLowerCase().includes(q)) {
+    return true;
+  }
+  if ((option.description ?? "").toLowerCase().includes(q)) {
+    return true;
+  }
+  return option.visibility.toLowerCase().includes(q);
+}
+
+export function filterProjectOptions(
+  options: ProjectOption[],
+  query: string
+): ProjectOption[] {
+  return options.filter((option) => matchProjectOption(option, query));
+}
+
+/** react-select filterOption adapter. */
+export function matchProjectFilterOption(
+  option: { data: ProjectOption },
+  query: string
+): boolean {
+  return matchProjectOption(option.data, query);
+}

--- a/gui/workflow_frontend/src/views/home/components/projectFilter.ts
+++ b/gui/workflow_frontend/src/views/home/components/projectFilter.ts
@@ -23,6 +23,13 @@ export function toProjectOptions(projects: ProjectLike[]): ProjectOption[] {
   }));
 }
 
+function matchesVisibilityWord(visibility: ProjectVisibility, q: string): boolean {
+  if (q.length < 3) {
+    return false;
+  }
+  return visibility.startsWith(q);
+}
+
 export function matchProjectOption(option: ProjectOption, query: string): boolean {
   const q = query.trim().toLowerCase();
   if (!q) {
@@ -34,7 +41,7 @@ export function matchProjectOption(option: ProjectOption, query: string): boolea
   if ((option.description ?? "").toLowerCase().includes(q)) {
     return true;
   }
-  return option.visibility.toLowerCase().includes(q);
+  return matchesVisibilityWord(option.visibility, q);
 }
 
 export function filterProjectOptions(

--- a/gui/workflow_frontend/src/views/home/components/projectSelector.tsx
+++ b/gui/workflow_frontend/src/views/home/components/projectSelector.tsx
@@ -569,6 +569,7 @@ export const ProjectSelector = ({
                 size="sm"
                 isSearchable
                 isClearable
+                backspaceRemovesValue={false}
                 options={projectOptions}
                 value={selectedOption}
                 onChange={(option) => onProjectChange(option ? option.value : '')}
@@ -589,9 +590,23 @@ export const ProjectSelector = ({
                     borderColor: 'gray.300',
                     _hover: { borderColor: 'blue.300' },
                   }),
+                  menu: (provided) => ({
+                    ...provided,
+                    bg: 'white',
+                    borderColor: 'gray.200',
+                    boxShadow: 'md',
+                  }),
                   menuList: (provided) => ({
                     ...provided,
                     minWidth: '320px',
+                    bg: 'white',
+                    borderColor: 'gray.200',
+                  }),
+                  option: (provided) => ({
+                    ...provided,
+                    bg: 'white',
+                    color: 'gray.800',
+                    _hover: { bg: 'gray.50' },
                   }),
                   singleValue: (provided) => ({
                     ...provided,

--- a/gui/workflow_frontend/src/views/home/components/projectSelector.tsx
+++ b/gui/workflow_frontend/src/views/home/components/projectSelector.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback, useRef } from 'react';
+import { useEffect, useState, useCallback, useRef, useMemo } from 'react';
 import { AttributionDraft, HpcTarget, Project, Visibility } from '../type'
 import {
   HStack,
@@ -39,6 +39,12 @@ import { WorkflowContextEditor } from '../../../components/WorkflowContextEditor
 import { AttributionEditor } from './attributionEditor';
 import { AcknowledgmentModal } from './acknowledgmentModal';
 import { ProjectDataUploadModal } from './ProjectDataUploadModal';
+import { Select as ProjectCombobox } from 'chakra-react-select';
+import {
+  matchProjectFilterOption,
+  toProjectOptions,
+  type ProjectOption,
+} from './projectFilter';
 
 const emptyAttribution = (): AttributionDraft => ({
   doi: '',
@@ -85,6 +91,9 @@ export const ProjectSelector = ({
   const currentProject = selectedProject
     ? projects.find((p) => p.id === selectedProject) ?? null
     : null;
+  const projectOptions = useMemo(() => toProjectOptions(projects), [projects]);
+  const selectedOption =
+    projectOptions.find((option) => option.value === selectedProject) ?? null;
   // Island menu opening/closing management
   const [isIslandProjectOpen, setIslandProjectOpen] = useState(true);
   // Use the tab system context
@@ -550,36 +559,80 @@ export const ProjectSelector = ({
           </Flex>
           
           {/* Project selection */}
-          <HStack spacing={2}>
-            <Select 
-              value={selectedProject || ''} 
-              onChange={(e) => onProjectChange(e.target.value)}
-              size="sm"
-              bg="white"
-              color="gray.800"
-              borderColor="gray.300"
-              placeholder="Choose a project..."
-              _hover={{
-                borderColor: "blue.300"
-              }}
-              _focus={{
-                borderColor: "blue.500",
-                boxShadow: "0 0 0 1px #3182ce"
-              }}
-              flex="1"
-              marginTop={2}
-            >
-              {projects.map(project => {
-                const visLabel =
-                  project.visibility === 'public' ? ' (Public)' : '';
-                return (
-                  <option key={project.id} value={project.id} style={{ color: '#2D3748' }}>
-                    {project.name}
-                    {visLabel}
-                  </option>
-                );
-              })}
-            </Select>
+          <HStack spacing={2} align="flex-start">
+            <Box flex="1" minW="220px" mt={2}>
+              <ProjectCombobox<ProjectOption, false>
+                instanceId="project-workspace-select"
+                inputId="project-workspace-select"
+                aria-label="Choose a project"
+                placeholder="Search projects..."
+                size="sm"
+                isSearchable
+                isClearable
+                options={projectOptions}
+                value={selectedOption}
+                onChange={(option) => onProjectChange(option ? option.value : '')}
+                filterOption={matchProjectFilterOption}
+                noOptionsMessage={() => 'No matching projects'}
+                menuPortalTarget={typeof document === 'undefined' ? undefined : document.body}
+                menuPosition="fixed"
+                selectedOptionColorScheme="blue"
+                focusBorderColor="blue.500"
+                chakraStyles={{
+                  container: (provided) => ({
+                    ...provided,
+                    width: '100%',
+                  }),
+                  control: (provided) => ({
+                    ...provided,
+                    bg: 'white',
+                    borderColor: 'gray.300',
+                    _hover: { borderColor: 'blue.300' },
+                  }),
+                  menuList: (provided) => ({
+                    ...provided,
+                    minWidth: '320px',
+                  }),
+                  singleValue: (provided) => ({
+                    ...provided,
+                    overflow: 'hidden',
+                    textOverflow: 'ellipsis',
+                    whiteSpace: 'nowrap',
+                    maxWidth: '100%',
+                  }),
+                }}
+                styles={{
+                  menuPortal: (base) => ({ ...base, zIndex: 1500 }),
+                }}
+                formatOptionLabel={(option, { context }) => {
+                  if (context === 'value') {
+                    return option.label;
+                  }
+                  return (
+                    <Box py={0.5}>
+                      <HStack spacing={2} align="center">
+                        <Text fontSize="sm" color="gray.800" whiteSpace="normal">
+                          {option.label}
+                        </Text>
+                        <Badge
+                          size="sm"
+                          colorScheme={option.visibility === 'public' ? 'teal' : 'gray'}
+                          variant="subtle"
+                          flexShrink={0}
+                        >
+                          {option.visibility === 'public' ? 'Public' : 'Private'}
+                        </Badge>
+                      </HStack>
+                      {option.description ? (
+                        <Text fontSize="xs" color="gray.500" noOfLines={1}>
+                          {option.description}
+                        </Text>
+                      ) : null}
+                    </Box>
+                  );
+                }}
+              />
+            </Box>
 
             {selectedProject && (
               <Tooltip

--- a/gui/workflow_frontend/vitest.config.ts
+++ b/gui/workflow_frontend/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary
- Replaces the native Project Workspace `<select>` with a Chakra 2 searchable combobox (`chakra-react-select@5`) so users can type to find a project by **name**, **description**, or **public/private**.
- Menu shows the full name, a visibility badge, and a one-line description; the control stays clearable (same as choosing the empty placeholder today).
- No backend or visibility-rule changes. HPC Target select is unchanged.

## Test plan
- [ ] `pnpm test` in `gui/workflow_frontend` (projectFilter unit tests)
- [ ] After a frontend deploy: open Project Workspace, type `fMRI` (or another mid-name fragment) and confirm the list filters
- [ ] Type a description fragment that is not in the name and confirm a match
- [ ] Type `private` / `public` and confirm visibility filtering
- [ ] Clear the selection and confirm the canvas unloads (existing `handleProjectChange(null)` path)
- [ ] Select a project from the filtered list and confirm flow load still works
- [ ] Live dbrain.jp still serves the old native select until this PR is deployed — do not treat it as verification of this change