### PR TITLE
Add owner-only encrypted user secret store

### DIFF
--- a/NODE_SCHEMA.md
+++ b/NODE_SCHEMA.md
@@ -161,6 +161,7 @@ class ParameterDefinition:
     is_objective: bool = False               # Whether this parameter is an optimization objective/target
     objective_range: Optional[List] = None   # Acceptable range for the objective value [min, max]
     suggested_values: List[Dict[str, Any]] = field(default_factory=list)  # Optional suggestions
+    secret: bool = False                 # If True, store a SecretRef — never a plaintext credential
 ```
 
 ### Parameter Constraints
@@ -172,6 +173,11 @@ Parameters can have constraints that validate their values:
 - **min_length/max_length**: Constraints for list or string length
 
 Parameters are accessed within node methods using the `self._parameters` dictionary.
+
+Set `secret=True` for credentials (API keys, passwords). The GUI stores a named vault
+reference, not the value. At runtime, call `from neuroworkflow.core.secrets import resolve`
+and `resolve(self._parameters['password'])` before using the credential. Never put
+secrets in `default_value`.
 
 ## Suggested Values (Optional)
 

--- a/deployment/task9-secrets-progress.log
+++ b/deployment/task9-secrets-progress.log
@@ -107,3 +107,35 @@ Fixes from this work only:
 
 Did not deploy. dbrain.jp stays baseline (no secret UI until a later deploy).
 
+## Step 9 — Commit, push, PR
+Date: 2026-09-02
+
+Done:
+- Commit 4b598eac on feat/user-secret-store: Add owner-only encrypted secret store so credentials never live in workflow JSON.
+- Pushed to origin (no force).
+- Opened PR https://github.com/oist/neuro-workflow/pull/92 (not merged).
+
+Verify:
+- Working tree was clean after commit.
+- No deploy, no /data writes, no live Docker rebuild.
+
+## Step 10 — Close-out
+Date: 2026-09-02
+
+Files changed (high level):
+- app.secrets: crypto, keys, models, migrations, REST /api/secrets/, redaction, logging filter, inject helpers
+- CustomDatabase encrypted at rest + optional vault ref
+- ParameterDefinition.secret + neuroworkflow.core.secrets (src and codes)
+- Codegen SecretRef; Jupyter/Slurm/Local inject + shred; context blocklist
+- Frontend /settings/secrets, SecretParamEditor, export strip, WorkflowContextEditor
+- AsperaSharesLoaderNode (vault password, temp YAML shred)
+- Tests: crypto, API, inject, aspera, customdb, core secrets, vitest secretRefs
+- env.template + docker-compose empty SECRETS_MASTER_KEY passthrough
+- deployment/task9-secrets-progress.log (this file)
+
+Tests: core 8 passed; backend 22 passed; vitest 3 passed. Could not UI-verify on dbrain.jp without a deploy.
+
+Non-goals left alone: HashiCorp Vault, per-project ACL, Jupyter per-Keycloak isolation, encrypting whole FlowNode.data, other Selects, Chakra v3.
+
+Remaining ops action: generate SECRETS_MASTER_KEY before any production deploy (`python3 -c "import secrets; print(secrets.token_urlsafe(32))"`). Missing key must not boot production (DEBUG=false). Optional SECRETS_MASTER_KEY_PREVIOUS for rotation.
+

--- a/deployment/task9-secrets-progress.log
+++ b/deployment/task9-secrets-progress.log
@@ -267,3 +267,18 @@ Fixes from this pass only:
 - Jupyter kernel-create failure: asynccontextmanager _runtime_secret_scope always clears contextvars; test asserts inside the asyncio context
 
 Did not deploy. dbrain.jp stays baseline.
+
+## Step 10 — Commit, push, close-out
+Date: 2026-09-02
+
+Done:
+- Commit 841c6d02 on feat/user-secret-store: Harden the owner-only secret store so rotation, writes, and redaction match the vault contract.
+- Pushed to origin (no force). PR https://github.com/oist/neuro-workflow/pull/92 remains open (not merged).
+
+Verify:
+- Working tree clean after commit (except the close-out log if committed separately).
+- No deploy, no /data writes, no live Docker rebuild.
+
+Architecture now matches the original plan for rotation (current then PREVIOUS KEK), no plaintext on flow writes, owner-only Custom DB resolve, ascp auth, and remaining log/notebook/export leaks. Jupyter wrap topology unchanged (Django cannot write Jupyter /tmp). Non-goals left alone: HashiCorp Vault, per-project ACL, Jupyter per-Keycloak isolation, encrypting whole FlowNode.data.
+
+Remaining ops action (not this task): set SECRETS_MASTER_KEY before any production deploy. Missing key must not boot production (DEBUG=false). Live dbrain.jp stays baseline until an approved deploy.

--- a/deployment/task9-secrets-progress.log
+++ b/deployment/task9-secrets-progress.log
@@ -139,3 +139,131 @@ Non-goals left alone: HashiCorp Vault, per-project ACL, Jupyter per-Keycloak iso
 
 Remaining ops action: generate SECRETS_MASTER_KEY before any production deploy (`python3 -c "import secrets; print(secrets.token_urlsafe(32))"`). Missing key must not boot production (DEBUG=false). Optional SECRETS_MASTER_KEY_PREVIOUS for rotation.
 
+
+
+## Follow-up — Production audit and hardening
+Date: 2026-09-02
+Branch: feat/user-secret-store
+PR: https://github.com/oist/neuro-workflow/pull/92
+This file remains append-only. Earlier Step 1–10 sections are not rewritten.
+
+### Architecture match vs original plan
+
+The original Task 9 plan is architecturally delivered:
+- Envelope AES-256-GCM in existing Postgres (no HashiCorp Vault, no new Docker service, no new public ports)
+- Owner-only /api/secrets/; GET never returns value; audit never stores plaintext
+- Flow JSON / codegen / MCP hold SecretRef / { "__nw_secret": { id, name } } only
+- Jupyter wrap + store_history False; Slurm 0600 .nw-secrets + shred; LocalExecutor NW_SECRET_* env
+- Vault UI /settings/secrets; SecretParamEditor; export strip; context blocklist
+- AsperaSharesLoaderNode password secret=True; CustomDatabase encrypted at rest
+
+Non-goals left alone: HashiCorp Vault, per-project ACL, Jupyter per-Keycloak isolation, encrypting whole FlowNode.data, other Selects, Chakra v3.
+
+### Findings (this pass)
+
+Gaps vs original vision (rotation, no plaintext in documents, owner-only materialization, no log/export leaks):
+1. KEK rotation dead: decrypt_kek_for_version(1) uses current master only; SECRETS_MASTER_KEY_PREVIOUS never used.
+2. Unique (owner, name) is unconditional; recreate after soft-revoke IntegrityError/500.
+3. Flow PUT / node create persist data as-is; GET redacts so Postgres can still hold plaintext.
+4. Jupyter wrap topology stays (Django cannot write Jupyter /tmp; vanilla POST /api/kernels has no env). Remaining leaks: request.data INFO logs, kernel-create failure skipping clear_secret_values, GET /code/ notebook outputs, run stdout redacted with poller not submitter.
+5. Custom DB suggestions load every verified DB and resolve_api_key(); config spread can overwrite api_key.
+6. ascp fallback ignores YAML; tests always take aspera branch.
+7. Frontend: AI suggest on secret params; export misses field_modifications; console.log of values/flow JSON; window.prompt for rotate; Custom DB test-connection may ignore vault name.
+8. settings.py sqlite switch on "pytest" in sys.modules is a production landmine.
+
+This pass is production hardening on PR #92. No deploy. No /data writes.
+
+## Step 1 — Append audit header
+Date: 2026-09-02
+
+Done:
+- Appended this follow-up header (architecture match + findings). No code changes.
+
+Verify:
+- File grew; original Step 1–10 text unchanged.
+
+## Step 2 — KEK rotation
+Date: 2026-09-02
+
+Done:
+- decrypt_blob tries current KEK then SECRETS_MASTER_KEY_PREVIOUS (same AAD). Encrypt still uses current master.
+- UserSecret.decrypt_plaintext and CustomDatabase.get_api_key use decrypt_blob.
+- rotate_user_secret rewraps onto the current KEK when value is omitted; rewrap_owner_secrets helper rewraps all active owner secrets.
+- Tests: test_decrypt_blob_uses_previous_master; test_user_secret_decrypts_after_master_rotation (PREVIOUS then rewrap, AAD tamper still fails).
+
+Verify: unit tests added; no live key written.
+
+## Step 3 — Soft-revoke unique names
+Date: 2026-09-02
+
+Done:
+- UniqueConstraint (owner, name) now condition=Q(revoked_at__isnull=True), name uniq_user_secret_owner_name_active.
+- Migration nw_secrets/0002_partial_unique_owner_name.py (RemoveConstraint + AddConstraint).
+- API test test_recreate_same_name_after_revoke: POST after DELETE → 201; second active same name → 400.
+
+## Step 4 — Fail closed on every flow write
+Date: 2026-09-02
+
+Done:
+- app.secrets.sanitize.sanitize_node_data: secret-schema params must be an owned SecretRef or empty; plaintext → ValidationError naming the param. Does not auto-create vault rows.
+- Used by FlowService.save_flow_data, create_node, update_node, and the existing-node branch of node create.
+- Tests: PUT flow with password hunter2 → 400 and DB has no hunter2; PUT with owned SecretRef → 200.
+
+## Step 5 — Jupyter / logs / notebook / run-stdout redaction
+Date: 2026-09-02
+
+Done:
+- Removed logger.info of request.data on node create/update.
+- materialize_named_secrets registers values for the logging filter.
+- Jupyter execute_code: outer finally always clear_secret_values; kernel delete only if create succeeded. Wrap topology unchanged.
+- GET /code/ redacts notebook outputs with the requesting user's materialized vault.
+- Status poll redacts stdout/stderr with run.user (submitter), not the poller.
+
+## Step 6 — Custom DB owner-only resolve
+Date: 2026-09-02
+
+Done:
+- _custom_databases_for_suggestions(user) = _visible_custom_databases(user).filter(is_verified=True).
+- get_metadata_service_instance(user=...) loads only those rows.
+- to_adapter_config pops config.api_key / api_key_secret then sets api_key from resolve_api_key().
+- GET serializer drops config.api_key.
+- Test-connection accepts api_key_secret_name and materializes the owner's secret.
+
+## Step 7 — Aspera ascp authenticates
+Date: 2026-09-02
+
+Done:
+- aspera CLI still uses --config YAML. ascp path sets ASPERA_PASSWORD in the subprocess env only (never argv). YAML still shredded.
+- Synced src/neuroworkflow/nodes/io/AsperaSharesLoaderNode.py and codes/nodes/io/AsperaSharesLoaderNode.py.
+- test_ascp_uses_env_not_argv: which("aspera") is None.
+
+## Step 8 — Frontend leaks
+Date: 2026-09-02
+
+Done:
+- Hidden Zap AI-suggest for param.secret; handleAcceptSuggestion refuses secret params.
+- stripSecretValuesFromExport walks parameter_modifications.field_modifications; vitest fixture with plaintext in that path.
+- Removed console.log of parameter values, request bodies, generate-code flow JSON.
+- Vault rotate uses Input type=password instead of window.prompt.
+- Custom DB Test Connection sends api_key_secret_name when vault mode is selected.
+
+## Step 9 — Pytest landmine + isolated tests
+Date: 2026-09-02
+
+Done:
+- settings.py / keys.py / apps.py gate test-only sqlite and master-key skip on NW_TESTING or PYTEST_CURRENT_TEST, never "pytest" in sys.modules.
+- tests/conftest.py sets NW_TESTING=1 before Django import.
+- Kept --nomigrations; added test_encrypt_api_key_migration.py that loads 0002 via importlib and checks plaintext api_key is encrypted then dropped.
+
+Commands (ephemeral docker run --rm --entrypoint "" neuro-workflow-backend:latest, worktree bind-mount, not compose, not /data):
+
+- PYTHONPATH=/src/src pytest tests/test_core_secrets.py → 8 passed
+- poetry-less image: pip install pytest pytest-django inside ephemeral container only; pytest of test_secret_crypto, test_user_secret_model, test_secrets_api, test_secret_inject, test_aspera_secret, test_customdb_vault, test_flow_secret_writes, test_encrypt_api_key_migration → 35 passed
+- vitest secretRefs.test.ts via neuro-workflow-frontend-dev-check:latest (host has no vite) → 4 passed
+
+Fixes from this pass only:
+- importlib for 0002 helper (module name 0002_* is not a valid identifier)
+- GET /code/ assertion uses parsed JSON (bullets are \u2022 in raw bytes)
+- Jupyter kernel-create failure: asynccontextmanager _runtime_secret_scope always clears contextvars; test asserts inside the asyncio context
+
+Did not deploy. dbrain.jp stays baseline.

--- a/deployment/task9-secrets-progress.log
+++ b/deployment/task9-secrets-progress.log
@@ -1,0 +1,109 @@
+# Task 9 — Owner-only encrypted secret store
+Branch: feat/user-secret-store
+Base: origin/main (e1218777 Merge pull request #87)
+Worktree: /home/nw-kirill/neuro-workflow-secrets
+This file is append-only. Do not rewrite earlier sections.
+
+## Step 1 — Worktree, log, env contract
+Date: 2026-09-02
+
+Done:
+- Fetched origin/main; created worktree /home/nw-kirill/neuro-workflow-secrets on branch feat/user-secret-store.
+- HEAD: e1218777 Merge pull request #87 from oist/feat/node-figure-display
+- Added SECRETS_MASTER_KEY / SECRETS_MASTER_KEY_PREVIOUS to gui/workflow_backend/env.template with generation command.
+- Passed both through gui/docker-compose.yml backend environment with empty defaults.
+- Did not write a real key to git. Did not edit live /data .env.
+
+Verify:
+- git rev-parse HEAD == origin/main == e1218777
+- git status: feat/user-secret-store...origin/main
+- Did not start from Task 4/8 worktrees or /data/neuro-workflow.
+
+## Step 2 — Crypto module, models, migration
+Date: 2026-09-02
+
+Done:
+- Django app app.secrets (label nw_secrets): AES-256-GCM envelope crypto, versioned KEK from SECRETS_MASTER_KEY (DEBUG/pytest derives from DJANGO_SECRET_KEY).
+- Models UserSecret + SecretAuditEvent (never stores plaintext).
+- CustomDatabase.api_key replaced with encrypted columns; data migration 0002_encrypt_api_key.py.
+- Production refuses boot without SECRETS_MASTER_KEY when DEBUG is false (skipped under pytest).
+
+Verify:
+- test_secret_crypto.py round-trip + AAD tamper: PASS (4).
+- test_user_secret_model.py persist/decrypt + encrypted CustomDatabase: PASS with --nomigrations.
+
+## Step 3 — REST API, redaction, logging
+Date: 2026-09-02
+
+Done:
+- /api/secrets/ owner-only CRUD; list/GET never returns value.
+- Logging filter SecretValueFilter; DEBUG prints of request/node/generated values stripped in workflow/box views and codegen.
+- Flow GET, node serializers, GET /code/, MCP list_secrets/create_secret/delete_secret (names/ids only).
+- Flow JSON redacts to { "__nw_secret": { id, name } }.
+
+Verify:
+- test_secrets_api.py owner isolation, no value in JSON, audit without plaintext: PASS (3).
+
+## Step 4 — Schema + runtime resolver
+Date: 2026-09-02
+
+Done:
+- ParameterDefinition.secret = False in src and codes schema; NODE_SCHEMA.md; python_analyzer secret=; box/models pass-through; frontend ParameterField.secret.
+- neuroworkflow.core.secrets: SecretRef, SecretStr (repr ••••), install/load/resolve; copied to codes/neuroworkflow/core/secrets.py.
+- Node.configure / _initialize_parameters resolve secret params; missing names the ref.
+
+Verify:
+- tests/test_core_secrets.py (no Django): 8 passed.
+
+## Step 5 — Codegen + Jupyter/Slurm/Local inject
+Date: 2026-09-02
+
+Done:
+- Codegen emits SecretRef("NAME"); main() calls load_runtime_secrets(); workflow_context blocked keys fail closed.
+- Jupyter execute_code wraps install_runtime_secrets in-process; no file under codes/projects/; SSE redacted; contextvars cleared after kernel delete.
+- Slurm: SSH-stdin write ${RUN_DIR}/.nw-secrets mode 0600; wrapper NW_SECRETS_FILE + shred trap; rsync excludes .nw-secrets.
+- LocalExecutor / batch run: NW_SECRET_* env only.
+- Missing owner secret: HTTP 400 naming the secret name.
+
+Verify:
+- test_secret_inject.py: SecretRef in generated configure, no fixture value, wrapper shred, jupyter wrap has no codes/projects path: PASS (8).
+
+## Step 6 — Frontend vault + node editor + export
+Date: 2026-09-02
+
+Done:
+- Route /settings/secrets (header + TabManager).
+- SecretVaultPage: list/create/rotate/delete/copy name; fields •••• after save.
+- Node details: SecretParamEditor (password + select-from-my-secrets); sidebar/box rewrite of .py with secret values rejected.
+- Export Flow JSON strips values, keeps refs; console.log of export payload removed.
+- WorkflowContextEditor blocked-key error pointing at Settings → Secrets.
+
+Verify:
+- vitest src/utils/secretRefs.test.ts: 3 passed (npx vitest@3.1.1; host has no frontend node_modules).
+
+## Step 7 — Aspera + Custom DB + context PATCH
+Date: 2026-09-02
+
+Done:
+- AsperaSharesLoaderNode: username plain, password secret=True; temp 0600 YAML under TMPDIR; shred after ascp/aspera; ASPERA_PASSWORD env fallback. Not imported from /data hashed nodes.
+- CustomDatabase: encrypted at rest; optional api_key_secret_name vault ref in config; resolve_api_key in adapters only; GET never shows stored key.
+- FlowProjectSerializer.validate_workflow_context uses the same blocked-key list as codegen.
+
+Verify:
+- Analyzer sees secret=True on password; aspera temp yaml shredded (mock subprocess); CustomDatabase GET has no fixture key: PASS.
+
+## Step 8 — Isolated tests
+Date: 2026-09-02
+
+Commands (host has no poetry/pytest; used ephemeral docker run --rm neuro-workflow-backend, not compose, not live container):
+
+- PYTHONPATH=src pytest tests/test_core_secrets.py → 8 passed
+- poetry run pytest django-project/tests/test_secret_crypto.py test_user_secret_model.py test_secrets_api.py test_secret_inject.py test_aspera_secret.py test_customdb_vault.py → 22 passed
+- npx vitest@3.1.1 run src/utils/secretRefs.test.ts → 3 passed
+
+Fixes from this work only:
+- PortType.STRING → PortType.STR on Aspera output.
+- pytest addopts --nomigrations + sqlite while pytest is loaded (Postgres IF NOT EXISTS migrations are not sqlite-safe; avoids creating test_* on the live Postgres).
+
+Did not deploy. dbrain.jp stays baseline (no secret UI until a later deploy).
+

--- a/gui/docker-compose.yml
+++ b/gui/docker-compose.yml
@@ -37,6 +37,10 @@ services:
       - JUPYTERHUB_API_TOKEN=${JUPYTERHUB_API_TOKEN:-dev-token-change-in-production}
       - JUPYTERHUB_BASE_URL=${JUPYTERHUB_BASE_URL:-/jupyter/}
       - JUPYTER_EXECUTION_USER=${JUPYTER_EXECUTION_USER:-user1}
+      # Owner secret vault KEK. Empty here on purpose — set in workflow_backend/.env.
+      # Production must set SECRETS_MASTER_KEY; do not put a real key in git.
+      - SECRETS_MASTER_KEY=${SECRETS_MASTER_KEY:-}
+      - SECRETS_MASTER_KEY_PREVIOUS=${SECRETS_MASTER_KEY_PREVIOUS:-}
     depends_on:
       - db
     restart: unless-stopped

--- a/gui/mcp_server/workflow_mcp.py
+++ b/gui/mcp_server/workflow_mcp.py
@@ -80,6 +80,17 @@ async def _make_put_request(url: str, payload: dict | None = None, timeout: floa
             return None
 
 
+async def _make_patch_request(url: str, payload: dict | None = None, timeout: float = 30.0) -> dict | None:
+    async with httpx.AsyncClient() as client:
+        try:
+            r = await client.patch(url, headers=_build_headers(), json=payload or {}, timeout=timeout)
+            r.raise_for_status()
+            return r.json()
+        except Exception as e:
+            logger.error(f"PATCH request failed for {url}: {e}")
+            return None
+
+
 async def _make_multipart_post_request(
     url: str, files: dict, data: dict | None = None, timeout: float = 60.0
 ) -> dict | None:
@@ -115,6 +126,40 @@ async def _make_delete_request(url: str, timeout: float = 30.0) -> dict | None:
 
 
 mcp = FastMCP("workflow")
+
+
+@mcp.tool()
+async def list_secrets() -> dict[str, Any]:
+    """List the caller's named secrets (id, name, description). Never returns values."""
+    url = f"{DJANGO_API_URL}/secrets/"
+    data = await _make_get_request(url)
+    if data is None:
+        return {"status": "error", "error": "Failed to list secrets"}
+    return {"status": "success", "secrets": data}
+
+
+@mcp.tool()
+async def create_secret(name: str, value: str, description: str = "") -> dict[str, Any]:
+    """Create an owner-only secret. The value is stored encrypted and is not returned."""
+    url = f"{DJANGO_API_URL}/secrets/"
+    data = await _make_post_request(
+        url, {"name": name, "value": value, "description": description}
+    )
+    if data is None:
+        return {"status": "error", "error": "Failed to create secret"}
+    if isinstance(data, dict) and "value" in data:
+        data = {k: v for k, v in data.items() if k != "value"}
+    return {"status": "success", "secret": data}
+
+
+@mcp.tool()
+async def delete_secret(secret_id: str) -> dict[str, Any]:
+    """Revoke an owner-only secret by id. The value is never returned."""
+    url = f"{DJANGO_API_URL}/secrets/{secret_id}/"
+    data = await _make_delete_request(url)
+    if data is None:
+        return {"status": "error", "error": f"Failed to delete secret {secret_id}"}
+    return {"status": "success", "result": data}
 
 
 # Project endpoints

--- a/gui/workflow_backend/django-project/app/box/models.py
+++ b/gui/workflow_backend/django-project/app/box/models.py
@@ -207,6 +207,8 @@ class PythonFile(models.Model):
                 param_data["is_objective"] = param_info["is_objective"]
             if "objective_range" in param_info:
                 param_data["objective_range"] = param_info["objective_range"]
+            if param_info.get("secret"):
+                param_data["secret"] = True
 
             converted_params[param_name] = param_data
 

--- a/gui/workflow_backend/django-project/app/box/services/python_analyzer.py
+++ b/gui/workflow_backend/django-project/app/box/services/python_analyzer.py
@@ -471,6 +471,8 @@ class PythonNodeAnalyzer:
                 param_info["objective_range"] = self._extract_value(keyword.value)
             elif keyword.arg == "suggested_values":
                 param_info["suggested_values"] = self._extract_value(keyword.value)
+            elif keyword.arg == "secret":
+                param_info["secret"] = self._extract_bool_value(keyword.value)
             elif keyword.arg == "type":
                 param_info["type"] = self._extract_value(keyword.value)
 
@@ -613,6 +615,8 @@ class PythonNodeAnalyzer:
                     param_info["objective_range"] = self._extract_value(value)
                 elif key_name == "suggested_values":
                     param_info["suggested_values"] = self._extract_value(value)
+                elif key_name == "secret":
+                    param_info["secret"] = self._extract_bool_value(value)
                 elif key_name == "type":
                     param_info["type"] = self._extract_value(value)
         return param_info

--- a/gui/workflow_backend/django-project/app/box/views.py
+++ b/gui/workflow_backend/django-project/app/box/views.py
@@ -891,10 +891,15 @@ class PythonFileParameterUpdateView(APIView):
                     status=status.HTTP_403_FORBIDDEN,
                 )
 
-            # Debug: Check the type and value of parameter_value
-            logger.info(
-                f"Received parameter_value: {parameter_value} (type: {type(parameter_value)})"
-            )
+            for class_info in (python_file.node_classes or {}).values():
+                param_info = (class_info.get("parameters") or {}).get(parameter_key) or {}
+                if param_info.get("secret") and parameter_field in ("value", "default_value"):
+                    return Response(
+                        {
+                            "error": "Secret parameters cannot be written into node source. Use Settings → Secrets."
+                        },
+                        status=status.HTTP_400_BAD_REQUEST,
+                    )
 
             # Update parameter values ​​in source code (uniform for all cases)
             updated_code = self._update_parameter_in_source_code(
@@ -1235,7 +1240,11 @@ class PythonFileParameterUpdateView(APIView):
             param_content, field_name, field_value
         )
 
-        logger.info(f"Updated content for '{parameter_key}': {updated_content}")
+        logger.info(
+            "Updated parameter '%s' field '%s'",
+            parameter_key,
+            field_name,
+        )
 
         # Updated original code
         if updated_content != param_content:

--- a/gui/workflow_backend/django-project/app/metadata/migrations/0002_encrypt_api_key.py
+++ b/gui/workflow_backend/django-project/app/metadata/migrations/0002_encrypt_api_key.py
@@ -1,0 +1,75 @@
+# Encrypt CustomDatabase.api_key at rest with the owner secret KEK.
+
+from django.db import migrations, models
+
+
+def encrypt_existing_api_keys(apps, schema_editor):
+    CustomDatabase = apps.get_model("metadata", "CustomDatabase")
+    from app.secrets.crypto import aad_for_custom_db, envelope_encrypt
+    from app.secrets.keys import get_kek
+
+    kek = get_kek()
+    for row in CustomDatabase.objects.all():
+        plaintext = row.api_key
+        if not plaintext:
+            continue
+        blob = envelope_encrypt(
+            plaintext.encode("utf-8"),
+            kek,
+            aad_for_custom_db(row.created_by_id, str(row.id)),
+        )
+        row.api_key_wrapped_dek = blob.wrapped_dek
+        row.api_key_ciphertext = blob.ciphertext
+        row.api_key_nonce = blob.nonce
+        row.api_key_key_version = blob.key_version
+        row.api_key = None
+        row.save(
+            update_fields=[
+                "api_key_wrapped_dek",
+                "api_key_ciphertext",
+                "api_key_nonce",
+                "api_key_key_version",
+                "api_key",
+            ]
+        )
+
+
+def noop_reverse(apps, schema_editor):
+    # Do not write plaintext back out of the vault.
+    return
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("metadata", "0001_initial"),
+        ("nw_secrets", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="customdatabase",
+            name="api_key_ciphertext",
+            field=models.BinaryField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="customdatabase",
+            name="api_key_key_version",
+            field=models.PositiveSmallIntegerField(default=1),
+        ),
+        migrations.AddField(
+            model_name="customdatabase",
+            name="api_key_nonce",
+            field=models.BinaryField(blank=True, null=True),
+        ),
+        migrations.AddField(
+            model_name="customdatabase",
+            name="api_key_wrapped_dek",
+            field=models.BinaryField(blank=True, null=True),
+        ),
+        migrations.RunPython(encrypt_existing_api_keys, noop_reverse),
+        migrations.RemoveField(
+            model_name="customdatabase",
+            name="api_key",
+        ),
+    ]

--- a/gui/workflow_backend/django-project/app/metadata/models.py
+++ b/gui/workflow_backend/django-project/app/metadata/models.py
@@ -54,18 +54,17 @@ class CustomDatabase(models.Model):
     def get_api_key(self) -> str:
         if not self.api_key_ciphertext:
             return ""
-        from app.secrets.crypto import EncryptedBlob, aad_for_custom_db, envelope_decrypt
-        from app.secrets.keys import decrypt_kek_for_version
+        from app.secrets.crypto import EncryptedBlob, aad_for_custom_db
+        from app.secrets.keys import decrypt_blob
 
         aad = aad_for_custom_db(self.created_by_id, str(self.id))
-        kek = decrypt_kek_for_version(self.api_key_key_version)
         blob = EncryptedBlob(
             wrapped_dek=bytes(self.api_key_wrapped_dek or b""),
             ciphertext=bytes(self.api_key_ciphertext),
             nonce=bytes(self.api_key_nonce or b""),
             key_version=self.api_key_key_version,
         )
-        return envelope_decrypt(blob, kek, aad).decode("utf-8")
+        return decrypt_blob(blob, aad).decode("utf-8")
 
     def resolve_api_key(self) -> str:
         """Decrypt the stored key or materialize a vault SecretRef from config."""
@@ -116,13 +115,16 @@ class CustomDatabase(models.Model):
 
     def to_adapter_config(self, openai_client=None):
         """Build config dict for GenericDatabaseAdapter."""
+        extra = dict(self.get_config_dict())
+        extra.pop("api_key", None)
+        extra.pop("api_key_secret", None)
         cfg = {
             "base_url": self.base_url.rstrip("/"),
-            "api_key": self.resolve_api_key(),
             "source_name": self.name,
             "enabled": self.is_active,
             "openai_client": openai_client,
-            **self.get_config_dict(),
+            **extra,
+            "api_key": self.resolve_api_key(),
         }
         cfg.setdefault("adapter_type", self.adapter_type)
         return cfg

--- a/gui/workflow_backend/django-project/app/metadata/models.py
+++ b/gui/workflow_backend/django-project/app/metadata/models.py
@@ -14,7 +14,10 @@ class CustomDatabase(models.Model):
     name = models.CharField(max_length=255)
     description = models.TextField(blank=True, null=True)
     base_url = models.URLField()
-    api_key = models.CharField(max_length=500, blank=True, null=True)
+    api_key_wrapped_dek = models.BinaryField(null=True, blank=True)
+    api_key_ciphertext = models.BinaryField(null=True, blank=True)
+    api_key_nonce = models.BinaryField(null=True, blank=True)
+    api_key_key_version = models.PositiveSmallIntegerField(default=1)
     config = models.JSONField(default=dict, blank=True, help_text="Additional configuration (headers, query params, auth type, etc.)")
     adapter_type = models.CharField(max_length=50, default="rest_api")
     is_active = models.BooleanField(default=True)
@@ -40,6 +43,73 @@ class CustomDatabase(models.Model):
     def __str__(self):
         return self.name
 
+    @property
+    def api_key_is_set(self) -> bool:
+        if bool(self.api_key_ciphertext):
+            return True
+        cfg = self.get_config_dict()
+        ref = cfg.get("api_key_secret")
+        return isinstance(ref, dict) and "__nw_secret" in ref
+
+    def get_api_key(self) -> str:
+        if not self.api_key_ciphertext:
+            return ""
+        from app.secrets.crypto import EncryptedBlob, aad_for_custom_db, envelope_decrypt
+        from app.secrets.keys import decrypt_kek_for_version
+
+        aad = aad_for_custom_db(self.created_by_id, str(self.id))
+        kek = decrypt_kek_for_version(self.api_key_key_version)
+        blob = EncryptedBlob(
+            wrapped_dek=bytes(self.api_key_wrapped_dek or b""),
+            ciphertext=bytes(self.api_key_ciphertext),
+            nonce=bytes(self.api_key_nonce or b""),
+            key_version=self.api_key_key_version,
+        )
+        return envelope_decrypt(blob, kek, aad).decode("utf-8")
+
+    def resolve_api_key(self) -> str:
+        """Decrypt the stored key or materialize a vault SecretRef from config."""
+        cfg = self.get_config_dict()
+        ref = cfg.get("api_key_secret")
+        if isinstance(ref, dict) and "__nw_secret" in ref:
+            inner = ref.get("__nw_secret") or {}
+            name = inner.get("name") if isinstance(inner, dict) else None
+            if name and self.created_by_id:
+                from app.secrets.services import materialize_named_secrets
+
+                mapping = materialize_named_secrets(self.created_by, [name], audit=False)
+                if name not in mapping:
+                    raise ValueError(f"Secret '{name}' is not available")
+                return mapping[name]
+        return self.get_api_key()
+
+    def set_api_key(self, value: str | None) -> None:
+        if not value:
+            self.api_key_wrapped_dek = None
+            self.api_key_ciphertext = None
+            self.api_key_nonce = None
+            return
+        from app.secrets.crypto import aad_for_custom_db, envelope_encrypt
+        from app.secrets.keys import get_kek
+
+        if not self.id:
+            self.id = uuid.uuid4()
+        aad = aad_for_custom_db(self.created_by_id, str(self.id))
+        blob = envelope_encrypt(value.encode("utf-8"), get_kek(), aad)
+        self.api_key_wrapped_dek = blob.wrapped_dek
+        self.api_key_ciphertext = blob.ciphertext
+        self.api_key_nonce = blob.nonce
+        self.api_key_key_version = blob.key_version
+
+    # Back-compat for callers that still read database.api_key
+    @property
+    def api_key(self) -> str:
+        return self.get_api_key()
+
+    @api_key.setter
+    def api_key(self, value: str | None) -> None:
+        self.set_api_key(value)
+
     def get_config_dict(self):
         """Return config as dict for adapter initialization."""
         return self.config if isinstance(self.config, dict) else {}
@@ -48,7 +118,7 @@ class CustomDatabase(models.Model):
         """Build config dict for GenericDatabaseAdapter."""
         cfg = {
             "base_url": self.base_url.rstrip("/"),
-            "api_key": self.api_key or "",
+            "api_key": self.resolve_api_key(),
             "source_name": self.name,
             "enabled": self.is_active,
             "openai_client": openai_client,

--- a/gui/workflow_backend/django-project/app/metadata/serializers.py
+++ b/gui/workflow_backend/django-project/app/metadata/serializers.py
@@ -70,6 +70,15 @@ class CustomDatabaseSerializer(serializers.ModelSerializer):
         ]
         read_only_fields = ['id', 'created_at', 'updated_at', 'created_by', 'is_verified', 'last_tested', 'test_result', 'test_error', 'api_key_is_set']
 
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        cfg = data.get("config")
+        if isinstance(cfg, dict) and "api_key" in cfg:
+            cfg = dict(cfg)
+            cfg.pop("api_key", None)
+            data["config"] = cfg
+        return data
+
     def validate_base_url(self, value):
         """Validate base URL format."""
         if not value.startswith(('http://', 'https://')):
@@ -160,4 +169,5 @@ class DatabaseConnectionTestSerializer(serializers.Serializer):
     """Serializer for testing database connection."""
     base_url = serializers.URLField(required=True, help_text="Base URL of the database")
     api_key = serializers.CharField(required=False, allow_blank=True, help_text="API key if required")
+    api_key_secret_name = serializers.CharField(required=False, allow_blank=True)
     config = serializers.DictField(required=False, default=dict, help_text="Additional configuration")

--- a/gui/workflow_backend/django-project/app/metadata/serializers.py
+++ b/gui/workflow_backend/django-project/app/metadata/serializers.py
@@ -1,6 +1,22 @@
 from rest_framework import serializers
 from typing import Any, Optional, Dict, List
 from .models import CustomDatabase
+from app.secrets.redaction import make_secret_ref
+from app.secrets.services import owner_secrets_qs
+
+
+def _apply_api_key_secret_name(instance, name, request):
+    if not name:
+        return instance
+    user = getattr(request, "user", None) if request else None
+    owned = owner_secrets_qs(user).filter(name=name).first() if user and user.is_authenticated else None
+    if owned is None:
+        raise serializers.ValidationError({"api_key_secret_name": "Secret not found."})
+    cfg = dict(instance.config or {})
+    cfg["api_key_secret"] = make_secret_ref(owned.id, owned.name)
+    instance.config = cfg
+    instance.save(update_fields=["config"])
+    return instance
 
 
 class ParameterSuggestionSerializer(serializers.Serializer):
@@ -40,39 +56,104 @@ class CustomDatabaseSerializer(serializers.ModelSerializer):
         allow_blank=True,
         allow_null=True,
     )
-    
+    api_key_is_set = serializers.BooleanField(read_only=True)
+    api_key_secret_name = serializers.CharField(write_only=True, required=False, allow_blank=True)
+
     class Meta:
         model = CustomDatabase
         fields = [
             'id', 'name', 'description', 'base_url', 'api_key',
+            'api_key_is_set', 'api_key_secret_name',
             'config', 'adapter_type', 'is_active', 'is_verified',
             'last_tested', 'test_result', 'test_error',
             'created_by', 'created_at', 'updated_at'
         ]
-        read_only_fields = ['id', 'created_at', 'updated_at', 'created_by', 'is_verified', 'last_tested', 'test_result', 'test_error']
-    
+        read_only_fields = ['id', 'created_at', 'updated_at', 'created_by', 'is_verified', 'last_tested', 'test_result', 'test_error', 'api_key_is_set']
+
     def validate_base_url(self, value):
         """Validate base URL format."""
         if not value.startswith(('http://', 'https://')):
             raise serializers.ValidationError("Base URL must start with http:// or https://")
         return value
+
+    def create(self, validated_data):
+        raw_key = validated_data.pop("api_key", None)
+        secret_name = validated_data.pop("api_key_secret_name", None)
+        instance = super().create(validated_data)
+        if raw_key:
+            instance.set_api_key(raw_key)
+            instance.save(
+                update_fields=[
+                    "api_key_wrapped_dek",
+                    "api_key_ciphertext",
+                    "api_key_nonce",
+                    "api_key_key_version",
+                ]
+            )
+        request = self.context.get("request")
+        _apply_api_key_secret_name(instance, secret_name, request)
+        return instance
+
+    def update(self, instance, validated_data):
+        raw_key = validated_data.pop("api_key", None)
+        secret_name = validated_data.pop("api_key_secret_name", None)
+        instance = super().update(instance, validated_data)
+        if raw_key is not None:
+            instance.set_api_key(raw_key)
+            instance.save(
+                update_fields=[
+                    "api_key_wrapped_dek",
+                    "api_key_ciphertext",
+                    "api_key_nonce",
+                    "api_key_key_version",
+                ]
+            )
+        request = self.context.get("request")
+        _apply_api_key_secret_name(instance, secret_name, request)
+        return instance
 
 
 class CustomDatabaseCreateSerializer(serializers.ModelSerializer):
     """Serializer for creating a new CustomDatabase."""
-    
+
+    api_key = serializers.CharField(
+        write_only=True,
+        required=False,
+        allow_blank=True,
+        allow_null=True,
+    )
+    api_key_secret_name = serializers.CharField(write_only=True, required=False, allow_blank=True)
+
     class Meta:
         model = CustomDatabase
         fields = [
-            'name', 'description', 'base_url', 'api_key',
+            'name', 'description', 'base_url', 'api_key', 'api_key_secret_name',
             'config', 'adapter_type', 'is_active'
         ]
-    
+
     def validate_base_url(self, value):
         """Validate base URL format."""
         if not value.startswith(('http://', 'https://')):
             raise serializers.ValidationError("Base URL must start with http:// or https://")
         return value
+
+    def create(self, validated_data):
+        raw_key = validated_data.pop("api_key", None)
+        secret_name = validated_data.pop("api_key_secret_name", None)
+        instance = super().create(validated_data)
+        if raw_key:
+            instance.set_api_key(raw_key)
+            instance.save(
+                update_fields=[
+                    "api_key_wrapped_dek",
+                    "api_key_ciphertext",
+                    "api_key_nonce",
+                    "api_key_key_version",
+                ]
+            )
+        request = self.context.get("request")
+        _apply_api_key_secret_name(instance, secret_name, request)
+        return instance
 
 
 class DatabaseConnectionTestSerializer(serializers.Serializer):

--- a/gui/workflow_backend/django-project/app/metadata/views.py
+++ b/gui/workflow_backend/django-project/app/metadata/views.py
@@ -458,7 +458,7 @@ class CustomDatabaseListView(APIView):
 
     def post(self, request):
         """Create a new custom database."""
-        serializer = CustomDatabaseCreateSerializer(data=request.data)
+        serializer = CustomDatabaseCreateSerializer(data=request.data, context={"request": request})
         
         if not serializer.is_valid():
             return Response(
@@ -519,7 +519,7 @@ class CustomDatabaseListView(APIView):
             tester = DatabaseConnectionTester(openai_client=openai_client)
             result = tester.test_adapter_patterns(
                 base_url=database.base_url,
-                api_key=database.api_key,
+                api_key=database.resolve_api_key(),
                 config=database.config
             )
             
@@ -573,7 +573,7 @@ class CustomDatabaseDetailView(APIView):
                     {"error": "You don't have permission to update this database"},
                     status=status.HTTP_403_FORBIDDEN,
                 )
-            serializer = CustomDatabaseSerializer(database, data=request.data, partial=True)
+            serializer = CustomDatabaseSerializer(database, data=request.data, partial=True, context={"request": request})
             
             if not serializer.is_valid():
                 return Response(
@@ -654,7 +654,7 @@ class CustomDatabaseDetailView(APIView):
             tester = DatabaseConnectionTester(openai_client=openai_client)
             result = tester.test_adapter_patterns(
                 base_url=database.base_url,
-                api_key=database.api_key,
+                api_key=database.resolve_api_key(),
                 config=database.config
             )
             

--- a/gui/workflow_backend/django-project/app/metadata/views.py
+++ b/gui/workflow_backend/django-project/app/metadata/views.py
@@ -59,8 +59,14 @@ def _can_modify_custom_database(user, database):
         return True
     return database.created_by_id == user.id
 
+def _custom_databases_for_suggestions(user):
+    if not user or not getattr(user, "is_authenticated", False):
+        return CustomDatabase.objects.none()
+    return _visible_custom_databases(user).filter(is_verified=True)
+
+
 # Lazy import function for ParameterMetadataService
-def get_metadata_service_instance():
+def get_metadata_service_instance(user=None):
     """
     Get an instance of ParameterMetadataService.
     Uses lazy loading to avoid import issues at module load time.
@@ -146,7 +152,7 @@ def get_metadata_service_instance():
         
         # Load custom databases from Django database
         try:
-            custom_dbs = CustomDatabase.objects.filter(is_active=True, is_verified=True)
+            custom_dbs = _custom_databases_for_suggestions(user)
             for db in custom_dbs:
                 db_config = db.to_adapter_config(openai_client=service.openai_client)
                 db_config['source_name'] = db.name.lower().replace(' ', '_')
@@ -230,7 +236,7 @@ class ParameterSuggestionView(APIView):
         
         try:
             # Get metadata service instance (lazy import)
-            metadata_service = get_metadata_service_instance()
+            metadata_service = get_metadata_service_instance(user=request.user)
             
             if metadata_service is None:
                 logger.error("ParameterMetadataService is not available")
@@ -322,7 +328,7 @@ class SpeciesSpecificParametersView(APIView):
         
         try:
             # Get metadata service instance (lazy import)
-            metadata_service = get_metadata_service_instance()
+            metadata_service = get_metadata_service_instance(user=request.user)
             
             if metadata_service is None:
                 return Response(
@@ -509,7 +515,7 @@ class CustomDatabaseListView(APIView):
             # Get OpenAI client if available
             openai_client = None
             try:
-                metadata_service = get_metadata_service_instance()
+                metadata_service = get_metadata_service_instance(user=database.created_by)
                 if metadata_service:
                     openai_client = metadata_service.openai_client
             except:
@@ -645,7 +651,7 @@ class CustomDatabaseDetailView(APIView):
             
             openai_client = None
             try:
-                metadata_service = get_metadata_service_instance()
+                metadata_service = get_metadata_service_instance(user=database.created_by)
                 if metadata_service:
                     openai_client = metadata_service.openai_client
             except:
@@ -700,7 +706,7 @@ class DatabaseConnectionTestView(APIView):
             # Get OpenAI client if available
             openai_client = None
             try:
-                metadata_service = get_metadata_service_instance()
+                metadata_service = get_metadata_service_instance(user=request.user)
                 if metadata_service:
                     openai_client = metadata_service.openai_client
             except:
@@ -708,9 +714,23 @@ class DatabaseConnectionTestView(APIView):
             
             # Test connection
             tester = DatabaseConnectionTester(openai_client=openai_client)
+            api_key = serializer.validated_data.get('api_key') or ''
+            secret_name = serializer.validated_data.get('api_key_secret_name') or ''
+            if secret_name:
+                from app.secrets.services import materialize_named_secrets
+
+                mapping = materialize_named_secrets(
+                    request.user, [secret_name], actor=request.user, audit=False
+                )
+                if secret_name not in mapping:
+                    return Response(
+                        {"error": "Secret not found.", "success": False},
+                        status=status.HTTP_400_BAD_REQUEST,
+                    )
+                api_key = mapping[secret_name]
             result = tester.test_adapter_patterns(
                 base_url=serializer.validated_data['base_url'],
-                api_key=serializer.validated_data.get('api_key'),
+                api_key=api_key or None,
                 config=serializer.validated_data.get('config', {})
             )
             

--- a/gui/workflow_backend/django-project/app/secrets/__init__.py
+++ b/gui/workflow_backend/django-project/app/secrets/__init__.py
@@ -1,0 +1,1 @@
+"""Owner-only encrypted secret store."""

--- a/gui/workflow_backend/django-project/app/secrets/apps.py
+++ b/gui/workflow_backend/django-project/app/secrets/apps.py
@@ -1,0 +1,17 @@
+import sys
+
+from django.apps import AppConfig
+
+
+class SecretsConfig(AppConfig):
+    default_auto_field = "django.db.models.BigAutoField"
+    name = "app.secrets"
+    verbose_name = "Owner secret store"
+    label = "nw_secrets"
+
+    def ready(self) -> None:
+        if "pytest" in sys.modules:
+            return
+        from .keys import require_production_master_key
+
+        require_production_master_key()

--- a/gui/workflow_backend/django-project/app/secrets/apps.py
+++ b/gui/workflow_backend/django-project/app/secrets/apps.py
@@ -1,4 +1,4 @@
-import sys
+import os
 
 from django.apps import AppConfig
 
@@ -10,7 +10,7 @@ class SecretsConfig(AppConfig):
     label = "nw_secrets"
 
     def ready(self) -> None:
-        if "pytest" in sys.modules:
+        if os.environ.get("NW_TESTING") or os.environ.get("PYTEST_CURRENT_TEST"):
             return
         from .keys import require_production_master_key
 

--- a/gui/workflow_backend/django-project/app/secrets/crypto.py
+++ b/gui/workflow_backend/django-project/app/secrets/crypto.py
@@ -1,0 +1,85 @@
+"""AES-256-GCM envelope encryption. No Django imports — unit-testable alone.
+
+Each payload is encrypted with a random 32-byte DEK. The DEK is wrapped with
+a versioned KEK (HKDF-SHA256 of the operator master key). AAD binds the
+ciphertext to an application identity so rows cannot be swapped.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+
+CURRENT_KEY_VERSION = 1
+_NONCE_LEN = 12
+_DEK_LEN = 32
+_HKDF_SALT_PREFIX = b"neuroworkflow-secrets-kek-v"
+_HKDF_INFO = b"user-secret-store"
+
+
+class CryptoError(Exception):
+    """Envelope encrypt/decrypt failed."""
+
+
+@dataclass(frozen=True)
+class EncryptedBlob:
+    wrapped_dek: bytes
+    ciphertext: bytes
+    nonce: bytes
+    key_version: int
+
+
+def derive_kek(master_key: bytes, version: int) -> bytes:
+    if not master_key:
+        raise CryptoError("master key is empty")
+    if version < 0:
+        raise CryptoError("invalid key version")
+    return HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=_HKDF_SALT_PREFIX + str(version).encode("ascii"),
+        info=_HKDF_INFO,
+    ).derive(master_key)
+
+
+def envelope_encrypt(plaintext: bytes, kek: bytes, aad: bytes, *, key_version: int = CURRENT_KEY_VERSION) -> EncryptedBlob:
+    if not isinstance(plaintext, (bytes, bytearray)):
+        raise CryptoError("plaintext must be bytes")
+    dek = os.urandom(_DEK_LEN)
+    wrap_nonce = os.urandom(_NONCE_LEN)
+    wrapped_body = AESGCM(kek).encrypt(wrap_nonce, dek, aad)
+    data_nonce = os.urandom(_NONCE_LEN)
+    ciphertext = AESGCM(dek).encrypt(data_nonce, bytes(plaintext), aad)
+    return EncryptedBlob(
+        wrapped_dek=wrap_nonce + wrapped_body,
+        ciphertext=bytes(ciphertext),
+        nonce=data_nonce,
+        key_version=key_version,
+    )
+
+
+def envelope_decrypt(blob: EncryptedBlob, kek: bytes, aad: bytes) -> bytes:
+    if len(blob.wrapped_dek) < _NONCE_LEN + 16:
+        raise CryptoError("wrapped DEK is truncated")
+    if len(blob.nonce) != _NONCE_LEN:
+        raise CryptoError("data nonce must be 12 bytes")
+    wrap_nonce = blob.wrapped_dek[:_NONCE_LEN]
+    wrapped_body = blob.wrapped_dek[_NONCE_LEN:]
+    try:
+        dek = AESGCM(kek).decrypt(wrap_nonce, wrapped_body, aad)
+        return AESGCM(dek).decrypt(blob.nonce, blob.ciphertext, aad)
+    except Exception as exc:
+        raise CryptoError("decrypt failed") from exc
+
+
+def aad_for_user_secret(owner_id: int | str, secret_id: str) -> bytes:
+    return f"user-secret:{owner_id}:{secret_id}".encode("utf-8")
+
+
+def aad_for_custom_db(owner_id: int | str | None, database_id: str) -> bytes:
+    owner = owner_id if owner_id is not None else "0"
+    return f"custom-db:{owner}:{database_id}:api_key".encode("utf-8")

--- a/gui/workflow_backend/django-project/app/secrets/inject.py
+++ b/gui/workflow_backend/django-project/app/secrets/inject.py
@@ -1,0 +1,101 @@
+"""Collect named secret refs from flow JSON and fail closed before a run."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Iterable
+
+from .redaction import is_secret_ref, secret_ref_name
+from .services import materialize_named_secrets
+
+
+class MissingRuntimeSecrets(Exception):
+    def __init__(self, names: list[str]):
+        self.names = list(names)
+        super().__init__(
+            "Missing secrets: "
+            + ", ".join(self.names)
+            + ". Bind your own secret in Settings → Secrets."
+        )
+
+
+def _walk_value(value: Any, names: set[str]) -> None:
+    if is_secret_ref(value):
+        name = secret_ref_name(value)
+        if name:
+            names.add(name)
+        return
+    if isinstance(value, dict):
+        for item in value.values():
+            _walk_value(item, names)
+    elif isinstance(value, list):
+        for item in value:
+            _walk_value(item, names)
+
+
+def collect_secret_names_from_data(data: Any) -> list[str]:
+    names: set[str] = set()
+    _walk_value(data, names)
+    return sorted(names)
+
+
+def collect_secret_names_from_nodes(nodes: Iterable[Any]) -> list[str]:
+    names: set[str] = set()
+    for node in nodes:
+        data = getattr(node, "data", node)
+        names.update(collect_secret_names_from_data(data))
+    return sorted(names)
+
+
+def collect_secret_names_for_project(project) -> list[str]:
+    return collect_secret_names_from_nodes(project.nodes.all())
+
+
+def require_owner_runtime_secrets(owner, names: list[str], *, actor=None, ip=None) -> dict[str, str]:
+    wanted = [n for n in names if n]
+    if not wanted:
+        return {}
+    mapping = materialize_named_secrets(owner, wanted, actor=actor, ip=ip)
+    missing = [n for n in wanted if n not in mapping]
+    if missing:
+        raise MissingRuntimeSecrets(missing)
+    return mapping
+
+
+def wrap_jupyter_code(user_code: str, mapping: dict[str, str] | None) -> str:
+    """Prefix ephemeral kernel code with in-process secret install. Do not log the result."""
+    if not mapping:
+        return user_code
+    payload = json.dumps(mapping, ensure_ascii=False)
+    return (
+        "from neuroworkflow.core.secrets import install_runtime_secrets\n"
+        f"install_runtime_secrets({payload})\n"
+        + user_code
+    )
+
+
+def redact_with_values(text: Any, values: Iterable[str] | None) -> Any:
+    if not text or not values:
+        return text
+    if not isinstance(text, str):
+        return text
+    out = text
+    for value in sorted((v for v in values if v), key=len, reverse=True):
+        out = out.replace(value, "••••")
+    return out
+
+
+def redact_event(event: dict, values: Iterable[str] | None) -> dict:
+    if not event or not values:
+        return event
+    data = event.get("data")
+    if not isinstance(data, dict):
+        return event
+    if "content" in data:
+        data["content"] = redact_with_values(data["content"], values)
+    if "evalue" in data:
+        data["evalue"] = redact_with_values(data["evalue"], values)
+    tb = data.get("traceback")
+    if isinstance(tb, list):
+        data["traceback"] = [redact_with_values(item, values) for item in tb]
+    return event

--- a/gui/workflow_backend/django-project/app/secrets/keys.py
+++ b/gui/workflow_backend/django-project/app/secrets/keys.py
@@ -3,16 +3,15 @@
 from __future__ import annotations
 
 import os
-import sys
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
 
-from .crypto import CURRENT_KEY_VERSION, derive_kek
+from .crypto import CURRENT_KEY_VERSION, CryptoError, EncryptedBlob, derive_kek, envelope_decrypt
 
 
 def _running_tests() -> bool:
-    return "pytest" in sys.modules
+    return bool(os.environ.get("NW_TESTING") or os.environ.get("PYTEST_CURRENT_TEST"))
 
 
 def _master_bytes(raw: str) -> bytes:
@@ -45,28 +44,51 @@ def _current_master() -> tuple[bytes, int]:
 
 
 def get_kek(version: int | None = None) -> bytes:
+    """KEK for wrapping new ciphertext. Always the current master."""
     master, current_version = _current_master()
     use_version = current_version if version is None else version
     if use_version == current_version:
         return derive_kek(master, use_version)
+    raise ImproperlyConfigured(
+        f"Encrypt uses the current KEK only (key_version={current_version}), "
+        f"not key_version={use_version}."
+    )
+
+
+def _keks_for_decrypt(stored_version: int) -> list[bytes]:
+    """Current master first, then SECRETS_MASTER_KEY_PREVIOUS. Same AAD/version salt."""
+    master, current_version = _current_master()
     previous = os.getenv("SECRETS_MASTER_KEY_PREVIOUS", "").strip()
-    if previous and use_version == current_version - 1:
-        return derive_kek(_master_bytes(previous), use_version)
-    # Dev derivation is version CURRENT_KEY_VERSION only.
-    if (settings.DEBUG or _running_tests()) and use_version == CURRENT_KEY_VERSION:
-        return derive_kek(master, use_version)
-    raise ImproperlyConfigured(f"No KEK material for key_version={use_version}")
+    keks: list[bytes] = []
+    seen: set[bytes] = set()
+
+    def add(kek: bytes) -> None:
+        if kek not in seen:
+            seen.add(kek)
+            keks.append(kek)
+
+    add(derive_kek(master, stored_version))
+    if stored_version != current_version:
+        add(derive_kek(master, current_version))
+    if previous:
+        prev = _master_bytes(previous)
+        add(derive_kek(prev, stored_version))
+        if stored_version != current_version:
+            add(derive_kek(prev, current_version))
+    return keks
 
 
 def decrypt_kek_for_version(version: int) -> bytes:
-    """KEK used to unwrap a stored blob of this version."""
-    master, current_version = _current_master()
-    if version == current_version:
-        return derive_kek(master, version)
-    previous = os.getenv("SECRETS_MASTER_KEY_PREVIOUS", "").strip()
-    if previous:
-        return derive_kek(_master_bytes(previous), version)
-    if version == current_version:
-        return derive_kek(master, version)
-    # Same master can still unwrap old versions if only the version integer changed.
-    return derive_kek(master, version)
+    """First KEK to try for a stored blob (current master). Prefer decrypt_blob()."""
+    return _keks_for_decrypt(version)[0]
+
+
+def decrypt_blob(blob: EncryptedBlob, aad: bytes) -> bytes:
+    """Unwrap with current KEK, then PREVIOUS. AAD tamper still fails all candidates."""
+    last_error: CryptoError | None = None
+    for kek in _keks_for_decrypt(blob.key_version):
+        try:
+            return envelope_decrypt(blob, kek, aad)
+        except CryptoError as exc:
+            last_error = exc
+    raise last_error or CryptoError("decrypt failed")

--- a/gui/workflow_backend/django-project/app/secrets/keys.py
+++ b/gui/workflow_backend/django-project/app/secrets/keys.py
@@ -1,0 +1,72 @@
+"""Load versioned KEKs from the operator master key."""
+
+from __future__ import annotations
+
+import os
+import sys
+
+from django.conf import settings
+from django.core.exceptions import ImproperlyConfigured
+
+from .crypto import CURRENT_KEY_VERSION, derive_kek
+
+
+def _running_tests() -> bool:
+    return "pytest" in sys.modules
+
+
+def _master_bytes(raw: str) -> bytes:
+    return raw.encode("utf-8")
+
+
+def require_production_master_key() -> None:
+    """Refuse to boot production without an explicit SECRETS_MASTER_KEY."""
+    if settings.DEBUG or _running_tests():
+        return
+    if not os.getenv("SECRETS_MASTER_KEY", "").strip():
+        raise ImproperlyConfigured(
+            "SECRETS_MASTER_KEY is required when DJANGO_DEBUG is false. "
+            "Generate one with: python3 -c \"import secrets; print(secrets.token_urlsafe(32))\""
+        )
+
+
+def _current_master() -> tuple[bytes, int]:
+    explicit = os.getenv("SECRETS_MASTER_KEY", "").strip()
+    if explicit:
+        return _master_bytes(explicit), CURRENT_KEY_VERSION
+    if settings.DEBUG or _running_tests():
+        secret = settings.SECRET_KEY
+        if not secret:
+            raise ImproperlyConfigured(
+                "DJANGO_SECRET_KEY is required to derive a development secrets KEK."
+            )
+        return _master_bytes(str(secret)), CURRENT_KEY_VERSION
+    raise ImproperlyConfigured("SECRETS_MASTER_KEY is not set")
+
+
+def get_kek(version: int | None = None) -> bytes:
+    master, current_version = _current_master()
+    use_version = current_version if version is None else version
+    if use_version == current_version:
+        return derive_kek(master, use_version)
+    previous = os.getenv("SECRETS_MASTER_KEY_PREVIOUS", "").strip()
+    if previous and use_version == current_version - 1:
+        return derive_kek(_master_bytes(previous), use_version)
+    # Dev derivation is version CURRENT_KEY_VERSION only.
+    if (settings.DEBUG or _running_tests()) and use_version == CURRENT_KEY_VERSION:
+        return derive_kek(master, use_version)
+    raise ImproperlyConfigured(f"No KEK material for key_version={use_version}")
+
+
+def decrypt_kek_for_version(version: int) -> bytes:
+    """KEK used to unwrap a stored blob of this version."""
+    master, current_version = _current_master()
+    if version == current_version:
+        return derive_kek(master, version)
+    previous = os.getenv("SECRETS_MASTER_KEY_PREVIOUS", "").strip()
+    if previous:
+        return derive_kek(_master_bytes(previous), version)
+    if version == current_version:
+        return derive_kek(master, version)
+    # Same master can still unwrap old versions if only the version integer changed.
+    return derive_kek(master, version)

--- a/gui/workflow_backend/django-project/app/secrets/logging_filter.py
+++ b/gui/workflow_backend/django-project/app/secrets/logging_filter.py
@@ -1,0 +1,55 @@
+"""Contextvar-backed logging filter that never writes known secret values."""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+_secret_values: ContextVar[tuple[str, ...]] = ContextVar("nw_secret_values", default=())
+
+
+def register_secret_values(*values: str) -> None:
+    current = list(_secret_values.get())
+    for value in values:
+        if value and value not in current:
+            current.append(value)
+    _secret_values.set(tuple(current))
+
+
+def clear_secret_values() -> None:
+    _secret_values.set(())
+
+
+@contextmanager
+def secret_value_scope(*values: str):
+    token = _secret_values.set(tuple(v for v in values if v))
+    try:
+        yield
+    finally:
+        _secret_values.reset(token)
+
+
+def redact_text(text: str, extra_values: tuple[str, ...] | None = None) -> str:
+    if not text:
+        return text
+    values = list(_secret_values.get())
+    if extra_values:
+        values.extend(extra_values)
+    out = text
+    for value in sorted((v for v in values if v), key=len, reverse=True):
+        out = out.replace(value, "••••")
+    return out
+
+
+class SecretValueFilter(logging.Filter):
+    def filter(self, record: logging.LogRecord) -> bool:
+        try:
+            msg = record.getMessage()
+        except Exception:
+            return True
+        redacted = redact_text(msg)
+        if redacted != msg:
+            record.msg = redacted
+            record.args = ()
+        return True

--- a/gui/workflow_backend/django-project/app/secrets/migrations/0001_initial.py
+++ b/gui/workflow_backend/django-project/app/secrets/migrations/0001_initial.py
@@ -1,0 +1,109 @@
+# Generated for Task 9 owner secret store
+
+import django.db.models.deletion
+import uuid
+from django.conf import settings
+from django.db import migrations, models
+
+import app.secrets.models
+
+
+class Migration(migrations.Migration):
+
+    initial = True
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="UserSecret",
+            fields=[
+                ("id", models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False)),
+                ("name", models.CharField(max_length=64, validators=[app.secrets.models.validate_secret_name])),
+                ("description", models.TextField(blank=True, default="")),
+                ("wrapped_dek", models.BinaryField()),
+                ("ciphertext", models.BinaryField()),
+                ("nonce", models.BinaryField()),
+                ("key_version", models.PositiveSmallIntegerField(default=1)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                ("updated_at", models.DateTimeField(auto_now=True)),
+                ("last_used_at", models.DateTimeField(blank=True, null=True)),
+                ("revoked_at", models.DateTimeField(blank=True, null=True)),
+                (
+                    "owner",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="user_secrets",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+            ],
+            options={"ordering": ["name"]},
+        ),
+        migrations.CreateModel(
+            name="SecretAuditEvent",
+            fields=[
+                ("id", models.UUIDField(default=uuid.uuid4, editable=False, primary_key=True, serialize=False)),
+                ("secret_id_snapshot", models.UUIDField(blank=True, null=True)),
+                ("secret_name", models.CharField(max_length=64)),
+                (
+                    "action",
+                    models.CharField(
+                        choices=[
+                            ("create", "Create"),
+                            ("rotate", "Rotate"),
+                            ("delete", "Delete"),
+                            ("inject", "Inject"),
+                            ("denied", "Denied"),
+                        ],
+                        max_length=16,
+                    ),
+                ),
+                ("ip_address", models.GenericIPAddressField(blank=True, null=True)),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "actor",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="secret_audit_actions",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "owner",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="secret_audit_events",
+                        to=settings.AUTH_USER_MODEL,
+                    ),
+                ),
+                (
+                    "secret",
+                    models.ForeignKey(
+                        blank=True,
+                        null=True,
+                        on_delete=django.db.models.deletion.SET_NULL,
+                        related_name="audit_events",
+                        to="nw_secrets.usersecret",
+                    ),
+                ),
+            ],
+            options={"ordering": ["-created_at"]},
+        ),
+        migrations.AddIndex(
+            model_name="usersecret",
+            index=models.Index(fields=["owner", "revoked_at"], name="nw_secrets__owner_i_revoked_idx"),
+        ),
+        migrations.AddConstraint(
+            model_name="usersecret",
+            constraint=models.UniqueConstraint(fields=("owner", "name"), name="uniq_user_secret_owner_name"),
+        ),
+        migrations.AddIndex(
+            model_name="secretauditevent",
+            index=models.Index(fields=["owner", "created_at"], name="nw_secrets__owner_created_idx"),
+        ),
+    ]

--- a/gui/workflow_backend/django-project/app/secrets/migrations/0002_partial_unique_owner_name.py
+++ b/gui/workflow_backend/django-project/app/secrets/migrations/0002_partial_unique_owner_name.py
@@ -1,0 +1,23 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("nw_secrets", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.RemoveConstraint(
+            model_name="usersecret",
+            name="uniq_user_secret_owner_name",
+        ),
+        migrations.AddConstraint(
+            model_name="usersecret",
+            constraint=models.UniqueConstraint(
+                condition=models.Q(revoked_at__isnull=True),
+                fields=("owner", "name"),
+                name="uniq_user_secret_owner_name_active",
+            ),
+        ),
+    ]

--- a/gui/workflow_backend/django-project/app/secrets/models.py
+++ b/gui/workflow_backend/django-project/app/secrets/models.py
@@ -13,10 +13,9 @@ from django.utils import timezone
 from .crypto import (
     EncryptedBlob,
     aad_for_user_secret,
-    envelope_decrypt,
     envelope_encrypt,
 )
-from .keys import decrypt_kek_for_version, get_kek
+from .keys import decrypt_blob, get_kek
 
 SECRET_NAME_RE = re.compile(r"^[A-Z][A-Z0-9_]{1,63}$")
 
@@ -50,7 +49,8 @@ class UserSecret(models.Model):
         constraints = [
             models.UniqueConstraint(
                 fields=["owner", "name"],
-                name="uniq_user_secret_owner_name",
+                condition=models.Q(revoked_at__isnull=True),
+                name="uniq_user_secret_owner_name_active",
             )
         ]
         ordering = ["name"]
@@ -83,14 +83,17 @@ class UserSecret(models.Model):
         if self.revoked_at is not None:
             raise ValidationError("Secret has been revoked.")
         aad = aad_for_user_secret(self.owner_id, str(self.id))
-        kek = decrypt_kek_for_version(self.key_version)
         blob = EncryptedBlob(
             wrapped_dek=bytes(self.wrapped_dek),
             ciphertext=bytes(self.ciphertext),
             nonce=bytes(self.nonce),
             key_version=self.key_version,
         )
-        return envelope_decrypt(blob, kek, aad).decode("utf-8")
+        return decrypt_blob(blob, aad).decode("utf-8")
+
+    def rewrap_to_current_kek(self) -> None:
+        """Re-encrypt with the current master after a PREVIOUS-key unwrap."""
+        self.set_plaintext(self.decrypt_plaintext())
 
     def mark_used(self) -> None:
         self.last_used_at = timezone.now()

--- a/gui/workflow_backend/django-project/app/secrets/models.py
+++ b/gui/workflow_backend/django-project/app/secrets/models.py
@@ -1,0 +1,145 @@
+"""Encrypted owner secrets and an audit trail that never stores plaintext."""
+
+from __future__ import annotations
+
+import re
+import uuid
+
+from django.conf import settings
+from django.core.exceptions import ValidationError
+from django.db import models
+from django.utils import timezone
+
+from .crypto import (
+    EncryptedBlob,
+    aad_for_user_secret,
+    envelope_decrypt,
+    envelope_encrypt,
+)
+from .keys import decrypt_kek_for_version, get_kek
+
+SECRET_NAME_RE = re.compile(r"^[A-Z][A-Z0-9_]{1,63}$")
+
+
+def validate_secret_name(value: str) -> None:
+    if not SECRET_NAME_RE.match(value or ""):
+        raise ValidationError(
+            "Secret name must match ^[A-Z][A-Z0-9_]{1,63}$ (e.g. ASPERA_PASSWORD)."
+        )
+
+
+class UserSecret(models.Model):
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    owner = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="user_secrets",
+    )
+    name = models.CharField(max_length=64, validators=[validate_secret_name])
+    description = models.TextField(blank=True, default="")
+    wrapped_dek = models.BinaryField()
+    ciphertext = models.BinaryField()
+    nonce = models.BinaryField()
+    key_version = models.PositiveSmallIntegerField(default=1)
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+    last_used_at = models.DateTimeField(null=True, blank=True)
+    revoked_at = models.DateTimeField(null=True, blank=True)
+
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(
+                fields=["owner", "name"],
+                name="uniq_user_secret_owner_name",
+            )
+        ]
+        ordering = ["name"]
+        indexes = [
+            models.Index(fields=["owner", "revoked_at"]),
+        ]
+
+    def __str__(self) -> str:
+        return f"{self.name} ({self.owner_id})"
+
+    @property
+    def is_set(self) -> bool:
+        return bool(self.ciphertext) and self.revoked_at is None
+
+    def set_plaintext(self, value: str) -> None:
+        if not value:
+            raise ValidationError("Secret value cannot be empty.")
+        if not self.id:
+            self.id = uuid.uuid4()
+        aad = aad_for_user_secret(self.owner_id, str(self.id))
+        kek = get_kek()
+        blob = envelope_encrypt(value.encode("utf-8"), kek, aad)
+        self.wrapped_dek = blob.wrapped_dek
+        self.ciphertext = blob.ciphertext
+        self.nonce = blob.nonce
+        self.key_version = blob.key_version
+        self.revoked_at = None
+
+    def decrypt_plaintext(self) -> str:
+        if self.revoked_at is not None:
+            raise ValidationError("Secret has been revoked.")
+        aad = aad_for_user_secret(self.owner_id, str(self.id))
+        kek = decrypt_kek_for_version(self.key_version)
+        blob = EncryptedBlob(
+            wrapped_dek=bytes(self.wrapped_dek),
+            ciphertext=bytes(self.ciphertext),
+            nonce=bytes(self.nonce),
+            key_version=self.key_version,
+        )
+        return envelope_decrypt(blob, kek, aad).decode("utf-8")
+
+    def mark_used(self) -> None:
+        self.last_used_at = timezone.now()
+        self.save(update_fields=["last_used_at"])
+
+    def revoke(self) -> None:
+        self.revoked_at = timezone.now()
+        self.save(update_fields=["revoked_at"])
+
+
+class SecretAuditEvent(models.Model):
+    class Action(models.TextChoices):
+        CREATE = "create", "Create"
+        ROTATE = "rotate", "Rotate"
+        DELETE = "delete", "Delete"
+        INJECT = "inject", "Inject"
+        DENIED = "denied", "Denied"
+
+    id = models.UUIDField(primary_key=True, default=uuid.uuid4, editable=False)
+    owner = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name="secret_audit_events",
+    )
+    actor = models.ForeignKey(
+        settings.AUTH_USER_MODEL,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="secret_audit_actions",
+    )
+    secret = models.ForeignKey(
+        UserSecret,
+        on_delete=models.SET_NULL,
+        null=True,
+        blank=True,
+        related_name="audit_events",
+    )
+    secret_id_snapshot = models.UUIDField(null=True, blank=True)
+    secret_name = models.CharField(max_length=64)
+    action = models.CharField(max_length=16, choices=Action.choices)
+    ip_address = models.GenericIPAddressField(null=True, blank=True)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    class Meta:
+        ordering = ["-created_at"]
+        indexes = [
+            models.Index(fields=["owner", "created_at"]),
+        ]
+
+    def __str__(self) -> str:
+        return f"{self.action} {self.secret_name}"

--- a/gui/workflow_backend/django-project/app/secrets/redaction.py
+++ b/gui/workflow_backend/django-project/app/secrets/redaction.py
@@ -1,0 +1,161 @@
+"""Redact secret material from API payloads, flow JSON, and generated code views."""
+
+from __future__ import annotations
+
+import copy
+import re
+from typing import Any
+
+SECRET_REF_KEY = "__nw_secret"
+REDACTED = "••••"
+
+_CONTEXT_BLOCKED = (
+    "password",
+    "secret",
+    "token",
+    "api_key",
+    "apikey",
+    "aspera_pass",
+    "authorization",
+)
+
+
+def is_secret_ref(value: Any) -> bool:
+    return isinstance(value, dict) and SECRET_REF_KEY in value and isinstance(value[SECRET_REF_KEY], dict)
+
+
+def make_secret_ref(secret_id: str | None, name: str) -> dict[str, Any]:
+    return {SECRET_REF_KEY: {"id": str(secret_id or ""), "name": name}}
+
+
+def secret_ref_name(value: Any) -> str | None:
+    if not is_secret_ref(value):
+        return None
+    return value[SECRET_REF_KEY].get("name") or None
+
+
+def secret_ref_id(value: Any) -> str | None:
+    if not is_secret_ref(value):
+        return None
+    sid = value[SECRET_REF_KEY].get("id") or None
+    return str(sid) if sid else None
+
+
+def param_is_secret(param: Any) -> bool:
+    if not isinstance(param, dict):
+        return False
+    if param.get("secret") is True:
+        return True
+    return is_secret_ref(param.get("default_value"))
+
+
+def redact_param_value(param: Any, value: Any) -> Any:
+    if is_secret_ref(value):
+        ref = value[SECRET_REF_KEY]
+        return make_secret_ref(ref.get("id"), ref.get("name") or "")
+    if param_is_secret(param) and value not in (None, ""):
+        name = secret_ref_name(param.get("default_value")) or ""
+        return make_secret_ref(secret_ref_id(param.get("default_value")), name or "REDACTED")
+    return value
+
+
+def _redact_modifications(params: dict, modifications: Any) -> Any:
+    if not isinstance(modifications, dict):
+        return modifications
+    out = copy.deepcopy(modifications)
+    for key, info in out.items():
+        if not isinstance(info, dict):
+            continue
+        param = params.get(key) if isinstance(params, dict) else {}
+        if not param_is_secret(param) and not is_secret_ref(info.get("current_value")) and not is_secret_ref(info.get("original_value")):
+            field_mods = info.get("field_modifications") or {}
+            if not any(
+                is_secret_ref(field_mods.get(k))
+                for k in ("default_value", "default_value_original")
+            ):
+                continue
+        for field in ("original_value", "current_value"):
+            if field in info:
+                info[field] = redact_param_value(param, info.get(field))
+        field_mods = info.get("field_modifications")
+        if isinstance(field_mods, dict):
+            for fk, fv in list(field_mods.items()):
+                field_mods[fk] = redact_param_value(param, fv)
+    return out
+
+
+def redact_node_data(data: Any) -> Any:
+    if not isinstance(data, dict):
+        return data
+    redacted = copy.deepcopy(data)
+    schema = redacted.get("schema") or {}
+    params = schema.get("parameters") or {}
+    if isinstance(params, dict):
+        for key, param in params.items():
+            if not isinstance(param, dict):
+                continue
+            if "default_value" in param:
+                param["default_value"] = redact_param_value(param, param.get("default_value"))
+    if "parameter_modifications" in redacted:
+        redacted["parameter_modifications"] = _redact_modifications(
+            params if isinstance(params, dict) else {},
+            redacted.get("parameter_modifications"),
+        )
+    return redacted
+
+
+def redact_flow_payload(flow: Any) -> Any:
+    if not isinstance(flow, dict):
+        return flow
+    out = copy.deepcopy(flow)
+    nodes = out.get("nodes")
+    if isinstance(nodes, list):
+        for node in nodes:
+            if isinstance(node, dict) and "data" in node:
+                node["data"] = redact_node_data(node.get("data"))
+    return out
+
+
+def redact_generated_code(source: str | None) -> str | None:
+    """Keep SecretRef(...) lines; never required to know plaintext.
+
+    Also masks obvious password= / api_key= string literals as defense in depth.
+    """
+    if source is None:
+        return None
+    patterns = [
+        re.compile(r"(password\s*=\s*)(['\"])([^'\"]+)\2", re.IGNORECASE),
+        re.compile(r"(api_key\s*=\s*)(['\"])([^'\"]+)\2", re.IGNORECASE),
+        re.compile(r"(aspera_pass\s*[:=]\s*)(['\"])([^'\"]+)\2", re.IGNORECASE),
+    ]
+    out = source
+    for pat in patterns:
+        out = pat.sub(rf"\1\2{REDACTED}\2", out)
+    return out
+
+
+def blocked_context_keys(context: Any) -> list[str]:
+    if not isinstance(context, dict):
+        return []
+    hits = []
+    for key in context.keys():
+        lowered = str(key).lower().replace("-", "_")
+        if any(token in lowered for token in _CONTEXT_BLOCKED):
+            hits.append(str(key))
+    return hits
+
+
+class WorkflowContextBlockedError(ValueError):
+    def __init__(self, keys: list[str]):
+        self.keys = keys
+        super().__init__(
+            "workflow_context must not contain "
+            + ", ".join(keys)
+            + "; store credentials in Settings → Secrets."
+        )
+
+
+def assert_context_has_no_secrets(context: Any) -> None:
+    hits = blocked_context_keys(context)
+    if hits:
+        raise WorkflowContextBlockedError(hits)

--- a/gui/workflow_backend/django-project/app/secrets/sanitize.py
+++ b/gui/workflow_backend/django-project/app/secrets/sanitize.py
@@ -1,0 +1,72 @@
+"""Reject plaintext secret parameters on flow/node writes. Persist refs only."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from django.core.exceptions import ValidationError
+
+from .redaction import is_secret_ref, make_secret_ref, param_is_secret, secret_ref_id, secret_ref_name
+from .services import get_owned_secret, owner_secrets_qs
+
+
+def _require_ref_or_empty(owner, key: str, value: Any) -> Any:
+    if value in (None, ""):
+        return value
+    if is_secret_ref(value):
+        sid = secret_ref_id(value)
+        name = secret_ref_name(value)
+        owned = None
+        if sid:
+            owned = get_owned_secret(owner, sid)
+        if owned is None and name:
+            owned = owner_secrets_qs(owner).filter(name=name).first()
+        if owned is None or owned.revoked_at is not None:
+            raise ValidationError(f"Secret parameter '{key}' is not an owned vault reference.")
+        return make_secret_ref(owned.id, owned.name)
+    raise ValidationError(
+        f"Secret parameter '{key}' must be a vault reference, not a literal value."
+    )
+
+
+def _secretish_param(param: Any, value: Any) -> bool:
+    return param_is_secret(param) or is_secret_ref(value)
+
+
+def sanitize_node_data(owner, data: Any) -> Any:
+    """Fail closed: secret-schema params must be a valid owner SecretRef or empty."""
+    if not isinstance(data, dict):
+        return data
+    schema = data.get("schema") or {}
+    params = schema.get("parameters") or {}
+    if isinstance(params, dict):
+        for key, param in params.items():
+            if not isinstance(param, dict):
+                continue
+            value = param.get("default_value")
+            if not _secretish_param(param, value):
+                continue
+            if "default_value" in param:
+                param["default_value"] = _require_ref_or_empty(owner, key, value)
+    mods = data.get("parameter_modifications")
+    if isinstance(mods, dict):
+        for key, info in mods.items():
+            if not isinstance(info, dict):
+                continue
+            param = params.get(key) if isinstance(params, dict) else {}
+            secret_mod = param_is_secret(param) or is_secret_ref(info.get("current_value")) or is_secret_ref(
+                info.get("original_value")
+            )
+            field_mods = info.get("field_modifications")
+            if isinstance(field_mods, dict) and any(is_secret_ref(v) for v in field_mods.values()):
+                secret_mod = True
+            if not secret_mod:
+                continue
+            for field in ("original_value", "current_value"):
+                if field in info:
+                    info[field] = _require_ref_or_empty(owner, key, info.get(field))
+            if isinstance(field_mods, dict):
+                for fk, fv in list(field_mods.items()):
+                    if param_is_secret(param) or is_secret_ref(fv):
+                        field_mods[fk] = _require_ref_or_empty(owner, f"{key}.{fk}", fv)
+    return data

--- a/gui/workflow_backend/django-project/app/secrets/serializers.py
+++ b/gui/workflow_backend/django-project/app/secrets/serializers.py
@@ -1,0 +1,32 @@
+from rest_framework import serializers
+
+from .models import UserSecret, validate_secret_name
+
+
+class UserSecretSerializer(serializers.ModelSerializer):
+    is_set = serializers.BooleanField(read_only=True)
+    value = serializers.CharField(write_only=True, required=False, allow_blank=False)
+
+    class Meta:
+        model = UserSecret
+        fields = [
+            "id",
+            "name",
+            "description",
+            "is_set",
+            "value",
+            "created_at",
+            "updated_at",
+            "last_used_at",
+        ]
+        read_only_fields = [
+            "id",
+            "is_set",
+            "created_at",
+            "updated_at",
+            "last_used_at",
+        ]
+
+    def validate_name(self, value):
+        validate_secret_name(value)
+        return value

--- a/gui/workflow_backend/django-project/app/secrets/services.py
+++ b/gui/workflow_backend/django-project/app/secrets/services.py
@@ -1,0 +1,121 @@
+"""Audit helper and owner-secret CRUD (values never leave the vault API)."""
+
+from __future__ import annotations
+
+from django.core.exceptions import ValidationError
+
+from .models import SECRET_NAME_RE, SecretAuditEvent, UserSecret, validate_secret_name
+
+
+def client_ip(request) -> str | None:
+    forwarded = request.META.get("HTTP_X_FORWARDED_FOR")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    return request.META.get("REMOTE_ADDR")
+
+
+def record_audit(*, owner, actor, secret: UserSecret | None, action: str, ip=None, name: str | None = None) -> None:
+    SecretAuditEvent.objects.create(
+        owner=owner,
+        actor=actor,
+        secret=secret,
+        secret_id_snapshot=getattr(secret, "id", None),
+        secret_name=name or (secret.name if secret else ""),
+        action=action,
+        ip_address=ip,
+    )
+
+
+def owner_secrets_qs(user):
+    return UserSecret.objects.filter(owner=user, revoked_at__isnull=True)
+
+
+def get_owned_secret(user, secret_id) -> UserSecret | None:
+    return UserSecret.objects.filter(owner=user, id=secret_id).first()
+
+
+def create_user_secret(owner, *, name: str, value: str, description: str = "", actor=None, ip=None) -> UserSecret:
+    validate_secret_name(name)
+    if UserSecret.objects.filter(owner=owner, name=name, revoked_at__isnull=True).exists():
+        raise ValidationError({"name": "A secret with this name already exists."})
+    secret = UserSecret(owner=owner, name=name, description=description or "")
+    secret.set_plaintext(value)
+    secret.save()
+    record_audit(owner=owner, actor=actor or owner, secret=secret, action=SecretAuditEvent.Action.CREATE, ip=ip)
+    return secret
+
+
+def rotate_user_secret(secret: UserSecret, *, value: str | None = None, description: str | None = None, actor=None, ip=None) -> UserSecret:
+    if secret.revoked_at is not None:
+        raise ValidationError("Secret has been revoked.")
+    if description is not None:
+        secret.description = description
+    if value:
+        secret.set_plaintext(value)
+    secret.save()
+    record_audit(
+        owner=secret.owner,
+        actor=actor or secret.owner,
+        secret=secret,
+        action=SecretAuditEvent.Action.ROTATE,
+        ip=ip,
+    )
+    return secret
+
+
+def revoke_user_secret(secret: UserSecret, *, actor=None, ip=None) -> None:
+    secret.revoke()
+    record_audit(
+        owner=secret.owner,
+        actor=actor or secret.owner,
+        secret=secret,
+        action=SecretAuditEvent.Action.DELETE,
+        ip=ip,
+    )
+
+
+def materialize_named_secrets(owner, names: list[str], *, actor=None, ip=None, audit: bool = True) -> dict[str, str]:
+    """Decrypt owner secrets by name. Missing names are omitted (caller fails closed)."""
+    wanted = {n for n in names if n}
+    if not wanted:
+        return {}
+    mapping: dict[str, str] = {}
+    qs = owner_secrets_qs(owner).filter(name__in=wanted)
+    found = set()
+    for secret in qs:
+        mapping[secret.name] = secret.decrypt_plaintext()
+        secret.mark_used()
+        found.add(secret.name)
+        if audit:
+            record_audit(
+                owner=owner,
+                actor=actor or owner,
+                secret=secret,
+                action=SecretAuditEvent.Action.INJECT,
+                ip=ip,
+            )
+    missing = wanted - found
+    if missing and audit:
+        record_audit(
+            owner=owner,
+            actor=actor or owner,
+            secret=None,
+            action=SecretAuditEvent.Action.DENIED,
+            ip=ip,
+            name=",".join(sorted(missing)),
+        )
+    return mapping
+
+
+def suggest_secret_name(owner, base: str) -> str:
+    cleaned = "".join(ch if ch.isalnum() else "_" for ch in (base or "SECRET").upper())
+    if not cleaned or not cleaned[0].isalpha():
+        cleaned = "S_" + cleaned
+    cleaned = cleaned[:64]
+    if SECRET_NAME_RE.match(cleaned) and not owner_secrets_qs(owner).filter(name=cleaned).exists():
+        return cleaned
+    for i in range(2, 100):
+        candidate = f"{cleaned[:60]}_{i}"
+        if not owner_secrets_qs(owner).filter(name=candidate).exists():
+            return candidate
+    return cleaned[:50] + "_X"

--- a/gui/workflow_backend/django-project/app/secrets/services.py
+++ b/gui/workflow_backend/django-project/app/secrets/services.py
@@ -52,6 +52,8 @@ def rotate_user_secret(secret: UserSecret, *, value: str | None = None, descript
         secret.description = description
     if value:
         secret.set_plaintext(value)
+    else:
+        secret.rewrap_to_current_kek()
     secret.save()
     record_audit(
         owner=secret.owner,
@@ -61,6 +63,18 @@ def rotate_user_secret(secret: UserSecret, *, value: str | None = None, descript
         ip=ip,
     )
     return secret
+
+
+def rewrap_owner_secrets(owner) -> int:
+    """Rewrap every active secret onto the current KEK (vault PATCH rotation helper)."""
+    count = 0
+    for secret in owner_secrets_qs(owner):
+        secret.rewrap_to_current_kek()
+        secret.save(
+            update_fields=["wrapped_dek", "ciphertext", "nonce", "key_version", "updated_at"]
+        )
+        count += 1
+    return count
 
 
 def revoke_user_secret(secret: UserSecret, *, actor=None, ip=None) -> None:
@@ -94,6 +108,10 @@ def materialize_named_secrets(owner, names: list[str], *, actor=None, ip=None, a
                 action=SecretAuditEvent.Action.INJECT,
                 ip=ip,
             )
+    if mapping:
+        from .logging_filter import register_secret_values
+
+        register_secret_values(*mapping.values())
     missing = wanted - found
     if missing and audit:
         record_audit(

--- a/gui/workflow_backend/django-project/app/secrets/urls.py
+++ b/gui/workflow_backend/django-project/app/secrets/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path
+
+from .views import UserSecretDetailView, UserSecretListCreateView
+
+app_name = "secrets"
+
+urlpatterns = [
+    path("", UserSecretListCreateView.as_view(), name="secret-list-create"),
+    path("<uuid:secret_id>/", UserSecretDetailView.as_view(), name="secret-detail"),
+]

--- a/gui/workflow_backend/django-project/app/secrets/views.py
+++ b/gui/workflow_backend/django-project/app/secrets/views.py
@@ -1,0 +1,91 @@
+from django.core.exceptions import ValidationError as DjangoValidationError
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from app.auth.authentication import KeycloakAuthentication
+
+from .models import UserSecret
+from .serializers import UserSecretSerializer
+from .services import (
+    client_ip,
+    create_user_secret,
+    get_owned_secret,
+    owner_secrets_qs,
+    revoke_user_secret,
+    rotate_user_secret,
+)
+
+
+def _not_found():
+    return Response({"error": "Secret not found."}, status=status.HTTP_404_NOT_FOUND)
+
+
+class UserSecretListCreateView(APIView):
+    authentication_classes = [KeycloakAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        qs = owner_secrets_qs(request.user)
+        return Response(UserSecretSerializer(qs, many=True).data)
+
+    def post(self, request):
+        ser = UserSecretSerializer(data=request.data)
+        ser.is_valid(raise_exception=True)
+        value = ser.validated_data.get("value")
+        if not value:
+            return Response({"error": "value is required."}, status=status.HTTP_400_BAD_REQUEST)
+        try:
+            secret = create_user_secret(
+                request.user,
+                name=ser.validated_data["name"],
+                value=value,
+                description=ser.validated_data.get("description") or "",
+                actor=request.user,
+                ip=client_ip(request),
+            )
+        except DjangoValidationError as exc:
+            return Response({"error": exc.message_dict if hasattr(exc, "message_dict") else str(exc)}, status=400)
+        return Response(UserSecretSerializer(secret).data, status=status.HTTP_201_CREATED)
+
+
+class UserSecretDetailView(APIView):
+    authentication_classes = [KeycloakAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    def _load(self, request, secret_id) -> UserSecret | None:
+        return get_owned_secret(request.user, secret_id)
+
+    def get(self, request, secret_id):
+        secret = self._load(request, secret_id)
+        if secret is None or secret.revoked_at is not None:
+            return _not_found()
+        return Response(UserSecretSerializer(secret).data)
+
+    def patch(self, request, secret_id):
+        secret = self._load(request, secret_id)
+        if secret is None:
+            return _not_found()
+        value = request.data.get("value")
+        description = request.data.get("description")
+        if value is None and description is None:
+            return Response({"error": "value or description is required."}, status=400)
+        try:
+            secret = rotate_user_secret(
+                secret,
+                value=value,
+                description=description,
+                actor=request.user,
+                ip=client_ip(request),
+            )
+        except DjangoValidationError as exc:
+            return Response({"error": str(exc)}, status=400)
+        return Response(UserSecretSerializer(secret).data)
+
+    def delete(self, request, secret_id):
+        secret = self._load(request, secret_id)
+        if secret is None:
+            return _not_found()
+        revoke_user_secret(secret, actor=request.user, ip=client_ip(request))
+        return Response(status=status.HTTP_204_NO_CONTENT)

--- a/gui/workflow_backend/django-project/app/workflow/code_generation_service.py
+++ b/gui/workflow_backend/django-project/app/workflow/code_generation_service.py
@@ -11,7 +11,20 @@ from .path_utils import code_file_path, notebook_file_path, projects_root
 import logging
 import traceback
 
+from app.secrets.redaction import (
+    WorkflowContextBlockedError,
+    assert_context_has_no_secrets,
+    is_secret_ref,
+    param_is_secret,
+    secret_ref_name,
+)
+
 logger = logging.getLogger(__name__)
+
+
+class _SecretRefEmit:
+    def __init__(self, name: str):
+        self.name = name
 
 
 class CodeGenerationService:
@@ -286,6 +299,7 @@ class CodeGenerationService:
     def _create_base_template(self, project):
         """Create a basic template (with section comments)"""
         context_obj = getattr(project, "workflow_context", {}) or {}
+        assert_context_has_no_secrets(context_obj)
         context_block = json.dumps(context_obj, indent=4)
         context_block_indented = textwrap.indent(context_block, " " * 8)
         if context_block_indented.startswith(" " * 8):
@@ -304,9 +318,11 @@ import numpy as np
 sys.path.append('../../')
 
 from neuroworkflow.core.workflow import WorkflowBuilder
+from neuroworkflow.core.secrets import SecretRef, load_runtime_secrets
 
 def main():
     """Run a simple neural simulation workflow."""
+    load_runtime_secrets()
 
     # workflow_builder_import
 
@@ -369,7 +385,10 @@ if __name__ == "__main__":
         node_id = node.id
 
         logger.info(
-            f"DEBUG: Generating code block for node {node_id} - label: '{label}', category: '{category}', node_data: {node.data}"
+            "Generating code block for node %s label=%s category=%s",
+            node_id,
+            label,
+            category,
         )
 
         if not label:
@@ -414,7 +433,7 @@ if __name__ == "__main__":
             code_block += f"""
     {var_name}.configure()\n"""
 
-        logger.info(f"DEBUG: Generated code block for node {node_id}:\n{code_block}")
+        logger.info("Generated configure block for node %s", node_id)
         return code_block
 
     def _sanitize_variable_name(self, node_id, prefix):
@@ -472,6 +491,15 @@ if __name__ == "__main__":
         for key, value in modified_params.items():
             # Sanitize parameter key to avoid Python keyword collisions
             safe_key = f"{key}_" if keyword.iskeyword(key) else key
+            if isinstance(value, _SecretRefEmit):
+                config_lines.append(f"            {safe_key}=SecretRef({value.name!r})")
+                continue
+            if is_secret_ref(value):
+                name = secret_ref_name(value) or ""
+                if not name:
+                    continue
+                config_lines.append(f"            {safe_key}=SecretRef({name!r})")
+                continue
             if isinstance(value, str):
                 trimmed = value.strip()
                 # Lambda expressions must be emitted bare — repr() would quote them
@@ -511,20 +539,41 @@ if __name__ == "__main__":
         schema = node_data.get("schema", {})
         parameters = schema.get("parameters", {})
 
-        logger.info(f"DEBUG: Processing parameters for configure block: {parameters}")
+        logger.debug("Building configure block")
 
         # Get modification information from parameter_modifications
         modifications = node_data.get("parameter_modifications", {})
-        logger.info(f"DEBUG: parameter_modifications: {modifications}")
+        logger.debug("Read parameter_modifications")
+
+        def _secret_emit(param_info, current_value):
+            if is_secret_ref(current_value):
+                name = secret_ref_name(current_value)
+                if not name:
+                    return None
+                return _SecretRefEmit(name)
+            if param_is_secret(param_info):
+                if isinstance(current_value, str) and current_value and current_value.isupper():
+                    return _SecretRefEmit(current_value)
+                if current_value in (None, "", {}):
+                    return None
+                raise ValueError(
+                    "Secret parameters must be vault references (SecretRef), not literal values"
+                )
+            return None
 
         # Process only changed parameters
         for param_key, param_info in parameters.items():
             current_value = param_info.get("default_value")  # Get the current value from default_value
-            logger.info(f"DEBUG: Processing parameter '{param_key}' with value '{current_value}'")
+            logger.debug("Processing parameter %s", param_key)
 
             # Get the parameter name that maps to a configuration setting
             config_key = self._map_parameter_to_config_key(param_key)
-            logger.info(f"DEBUG: Parameter '{param_key}' mapped to config_key '{config_key}'")
+            logger.debug("Parameter %s mapped to config_key %s", param_key, config_key)
+
+            secret_value = _secret_emit(param_info, current_value)
+            if secret_value is not None:
+                modified_params_only[config_key] = secret_value
+                continue
 
             # Check only when default_value is changed
             if param_key in modifications:
@@ -534,10 +583,15 @@ if __name__ == "__main__":
                 is_modified = modification_info.get("is_modified", False)
                 # Check if default_value is different from original value
                 has_default_value_changed = (current_value != original_value) and is_modified
-                logger.info(f"DEBUG: Parameter '{param_key}' default_value changed: {original_value} -> {current_value} (changed: {has_default_value_changed}, is_modified: {is_modified})")
+                logger.debug(
+                    "Parameter %s default_value changed=%s is_modified=%s",
+                    param_key,
+                    has_default_value_changed,
+                    is_modified,
+                )
             else:
                 has_default_value_changed = False
-                logger.info(f"DEBUG: Parameter '{param_key}' not found in modifications")
+                logger.debug("Parameter %s not found in modifications", param_key)
 
             # Add only parameters whose default_value has changed
             if (param_key in modifications and
@@ -547,30 +601,33 @@ if __name__ == "__main__":
                 # perform type conversion
                 converted_value = self._convert_parameter_value(current_value, config_key)
                 modified_params_only[config_key] = converted_value
-
-                modification_info = modifications[param_key]
-                original_value = modification_info.get("field_modifications", {}).get("default_value_original", "")
-                logger.info(f"DEBUG: Added parameter with default_value change '{param_key}' -> '{config_key}': {original_value} -> {current_value}")
+                logger.debug("Added parameter with default_value change %s -> %s", param_key, config_key)
 
         # Additional checks to ensure all items in parameter_modifications are processed
         # More detailed logging to resolve recognition issue after the third one
         logger.info(f"DEBUG: Starting additional check for all modifications: {len(modifications)} items")
         for i, (param_key, modification_info) in enumerate(modifications.items()):
-            logger.info(f"DEBUG: Processing modification {i+1}/{len(modifications)}: {param_key}")
+            logger.debug("Modification %s/%s: %s", i + 1, len(modifications), param_key)
 
             if param_key not in parameters:
-                logger.warning(f"DEBUG: Parameter '{param_key}' found in modifications but not in schema.parameters")
+                logger.warning("Parameter %s found in modifications but not in schema.parameters", param_key)
                 continue
 
             param_info = parameters[param_key]
             current_value = param_info.get("default_value")
+            secret_value = _secret_emit(param_info, current_value)
+            if secret_value is not None:
+                config_key = self._map_parameter_to_config_key(param_key)
+                if config_key:
+                    modified_params_only[config_key] = secret_value
+                continue
             # Compatible with new data structures
             original_value = modification_info.get("field_modifications", {}).get("default_value_original", "")
             is_modified = modification_info.get("is_modified", False)
 
             # Get the parameter name that maps to a configuration setting
             config_key = self._map_parameter_to_config_key(param_key)
-            logger.info(f"DEBUG: Modification {i+1} - '{param_key}' -> '{config_key}': {original_value} -> {current_value} (is_modified: {is_modified})")
+            logger.debug("Modification %s %s -> %s is_modified=%s", i + 1, param_key, config_key, is_modified)
 
             # More lenient mutation detection (comparison after type conversion)
             current_converted = self._convert_parameter_value(current_value, config_key)
@@ -590,11 +647,11 @@ if __name__ == "__main__":
                 converted_value = self._convert_parameter_value(current_value, config_key)
                 modified_params_only[config_key] = converted_value
 
-                logger.info(f"DEBUG: Added modification {i+1} '{param_key}' -> '{config_key}': {original_value} -> {current_value}")
+                logger.debug("Added modification %s %s -> %s", i + 1, param_key, config_key)
             else:
-                logger.info(f"DEBUG: Skipped modification {i+1} '{param_key}' (already processed or no change)")
+                logger.debug("Skipped modification %s %s (already processed or no change)", i + 1, param_key)
 
-        logger.info(f"DEBUG: Found {len(modified_params_only)} modified parameters for configure block")
+        logger.debug("Found %s modified parameters for configure block", len(modified_params_only))
         return modified_params_only
 
     def _map_parameter_to_config_key(self, parameter_key):
@@ -608,6 +665,9 @@ if __name__ == "__main__":
         """
         Converts parameter values ​​to the appropriate type (supports arrays and numbers)
         """
+        if is_secret_ref(value) or isinstance(value, _SecretRefEmit):
+            return value
+
         # Processing arrays
         if isinstance(value, list):
             # If it is a list, convert it to Python array notation
@@ -820,7 +880,7 @@ if __name__ == "__main__":
             # Assigning node numbers
             node_no = 1
             for i, node_data in enumerate(nodes_data):
-                logger.info(f"DEBUG: Node {i+1}: {node_data}")
+                logger.debug("Processing node %s", i + 1)
 
                 # Retrieve node information from the actual database and include parameter change information
                 node_id = node_data.get("id", "")
@@ -838,7 +898,7 @@ if __name__ == "__main__":
                     enhanced_node_data['parameter_modifications'] = db_node.data.get('parameter_modifications', {})
                     enhanced_node_data['has_parameter_modifications'] = db_node.data.get('has_parameter_modifications', False)
 
-                    logger.info(f"DEBUG: Enhanced node data with parameter modifications: {enhanced_node_data}")
+                    logger.debug("Merged DB parameter_modifications for node %s", node_id)
                 except FlowNode.DoesNotExist:
                     logger.warning(f"Node {node_id} not found in DB, using JSON data only")
                     enhanced_node_data = node_data.get("data", {})
@@ -860,7 +920,7 @@ if __name__ == "__main__":
 
                 # Generate a code block for a node
                 code_block = self._generate_node_code_block(temp_node, node_no, instance_name)                
-                logger.info(f"DEBUG: Generated code block: '{code_block}'")
+                logger.debug("Generated code block for node %s", node_id)
                 # Node number count
                 node_no += 1
 
@@ -977,7 +1037,7 @@ if __name__ == "__main__":
             )
             match = workflow_section_pattern.search(updated_code)
 
-            logger.info(f"DEBUG: !!! updated_code !!! {updated_code}")
+            logger.debug("updated_code assembled")
 
             if match:
                 insertion_point = match.end()
@@ -1006,7 +1066,7 @@ if __name__ == "__main__":
             with open(code_file, "w", encoding="utf-8") as f:
                 f.write(updated_code)
 
-            logger.info(f"DEBUG: Final generated code:\n{updated_code}")
+            logger.info("Wrote generated workflow.py")
             logger.info(f"Successfully saved generated code to: {code_file}")
 
             # Sidecar map used by the run stream to attribute output (figures)
@@ -1033,7 +1093,15 @@ if __name__ == "__main__":
             logger.info("=== Batch code generation completed successfully ===")
             return True
 
+        except WorkflowContextBlockedError:
+            raise
+        except ValueError as e:
+            if "Secret parameters must be vault" in str(e):
+                raise
+            logger.error("=== Critical error in batch code generation: %s ===", e)
+            logger.error(traceback.format_exc())
+            return False
         except Exception as e:
-            logger.error(f"=== Critical error in batch code generation: {e} ===")
+            logger.error("=== Critical error in batch code generation: %s ===", e)
             logger.error(traceback.format_exc())
             return False

--- a/gui/workflow_backend/django-project/app/workflow/execution/base.py
+++ b/gui/workflow_backend/django-project/app/workflow/execution/base.py
@@ -46,6 +46,7 @@ class ExecutionBackend(ABC):
         *,
         run_id: Optional[str] = None,
         resource_requests: Optional[dict] = None,
+        runtime_secrets: Optional[dict] = None,
     ) -> ExecutionResult:
         """Submit a workflow run. Returns immediately with a pending result.
 

--- a/gui/workflow_backend/django-project/app/workflow/execution/local_executor.py
+++ b/gui/workflow_backend/django-project/app/workflow/execution/local_executor.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import os
 import subprocess
 import threading
 from datetime import datetime, timezone
@@ -34,6 +35,7 @@ class LocalExecutor(ExecutionBackend):
         *,
         run_id: Optional[str] = None,
         resource_requests: Optional[dict] = None,
+        runtime_secrets: Optional[dict] = None,
     ) -> ExecutionResult:
         result = ExecutionResult(
             status=ExecutionStatus.PENDING,
@@ -55,31 +57,39 @@ class LocalExecutor(ExecutionBackend):
 
         thread = threading.Thread(
             target=self._run,
-            args=(result.run_id, str(script_path)),
+            args=(result.run_id, str(script_path), dict(runtime_secrets or {})),
             daemon=True,
         )
         thread.start()
         return result
 
-    def _run(self, run_id: str, script_path: str) -> None:
+    def _run(self, run_id: str, script_path: str, runtime_secrets: Optional[dict] = None) -> None:
         entry = _runs.get(run_id)
         if not entry:
             return
         res: ExecutionResult = entry["result"]
         res.status = ExecutionStatus.RUNNING
         res.started_at = datetime.now(timezone.utc)
+        runtime_secrets = runtime_secrets or {}
 
         try:
+            env = os.environ.copy()
+            for name, value in runtime_secrets.items():
+                env[f"NW_SECRET_{name}"] = str(value)
             proc = subprocess.Popen(
                 ["python", script_path],
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
                 text=True,
+                env=env,
             )
             entry["process"] = proc
             stdout, stderr = proc.communicate()
-            res.stdout = stdout
-            res.stderr = stderr
+            from app.secrets.inject import redact_with_values
+
+            values = list(runtime_secrets.values())
+            res.stdout = redact_with_values(stdout, values)
+            res.stderr = redact_with_values(stderr, values)
             res.exit_code = proc.returncode
             res.status = (
                 ExecutionStatus.COMPLETED

--- a/gui/workflow_backend/django-project/app/workflow/execution/remote_slurm_executor.py
+++ b/gui/workflow_backend/django-project/app/workflow/execution/remote_slurm_executor.py
@@ -14,6 +14,7 @@ import os
 import re
 import shlex
 import shutil
+import json
 import subprocess
 import uuid
 from datetime import datetime, timezone
@@ -77,7 +78,7 @@ def _rsync(
     ssh_e = "ssh " + " ".join(_SSH_OPTS)
     if key_path:
         ssh_e += f" -i {key_path} -o IdentitiesOnly=yes"
-    rsync_args = ["rsync", "-az", "--mkpath", "-e", ssh_e]
+    rsync_args = ["rsync", "-az", "--mkpath", "--exclude=.nw-secrets", "-e", ssh_e]
     if to_remote:
         rsync_args += [src, f"{user}@{host}:{dst}"]
     else:
@@ -115,6 +116,27 @@ class RemoteSlurmExecutor(ExecutionBackend):
 
     def _ssh(self, cmd: str) -> str:
         return _ssh_cmd(self.host, self.user, cmd, self.key_path)
+
+    def _push_runtime_secrets(self, remote_run_dir: str, mapping: dict) -> None:
+        """Write ${RUN_DIR}/.nw-secrets mode 0600 via SSH stdin (not in argv, not in results/)."""
+        if not mapping:
+            return
+        dest = f"{remote_run_dir.rstrip('/')}/.nw-secrets"
+        payload = json.dumps(mapping, ensure_ascii=False)
+        ssh_args = ["ssh", *_SSH_OPTS]
+        if self.key_path:
+            ssh_args += ["-i", self.key_path, "-o", "IdentitiesOnly=yes"]
+        ssh_args += [
+            f"{self.user}@{self.host}",
+            f"umask 077 && cat > {shlex.quote(dest)}",
+        ]
+        result = subprocess.run(
+            ssh_args, input=payload, capture_output=True, text=True, timeout=60
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"Failed to write remote secrets file (rc={result.returncode})"
+            )
 
     def _sync_to_remote(self, local: str, remote: str) -> None:
         _rsync(local, remote, self.host, self.user, self.key_path, to_remote=True)
@@ -218,6 +240,7 @@ class RemoteSlurmExecutor(ExecutionBackend):
         *,
         run_id: Optional[str] = None,
         resource_requests: Optional[dict] = None,
+        runtime_secrets: Optional[dict] = None,
     ) -> ExecutionResult:
         run_id = run_id or str(uuid.uuid4())
         result = ExecutionResult(
@@ -242,7 +265,12 @@ class RemoteSlurmExecutor(ExecutionBackend):
                 project_dir,
                 local_dir,
                 ignore=shutil.ignore_patterns(
-                    "batch", "results", "__pycache__", "*.pyc", ".ipynb_checkpoints"
+                    "batch",
+                    "results",
+                    "__pycache__",
+                    "*.pyc",
+                    ".ipynb_checkpoints",
+                    ".nw-secrets",
                 ),
                 dirs_exist_ok=True,
             )
@@ -272,6 +300,7 @@ class RemoteSlurmExecutor(ExecutionBackend):
         try:
             self._ssh(f"mkdir -p {remote_run_dir}")
             self._sync_to_remote(f"{local_dir}/", remote_run_dir + "/")
+            self._push_runtime_secrets(remote_run_dir, runtime_secrets or {})
             output = self._ssh(f"cd {remote_run_dir} && sbatch run.sbatch")
             match = re.search(r"Submitted batch job (\d+)", output)
             if match:

--- a/gui/workflow_backend/django-project/app/workflow/execution/templates/slurm_wrapper.sh.template
+++ b/gui/workflow_backend/django-project/app/workflow/execution/templates/slurm_wrapper.sh.template
@@ -54,9 +54,25 @@ if [ -d "{{VENV_PATH}}" ]; then
 fi
 
 # -- Execution ---------------------------------------------------------------
+export NW_SECRETS_FILE="${RUN_DIR}/.nw-secrets"
+_nw_shred_secrets() {
+  if [ -f "${NW_SECRETS_FILE}" ]; then
+    if command -v shred >/dev/null 2>&1; then
+      shred -u "${NW_SECRETS_FILE}" 2>/dev/null || true
+    fi
+    if [ -f "${NW_SECRETS_FILE}" ]; then
+      : > "${NW_SECRETS_FILE}"
+      rm -f "${NW_SECRETS_FILE}"
+    fi
+  fi
+}
+trap _nw_shred_secrets EXIT
+
 python "${SCRIPT}" > stdout.log 2> stderr.log
 EXIT_CODE=$?
 echo ${EXIT_CODE} > exit_code.txt
+_nw_shred_secrets
+trap - EXIT
 
 # -- Manifest ----------------------------------------------------------------
 cat > manifest.json <<MANIFEST_EOF

--- a/gui/workflow_backend/django-project/app/workflow/jupyter_execution_service.py
+++ b/gui/workflow_backend/django-project/app/workflow/jupyter_execution_service.py
@@ -3,6 +3,7 @@ import json
 import logging
 import os
 import uuid
+from contextlib import asynccontextmanager
 
 import httpx
 from websockets.asyncio.client import connect
@@ -169,28 +170,35 @@ class JupyterExecutionService:
     # WebSocket: execute code and stream output
     # ------------------------------------------------------------------
 
+    @asynccontextmanager
+    async def _runtime_secret_scope(self, runtime_secrets: dict | None):
+        from app.secrets.logging_filter import clear_secret_values, register_secret_values
+
+        values = tuple((runtime_secrets or {}).values())
+        if runtime_secrets:
+            register_secret_values(*values)
+        try:
+            yield values
+        finally:
+            clear_secret_values()
+
     async def execute_code(self, code: str, *, runtime_secrets: dict | None = None):
         """Async generator that yields SSE event dicts.
 
         Each yielded dict has the shape ``{"type": str, "data": dict}``.
         """
         from app.secrets.inject import redact_event, wrap_jupyter_code
-        from app.secrets.logging_filter import clear_secret_values, register_secret_values
 
-        values = tuple((runtime_secrets or {}).values())
-        if runtime_secrets:
-            register_secret_values(*values)
-            code = wrap_jupyter_code(code, runtime_secrets)
-
-        await self._ensure_server_running()
-        kernel_id = await self._create_kernel()
-
-        try:
-            async for event in self._stream_execution(kernel_id, code):
-                yield redact_event(event, values)
-        finally:
-            await self._delete_kernel(kernel_id)
-            clear_secret_values()
+        async with self._runtime_secret_scope(runtime_secrets) as values:
+            if runtime_secrets:
+                code = wrap_jupyter_code(code, runtime_secrets)
+            await self._ensure_server_running()
+            kernel_id = await self._create_kernel()
+            try:
+                async for event in self._stream_execution(kernel_id, code):
+                    yield redact_event(event, values)
+            finally:
+                await self._delete_kernel(kernel_id)
 
     async def _stream_execution(self, kernel_id: str, code: str):
         """Connect to the kernel WebSocket and execute *code*."""

--- a/gui/workflow_backend/django-project/app/workflow/jupyter_execution_service.py
+++ b/gui/workflow_backend/django-project/app/workflow/jupyter_execution_service.py
@@ -169,19 +169,28 @@ class JupyterExecutionService:
     # WebSocket: execute code and stream output
     # ------------------------------------------------------------------
 
-    async def execute_code(self, code: str):
+    async def execute_code(self, code: str, *, runtime_secrets: dict | None = None):
         """Async generator that yields SSE event dicts.
 
         Each yielded dict has the shape ``{"type": str, "data": dict}``.
         """
+        from app.secrets.inject import redact_event, wrap_jupyter_code
+        from app.secrets.logging_filter import clear_secret_values, register_secret_values
+
+        values = tuple((runtime_secrets or {}).values())
+        if runtime_secrets:
+            register_secret_values(*values)
+            code = wrap_jupyter_code(code, runtime_secrets)
+
         await self._ensure_server_running()
         kernel_id = await self._create_kernel()
 
         try:
             async for event in self._stream_execution(kernel_id, code):
-                yield event
+                yield redact_event(event, values)
         finally:
             await self._delete_kernel(kernel_id)
+            clear_secret_values()
 
     async def _stream_execution(self, kernel_id: str, code: str):
         """Connect to the kernel WebSocket and execute *code*."""

--- a/gui/workflow_backend/django-project/app/workflow/run_workflow_service.py
+++ b/gui/workflow_backend/django-project/app/workflow/run_workflow_service.py
@@ -17,29 +17,40 @@ class RunWorkflowService:
     def __init__(self):
         self.code_dir = projects_root()
 
-    def run_workflow_code(self, workflow_id, project_name):
+    def run_workflow_code(self, workflow_id, project_name, runtime_secrets=None):
         project = FlowProject.objects.get(id=workflow_id)
         script_path = code_file_path(project)
 
-        logger.info(f"DEBUG: Run Workflow [{project_name}: {script_path}]")
+        logger.info("Run Workflow [%s]", project_name)
+
+        env = os.environ.copy()
+        for name, value in (runtime_secrets or {}).items():
+            env[f"NW_SECRET_{name}"] = str(value)
 
         try:
             result = subprocess.run(
                 ["python", script_path],
                 capture_output=True,
                 text=True,
-                check=True
+                check=True,
+                env=env,
             )
 
+            from app.secrets.inject import redact_with_values
+
+            values = list((runtime_secrets or {}).values())
             return {
-                "stdout": result.stdout,
-                "stderr": result.stderr
+                "stdout": redact_with_values(result.stdout, values),
+                "stderr": redact_with_values(result.stderr, values),
             }
 
         except subprocess.CalledProcessError as e:
+            from app.secrets.inject import redact_with_values
+
+            values = list((runtime_secrets or {}).values())
             return {
                 "error": str(e),
-                "stdout": e.stdout,
-                "stderr": e.stderr,
+                "stdout": redact_with_values(e.stdout, values),
+                "stderr": redact_with_values(e.stderr, values),
             }
 

--- a/gui/workflow_backend/django-project/app/workflow/serializers.py
+++ b/gui/workflow_backend/django-project/app/workflow/serializers.py
@@ -3,6 +3,13 @@ from .models import FlowProject, FlowNode, FlowEdge, WorkflowRun
 from django.contrib.auth.models import User
 
 from app.box.models import get_categories
+from app.secrets.redaction import (
+    WorkflowContextBlockedError,
+    assert_context_has_no_secrets,
+    param_is_secret,
+    redact_node_data,
+    redact_param_value,
+)
 
 
 def _valid_category_values() -> list[str]:
@@ -94,6 +101,13 @@ class FlowProjectSerializer(serializers.ModelSerializer):
     def get_can_change_visibility(self, obj):
         return self.get_is_owned_by_me(obj)
 
+    def validate_workflow_context(self, value):
+        try:
+            assert_context_has_no_secrets(value or {})
+        except WorkflowContextBlockedError as exc:
+            raise serializers.ValidationError(str(exc))
+        return value or {}
+
     def validate_name(self, value):
         name = (value or "").strip()
         if not name:
@@ -177,7 +191,22 @@ class FlowNodeSerializer(serializers.ModelSerializer):
 
     def get_modified_parameters(self, obj):
         """Details of changed parameters"""
-        return obj.get_modified_parameters()
+        raw = obj.get_modified_parameters()
+        params = ((obj.data or {}).get("schema") or {}).get("parameters") or {}
+        redacted = {}
+        for key, info in raw.items():
+            param = params.get(key) if isinstance(params, dict) else {}
+            redacted[key] = {
+                "original_value": redact_param_value(param, info.get("original_value")),
+                "current_value": redact_param_value(param, info.get("current_value")),
+                "modified_at": info.get("modified_at"),
+            }
+        return redacted
+
+    def to_representation(self, instance):
+        ret = super().to_representation(instance)
+        ret["data"] = redact_node_data(instance.data)
+        return ret
 
     def get_parameter_modification_count(self, obj):
         """The number of parameters that were changed"""

--- a/gui/workflow_backend/django-project/app/workflow/services.py
+++ b/gui/workflow_backend/django-project/app/workflow/services.py
@@ -1,6 +1,7 @@
 from typing import Dict, List, Any
 from django.db import transaction
 from .models import FlowProject, FlowNode, FlowEdge
+from app.secrets.sanitize import sanitize_node_data
 
 
 class FlowService:
@@ -32,7 +33,7 @@ class FlowService:
                     position_x=node_data["position"]["x"],
                     position_y=node_data["position"]["y"],
                     node_type=node_data.get("type", "default"),
-                    data=node_data.get("data", {}),
+                    data=sanitize_node_data(project.owner, node_data.get("data", {})),
                 )
                 nodes.append(node)
 
@@ -121,7 +122,7 @@ class FlowService:
             position_x=node_data["position"]["x"],
             position_y=node_data["position"]["y"],
             node_type=node_data.get("type", "default"),
-            data=node_data.get("data", {}),
+            data=sanitize_node_data(project.owner, node_data.get("data", {})),
         )
 
         return node
@@ -137,7 +138,7 @@ class FlowService:
         node.node_type = node_data.get("type", node.node_type)
 
         if "data" in node_data:
-            new_data = dict(node_data["data"])
+            new_data = sanitize_node_data(project.owner, dict(node_data["data"]))
             # The PUT /parameters/ endpoint is the sole owner of parameter_modifications.
             # The general node update (triggered by position/schema changes in the
             # frontend) carries a stale copy — always restore from the DB record.

--- a/gui/workflow_backend/django-project/app/workflow/views.py
+++ b/gui/workflow_backend/django-project/app/workflow/views.py
@@ -26,6 +26,31 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from app.auth.authentication import KeycloakAuthentication
+from app.secrets.redaction import (
+    WorkflowContextBlockedError,
+    is_secret_ref,
+    make_secret_ref,
+    param_is_secret,
+    redact_flow_payload,
+    redact_generated_code,
+    redact_node_data,
+    redact_param_value,
+    secret_ref_id,
+    secret_ref_name,
+)
+from app.secrets.inject import (
+    MissingRuntimeSecrets,
+    collect_secret_names_for_project,
+    redact_with_values,
+    require_owner_runtime_secrets,
+)
+from app.secrets.services import (
+    client_ip,
+    create_user_secret,
+    get_owned_secret,
+    owner_secrets_qs,
+    suggest_secret_name,
+)
 
 from .code_generation_service import CodeGenerationService
 from .jupyter_execution_service import JupyterExecutionService
@@ -58,6 +83,68 @@ from .execution import LocalExecutor, RemoteSlurmExecutor
 from .services import FlowService
 
 logger = logging.getLogger(__name__)
+
+
+def _prepare_runtime_secrets(request, project):
+    """Return a name→value mapping or a 400 Response if a referenced secret is missing."""
+    names = collect_secret_names_for_project(project)
+    try:
+        return require_owner_runtime_secrets(
+            request.user,
+            names,
+            actor=request.user,
+            ip=client_ip(request),
+        )
+    except MissingRuntimeSecrets as exc:
+        return Response({"error": str(exc)}, status=status.HTTP_400_BAD_REQUEST)
+
+
+def _redact_run_text(owner, project, text: str) -> str:
+    if not text:
+        return text
+    from app.secrets.services import materialize_named_secrets
+
+    names = collect_secret_names_for_project(project)
+    mapping = materialize_named_secrets(owner, names, actor=owner, audit=False)
+    return redact_with_values(text, mapping.values())
+
+
+def _bind_secret_parameter(request, parameter_value):
+    """Turn a secret parameter write into an owner-only SecretRef.
+
+    Returns a ref dict, or a DRF Response on error.
+    """
+    if is_secret_ref(parameter_value):
+        sid = secret_ref_id(parameter_value)
+        name = secret_ref_name(parameter_value)
+        owned = None
+        if sid:
+            owned = get_owned_secret(request.user, sid)
+        if owned is None and name:
+            owned = owner_secrets_qs(request.user).filter(name=name).first()
+        if owned is None or owned.revoked_at is not None:
+            return Response(
+                {"error": "Secret not found."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+        return make_secret_ref(owned.id, owned.name)
+    if isinstance(parameter_value, str) and parameter_value:
+        name = suggest_secret_name(request.user, "NODE_PARAM")
+        secret = create_user_secret(
+            request.user,
+            name=name,
+            value=parameter_value,
+            description="Created from a secret node parameter",
+            actor=request.user,
+            ip=client_ip(request),
+        )
+        return make_secret_ref(secret.id, secret.name)
+    if parameter_value in ("", None):
+        return make_secret_ref("", "")
+    return Response(
+        {"error": "Secret parameters must be a vault reference or a new value."},
+        status=status.HTTP_400_BAD_REQUEST,
+    )
 
 
 @method_decorator(csrf_exempt, name="dispatch")
@@ -108,7 +195,7 @@ class FlowProjectViewSet(viewsets.ModelViewSet):
 
         if request.method == "GET":
             flow_data = FlowService.get_flow_data(str(project.id))
-            return Response(flow_data)
+            return Response(redact_flow_payload(flow_data))
 
         elif request.method == "PUT":
             serializer = FlowDataSerializer(data=request.data)
@@ -584,18 +671,18 @@ class FlowNodeParameterUpdateView(APIView):
             project = get_accessible_project(request, workflow_id, write=True)
             node = get_object_or_404(FlowNode, id=node_id, project=project)
 
-            # Debug: Print request data
-            print(f"🔍 DEBUG: Request data: {request.data}", flush=True)
-            print(f"🔍 DEBUG: Current node data: {node.data}", flush=True)
-
-            # Validating request data
             parameter_key = request.data.get("parameter_key")
             parameter_value = request.data.get("parameter_value")
             parameter_field = request.data.get("parameter_field", "default_value")
             if parameter_field == "value":
                 parameter_field = "default_value"
 
-            print(f"🔍 DEBUG: Parsed - parameter_key: {parameter_key}, parameter_value: {parameter_value}, parameter_field: {parameter_field}", flush=True)
+            logger.info(
+                "Updating parameter '%s.%s' in node %s",
+                parameter_key,
+                parameter_field,
+                node_id,
+            )
 
             if not parameter_key:
                 return Response(
@@ -609,18 +696,13 @@ class FlowNodeParameterUpdateView(APIView):
                     status=status.HTTP_400_BAD_REQUEST,
                 )
 
-            logger.info(f"Updating parameter '{parameter_key}.{parameter_field}' to {parameter_value} in node {node_id}")
-
-            # Check if schema.parameters exists
             if "schema" not in node.data:
-                print("❌ DEBUG: No schema found in node data", flush=True)
                 return Response(
                     {"error": "Node schema not found"},
                     status=status.HTTP_400_BAD_REQUEST,
                 )
 
             if "parameters" not in node.data["schema"]:
-                print("❌ DEBUG: No parameters found in schema", flush=True)
                 return Response(
                     {"error": "Node parameters not found in schema"},
                     status=status.HTTP_400_BAD_REQUEST,
@@ -628,27 +710,22 @@ class FlowNodeParameterUpdateView(APIView):
 
             if parameter_key not in node.data["schema"]["parameters"]:
                 available_keys = list(node.data["schema"]["parameters"].keys())
-                print(f"❌ DEBUG: Parameter '{parameter_key}' not found. Available: {available_keys}", flush=True)
                 return Response(
                     {"error": f"Parameter '{parameter_key}' not found. Available: {available_keys}"},
                     status=status.HTTP_400_BAD_REQUEST,
                 )
 
-            # Get the value before update
-            old_value = node.data["schema"]["parameters"][parameter_key].get(parameter_field)
-            print(f"🔍 DEBUG: Updating {parameter_key}.{parameter_field} from {old_value} to {parameter_value}", flush=True)
+            param_schema = node.data["schema"]["parameters"][parameter_key]
+            original_value = param_schema.get(parameter_field)
 
-            # Save original value (for change history)
-            original_value = node.data["schema"]["parameters"][parameter_key].get(parameter_field)
+            if parameter_field == "default_value" and param_is_secret(param_schema):
+                bound = _bind_secret_parameter(request, parameter_value)
+                if isinstance(bound, Response):
+                    return bound
+                parameter_value = bound
 
-            # Directly update the field specified by parameter_field
-            print(f"🔍 DEBUG: Before update - schema.parameters[{parameter_key}]: {node.data['schema']['parameters'][parameter_key]}", flush=True)
-            node.data["schema"]["parameters"][parameter_key][parameter_field] = parameter_value
-            print(f"🔍 DEBUG: After update - schema.parameters[{parameter_key}]: {node.data['schema']['parameters'][parameter_key]}", flush=True)
+            param_schema[parameter_field] = parameter_value
 
-            print(f"🔍 DEBUG: Updated {parameter_field} from {original_value} to {parameter_value}", flush=True)
-
-            # Track parameter changes (changes across all fields)
             self._update_parameter_modification_status(
                 node.data, parameter_key, parameter_field,
                 node.data["schema"]["parameters"][parameter_key],
@@ -656,15 +733,17 @@ class FlowNodeParameterUpdateView(APIView):
                 original_value
             )
 
-            # save node
             node.save()
+            logger.info(
+                "Successfully updated parameter '%s.%s' in node %s",
+                parameter_key,
+                parameter_field,
+                node_id,
+            )
 
-            print(f"✅ DEBUG: Successfully saved parameter update", flush=True)
-            print(f"🔍 DEBUG: After save - node.data keys: {list(node.data.keys())}", flush=True)
-            print(f"🔍 DEBUG: After save - parameter_modifications: {node.data.get('parameter_modifications', 'NOT FOUND')}", flush=True)
-
-            logger.info(f"Successfully updated parameter '{parameter_key}.{parameter_field}' in node {node_id}")
-
+            updated = redact_node_data(
+                {"schema": {"parameters": {parameter_key: param_schema}}}
+            )["schema"]["parameters"][parameter_key]
             return Response(
                 {
                     "status": "success",
@@ -673,8 +752,8 @@ class FlowNodeParameterUpdateView(APIView):
                     "workflow_id": str(workflow_id),
                     "parameter_key": parameter_key,
                     "parameter_field": parameter_field,
-                    "parameter_value": parameter_value,
-                    "updated_parameter": node.data["schema"]["parameters"][parameter_key]
+                    "parameter_value": redact_param_value(param_schema, parameter_value),
+                    "updated_parameter": updated,
                 }
             )
 
@@ -688,7 +767,6 @@ class FlowNodeParameterUpdateView(APIView):
 
     def _update_parameter_modification_status(self, node_data, parameter_key, parameter_field, parameter, new_value, original_value=None):
         """Track and update parameter changes (all fields)"""
-        print(f"🔍 DEBUG: Tracking modification status for {parameter_key}.{parameter_field}", flush=True)
 
         # Ensure the structure of parameter_modifications
         if "parameter_modifications" not in node_data:
@@ -736,8 +814,6 @@ class FlowNodeParameterUpdateView(APIView):
         original_field_value = param_mod["field_modifications"][field_key]
         is_field_modified = new_value != original_field_value
 
-        print(f"🔍 DEBUG: {parameter_field} - original={original_field_value}, new={new_value}, modified={is_field_modified}", flush=True)
-
         # Update field change status
         param_mod["field_modifications"][parameter_field] = {
             "current_value": new_value,
@@ -758,9 +834,6 @@ class FlowNodeParameterUpdateView(APIView):
 
         # Update overall changes
         node_data["has_parameter_modifications"] = len(modifications) > 0
-
-        print(f"✅ DEBUG: Parameter '{parameter_key}.{parameter_field}' modification status: {'modified' if is_field_modified else 'default'}", flush=True)
-        print(f"🔍 DEBUG: Final modifications data: {modifications}", flush=True)
 
 
 @method_decorator(csrf_exempt, name="dispatch")
@@ -818,6 +891,8 @@ class BatchCodeGenerationView(APIView):
                 {"error": "Invalid JSON format"},
                 status=status.HTTP_400_BAD_REQUEST
             )
+        except (WorkflowContextBlockedError, ValueError) as e:
+            return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
         except FlowProject.DoesNotExist:
             return Response(
                 {"error": f"Project {workflow_id} not found"},
@@ -878,6 +953,11 @@ class WorkflowRunStreamView(APIView):
 
         code = script_path.read_text(encoding="utf-8")
 
+        secrets_or_error = _prepare_runtime_secrets(request, project)
+        if isinstance(secrets_or_error, Response):
+            return secrets_or_error
+        runtime_secrets = secrets_or_error
+
         # Validate generated code syntax before execution
         try:
             ast.parse(code)
@@ -907,7 +987,12 @@ class WorkflowRunStreamView(APIView):
 
         response = StreamingHttpResponse(
             self._sync_event_generator(
-                workflow_id_str, project_name, code, var_to_node, figures_dir
+                workflow_id_str,
+                project_name,
+                code,
+                var_to_node,
+                figures_dir,
+                runtime_secrets,
             ),
             content_type="text/event-stream",
         )
@@ -916,7 +1001,7 @@ class WorkflowRunStreamView(APIView):
         return response
 
     def _sync_event_generator(
-        self, workflow_id, project_name, code, var_to_node, figures_dir
+        self, workflow_id, project_name, code, var_to_node, figures_dir, runtime_secrets=None
     ):
         """Wrap the async Jupyter execution into a sync generator for WSGI."""
         _running_workflows.add(workflow_id)
@@ -932,7 +1017,7 @@ class WorkflowRunStreamView(APIView):
             })
 
             service = JupyterExecutionService()
-            agen = service.execute_code(code)
+            agen = service.execute_code(code, runtime_secrets=runtime_secrets)
 
             while True:
                 try:
@@ -971,10 +1056,16 @@ class BatchWorkflowRunView(APIView):
         try:
             project = get_accessible_project(request, workflow_id, write=True)
 
+            secrets_or_error = _prepare_runtime_secrets(request, project)
+            if isinstance(secrets_or_error, Response):
+                return secrets_or_error
+
             # Run Workflow Project Service
             run_workflow_service = RunWorkflowService()
             project_name = str(project.id)
-            result = run_workflow_service.run_workflow_code(str(workflow_id), project_name)
+            result = run_workflow_service.run_workflow_code(
+                str(workflow_id), project_name, runtime_secrets=secrets_or_error
+            )
 
             response_data = {
                 "status": "success",
@@ -1015,14 +1106,8 @@ class FlowNodeInstanceNameUpdateView(APIView):
             project = get_accessible_project(request, workflow_id, write=True)
             node = get_object_or_404(FlowNode, id=node_id, project=project)
 
-            # Debug: Print request data
-            print(f"🔍 DEBUG: Request data: {request.data}", flush=True)
-            print(f"🔍 DEBUG: Current node data: {node.data}", flush=True)
-
             # Validating request data
             instance_name = request.data.get("instance_name")
-
-            print(f"🔍 DEBUG: Parsed - instance_name: {instance_name}", flush=True)
 
             if not instance_name:
                 return Response(
@@ -1218,7 +1303,7 @@ class WorkflowCodeView(APIView):
         # Generated Python code
         code_path = code_file_path(project)
         if code_path.exists():
-            result["code"] = code_path.read_text(encoding="utf-8")
+            result["code"] = redact_generated_code(code_path.read_text(encoding="utf-8"))
         else:
             result["code"] = None
 
@@ -1493,6 +1578,11 @@ class WorkflowRunSubmitView(APIView):
         script_path = code_file_path(project)
         code = script_path.read_text() if script_path.exists() else ""
 
+        secrets_or_error = _prepare_runtime_secrets(request, project)
+        if isinstance(secrets_or_error, Response):
+            return secrets_or_error
+        runtime_secrets = secrets_or_error
+
         run = WorkflowRun.objects.create(
             workflow=project,
             user=request.user,
@@ -1509,6 +1599,7 @@ class WorkflowRunSubmitView(APIView):
                 code=code,
                 run_id=str(run.id),
                 resource_requests=resource_reqs,
+                runtime_secrets=runtime_secrets,
             )
             run.status = exec_result.status.value
             if exec_result.remote_job_id:
@@ -1563,9 +1654,9 @@ class WorkflowRunDetailView(APIView):
                 if exec_result.exit_code is not None:
                     run.exit_code = exec_result.exit_code
                 if exec_result.stdout:
-                    run.stdout = exec_result.stdout
+                    run.stdout = _redact_run_text(request.user, run.workflow, exec_result.stdout)
                 if exec_result.stderr:
-                    run.stderr = exec_result.stderr
+                    run.stderr = _redact_run_text(request.user, run.workflow, exec_result.stderr)
                 if exec_result.error:
                     run.error_message = exec_result.error
                 if exec_result.artifacts:

--- a/gui/workflow_backend/django-project/app/workflow/views.py
+++ b/gui/workflow_backend/django-project/app/workflow/views.py
@@ -38,6 +38,7 @@ from app.secrets.redaction import (
     secret_ref_id,
     secret_ref_name,
 )
+from app.secrets.sanitize import sanitize_node_data
 from app.secrets.inject import (
     MissingRuntimeSecrets,
     collect_secret_names_for_project,
@@ -251,7 +252,7 @@ class FlowNodeViewSet(viewsets.ModelViewSet):
     def create(self, request, *args, **kwargs):
         """Node creation (real-time saving + code generation)"""
         project_id = self.kwargs.get("workflow_id")
-        logger.info(f"Creating node in project {project_id} with data: {request.data}")
+        logger.info("Creating node in project %s", project_id)
 
         try:
             project = get_accessible_project(request, project_id, write=True)
@@ -310,6 +311,7 @@ class FlowNodeViewSet(viewsets.ModelViewSet):
                 existing_node.node_type = node_data.get("type", existing_node.node_type)
                 new_data = node_data.get("data", existing_node.data)
                 if isinstance(new_data, dict):
+                    new_data = sanitize_node_data(project.owner, dict(new_data))
                     for key in ("parameter_modifications", "has_parameter_modifications"):
                         if key in existing_node.data:
                             new_data[key] = existing_node.data[key]
@@ -358,9 +360,7 @@ class FlowNodeViewSet(viewsets.ModelViewSet):
         """Node updates (position changes, data changes, etc. + conditional code generation)"""
         project_id = self.kwargs.get("workflow_id")
         node_id = self.kwargs.get("node_id")
-        logger.info(
-            f"Updating node {node_id} in project {project_id} with data: {request.data}"
-        )
+        logger.info("Updating node %s in project %s", node_id, project_id)
 
         try:
             project = get_accessible_project(request, project_id, write=True)
@@ -1334,6 +1334,24 @@ class WorkflowCodeView(APIView):
             except Exception as e:
                 notebook_outputs = [{"error": str(e)}]
 
+        names = collect_secret_names_for_project(project)
+        from app.secrets.services import materialize_named_secrets
+
+        mapping = materialize_named_secrets(
+            request.user, names, actor=request.user, audit=False
+        )
+        values = mapping.values()
+        for item in notebook_outputs:
+            if not isinstance(item, dict):
+                continue
+            if "source_snippet" in item:
+                item["source_snippet"] = redact_with_values(item["source_snippet"], values)
+            outs = item.get("outputs")
+            if isinstance(outs, list):
+                item["outputs"] = [redact_with_values(o, values) for o in outs]
+            if "error" in item:
+                item["error"] = redact_with_values(item["error"], values)
+
         result["notebook_outputs"] = notebook_outputs
         return JsonResponse({"status": "success", **result})
 
@@ -1654,9 +1672,9 @@ class WorkflowRunDetailView(APIView):
                 if exec_result.exit_code is not None:
                     run.exit_code = exec_result.exit_code
                 if exec_result.stdout:
-                    run.stdout = _redact_run_text(request.user, run.workflow, exec_result.stdout)
+                    run.stdout = _redact_run_text(run.user, run.workflow, exec_result.stdout)
                 if exec_result.stderr:
-                    run.stderr = _redact_run_text(request.user, run.workflow, exec_result.stderr)
+                    run.stderr = _redact_run_text(run.user, run.workflow, exec_result.stderr)
                 if exec_result.error:
                     run.error_message = exec_result.error
                 if exec_result.artifacts:

--- a/gui/workflow_backend/django-project/codes/neuroworkflow/core/__init__.py
+++ b/gui/workflow_backend/django-project/codes/neuroworkflow/core/__init__.py
@@ -14,3 +14,4 @@ from neuroworkflow.core.schema import (
 from neuroworkflow.core.port import Port, InputPort, OutputPort
 from neuroworkflow.core.node import Node, ProcessStep
 from neuroworkflow.core.workflow import Workflow, WorkflowBuilder, Connection
+from neuroworkflow.core.secrets import SecretRef, SecretStr, resolve, MissingSecretError

--- a/gui/workflow_backend/django-project/codes/neuroworkflow/core/node.py
+++ b/gui/workflow_backend/django-project/codes/neuroworkflow/core/node.py
@@ -10,6 +10,7 @@ import inspect
 
 from neuroworkflow.core.schema import NodeDefinitionSchema, PortDefinition, ParameterDefinition, MethodDefinition
 from neuroworkflow.core.port import InputPort, OutputPort, PortType
+from neuroworkflow.core.secrets import MissingSecretError, SecretStr, is_secret_ref, resolve
 
 
 class ProcessStep:
@@ -65,12 +66,37 @@ class Node:
         
         # Auto-create ports from NODE_DEFINITION
         self._define_ports_from_definition()
+
+    @staticmethod
+    def _param_is_secret(param_def) -> bool:
+        if isinstance(param_def, ParameterDefinition):
+            return bool(param_def.secret)
+        if isinstance(param_def, dict):
+            return bool(param_def.get("secret"))
+        return False
+
+    def _store_secret_parameter(self, name: str, value) -> None:
+        try:
+            if is_secret_ref(value):
+                plaintext = resolve(value)
+            elif isinstance(value, SecretStr):
+                plaintext = value.get_secret()
+            elif value in (None, ""):
+                plaintext = ""
+            else:
+                plaintext = str(value)
+        except MissingSecretError:
+            raise
+        self._parameters[name] = SecretStr(plaintext)
     
     def _initialize_parameters(self) -> None:
         """Initialize parameters from NODE_DEFINITION schema."""
         for name, param_def in self.__class__.NODE_DEFINITION.parameters.items():
             if isinstance(param_def, ParameterDefinition):
-                self._parameters[name] = param_def.default_value
+                if param_def.secret:
+                    self._store_secret_parameter(name, param_def.default_value)
+                else:
+                    self._parameters[name] = param_def.default_value
                 
                 # Store optimization metadata if parameter is optimizable
                 if param_def.optimizable:
@@ -81,7 +107,9 @@ class Node:
                     }
             elif isinstance(param_def, dict):
                 # Handle dictionary format
-                if 'default_value' in param_def:
+                if self._param_is_secret(param_def):
+                    self._store_secret_parameter(name, param_def.get('default_value'))
+                elif 'default_value' in param_def:
                     self._parameters[name] = param_def['default_value']
                 
                 # Store optimization metadata if parameter is optimizable
@@ -398,6 +426,10 @@ class Node:
             if param_name in self._parameters:
                 # Get parameter definition
                 param_def = self.__class__.NODE_DEFINITION.parameters.get(param_name)
+
+                if self._param_is_secret(param_def):
+                    self._store_secret_parameter(param_name, value)
+                    continue
                 
                 # Check parameter constraints
                 if isinstance(param_def, ParameterDefinition) and param_def.constraints:

--- a/gui/workflow_backend/django-project/codes/neuroworkflow/core/schema.py
+++ b/gui/workflow_backend/django-project/codes/neuroworkflow/core/schema.py
@@ -107,6 +107,7 @@ class ParameterDefinition:
     metadata_sources: List[str] = field(default_factory=list)
     species_specific: bool = False
     suggested_values: List[Dict[str, Any]] = field(default_factory=list)
+    secret: bool = False
 
 
 @dataclass

--- a/gui/workflow_backend/django-project/codes/neuroworkflow/core/secrets.py
+++ b/gui/workflow_backend/django-project/codes/neuroworkflow/core/secrets.py
@@ -1,0 +1,128 @@
+"""Runtime secret references. Django-free — used by generated Jupyter/Slurm code.
+
+Generated workflows call ``load_runtime_secrets()`` (file or ``NW_SECRET_*`` env)
+then ``configure(password=SecretRef("ASPERA_PASSWORD"))``. Node code should
+``resolve()`` secret parameters before using them as credentials.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+SECRET_REF_KEY = "__nw_secret"
+_SECRETS_FILE_ENV = "NW_SECRETS_FILE"
+_SECRETS_ENV_PREFIX = "NW_SECRET_"
+
+_installed: dict[str, str] = {}
+
+
+class MissingSecretError(ValueError):
+    """A SecretRef could not be resolved from the runtime mapping."""
+
+
+@dataclass(frozen=True)
+class SecretRef:
+    name: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {SECRET_REF_KEY: {"id": "", "name": self.name}}
+
+
+class SecretStr:
+    """Holds a secret in memory; repr/str never echo the value."""
+
+    def __init__(self, value: str):
+        self._value = value if value is not None else ""
+
+    def get_secret(self) -> str:
+        return self._value
+
+    def __str__(self) -> str:
+        return "••••" if self._value else ""
+
+    def __repr__(self) -> str:
+        return "SecretStr(••••)" if self._value else "SecretStr('')"
+
+    def __bool__(self) -> bool:
+        return bool(self._value)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, SecretStr):
+            return self._value == other._value
+        return False
+
+
+def install_runtime_secrets(mapping: Mapping[str, str] | None) -> None:
+    global _installed
+    _installed = {str(k): str(v) for k, v in (mapping or {}).items() if k}
+
+
+def clear_runtime_secrets() -> None:
+    global _installed
+    _installed = {}
+
+
+def load_runtime_secrets() -> dict[str, str]:
+    """Load from ``NW_SECRETS_FILE`` JSON and/or ``NW_SECRET_<NAME>`` env vars."""
+    mapping: dict[str, str] = dict(_installed)
+    path = os.environ.get(_SECRETS_FILE_ENV, "").strip()
+    if path:
+        with open(path, encoding="utf-8") as handle:
+            data = json.load(handle)
+        if isinstance(data, dict):
+            mapping.update({str(k): str(v) for k, v in data.items()})
+    for key, value in os.environ.items():
+        if key.startswith(_SECRETS_ENV_PREFIX) and key != _SECRETS_FILE_ENV:
+            name = key[len(_SECRETS_ENV_PREFIX) :]
+            if name:
+                mapping[name] = value
+    install_runtime_secrets(mapping)
+    return dict(_installed)
+
+
+def is_secret_ref(value: Any) -> bool:
+    if isinstance(value, SecretRef):
+        return True
+    return isinstance(value, dict) and SECRET_REF_KEY in value
+
+
+def secret_ref_name(value: Any) -> str | None:
+    if isinstance(value, SecretRef):
+        return value.name
+    if isinstance(value, dict) and SECRET_REF_KEY in value:
+        inner = value.get(SECRET_REF_KEY) or {}
+        if isinstance(inner, dict):
+            return inner.get("name") or None
+    return None
+
+
+def resolve(value: Any, *, required_name: str | None = None) -> Any:
+    """Return the plaintext for a SecretRef/dict ref, or passthrough."""
+    if isinstance(value, SecretStr):
+        return value.get_secret()
+    if not is_secret_ref(value):
+        return value
+    name = secret_ref_name(value) or required_name
+    if not name:
+        raise MissingSecretError("Secret reference is missing a name")
+    if name not in _installed:
+        load_runtime_secrets()
+    if name not in _installed:
+        raise MissingSecretError(f"Secret '{name}' is not available in this run")
+    return _installed[name]
+
+
+def wrap_resolved(value: Any, *, secret: bool) -> Any:
+    if not secret:
+        return value
+    if isinstance(value, SecretStr):
+        return value
+    plaintext = resolve(value) if is_secret_ref(value) else (value if isinstance(value, str) else "")
+    if is_secret_ref(value) or (isinstance(value, str) and value):
+        if is_secret_ref(value):
+            plaintext = resolve(value)
+        return SecretStr(str(plaintext or ""))
+    return SecretStr("")

--- a/gui/workflow_backend/django-project/codes/nodes/io/AsperaSharesLoaderNode.py
+++ b/gui/workflow_backend/django-project/codes/nodes/io/AsperaSharesLoaderNode.py
@@ -1,0 +1,148 @@
+"""Load files from an IBM Aspera Shares source.
+
+Passwords are vault SecretRefs (secret=True). At runtime the node writes a
+mode-0600 YAML under TMPDIR (never under results/), runs the transfer, then
+overwrites and deletes the YAML. Operators may still set ASPERA_PASSWORD.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+from typing import Any
+
+from neuroworkflow.core.node import Node
+from neuroworkflow.core.port import PortType
+from neuroworkflow.core.schema import (
+    MethodDefinition,
+    NodeDefinitionSchema,
+    ParameterDefinition,
+    PortDefinition,
+)
+from neuroworkflow.core.secrets import resolve
+
+
+def _shred_file(path: str) -> None:
+    if not path or not os.path.isfile(path):
+        return
+    try:
+        size = os.path.getsize(path)
+        with open(path, "r+b") as handle:
+            handle.write(b"\0" * size)
+            handle.flush()
+            os.fsync(handle.fileno())
+    except OSError:
+        pass
+    try:
+        os.remove(path)
+    except OSError:
+        pass
+
+
+class AsperaSharesLoaderNode(Node):
+    NODE_DEFINITION = NodeDefinitionSchema(
+        type="aspera_shares_loader",
+        description="Download from IBM Aspera Shares using a vault password reference",
+        stage="io",
+        tool="Aspera",
+        parameters={
+            "url": ParameterDefinition(
+                default_value="",
+                description="Aspera Shares base URL",
+            ),
+            "username": ParameterDefinition(
+                default_value="",
+                description="Aspera username (not secret)",
+            ),
+            "password": ParameterDefinition(
+                default_value="",
+                description="Vault secret for the Aspera password",
+                secret=True,
+            ),
+            "remote_path": ParameterDefinition(
+                default_value="",
+                description="Remote path to download",
+            ),
+            "local_path": ParameterDefinition(
+                default_value=".",
+                description="Local destination directory",
+            ),
+            "config_path": ParameterDefinition(
+                default_value="",
+                description="Optional existing Aspera YAML (overrides username/password)",
+            ),
+        },
+        outputs={
+            "local_path": PortDefinition(
+                type=PortType.STR,
+                description="Local path of the downloaded files",
+            )
+        },
+        methods={
+            "download": MethodDefinition(
+                description="Download via ascp/aspera using a shredded temp YAML",
+                inputs=[],
+                outputs=["local_path"],
+            )
+        },
+    )
+
+    def __init__(self, name: str):
+        super().__init__(name)
+        self._define_process_steps()
+
+    def _define_process_steps(self) -> None:
+        self.add_process_step("download", self.download, method_key="download")
+
+    def _password(self) -> str:
+        raw = self._parameters.get("password")
+        value = resolve(raw)
+        if value:
+            return str(value)
+        return os.environ.get("ASPERA_PASSWORD", "")
+
+    def _write_temp_yaml(self, username: str, password: str, url: str) -> str:
+        tmpdir = os.environ.get("TMPDIR") or tempfile.gettempdir()
+        fd, path = tempfile.mkstemp(prefix="nw-aspera-", suffix=".yml", dir=tmpdir)
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(f"user: {username}\n")
+            handle.write("password: " + password.replace("\n", "") + "\n")
+            handle.write(f"url: {url}\n")
+        return path
+
+    def _aspera_cmd(self, config_path: str, remote_path: str, local_path: str) -> list[str]:
+        aspera = shutil.which("aspera")
+        ascp = shutil.which("ascp")
+        if aspera:
+            return [aspera, "shares", "download", "--config", config_path, remote_path, local_path]
+        if ascp:
+            return [ascp, "-QT", remote_path, local_path]
+        raise FileNotFoundError("Neither aspera nor ascp is on PATH")
+
+    def download(self) -> dict[str, Any]:
+        url = str(self._parameters.get("url") or "")
+        username = str(self._parameters.get("username") or "")
+        remote_path = str(self._parameters.get("remote_path") or "")
+        local_path = str(self._parameters.get("local_path") or ".")
+        config_path = str(self._parameters.get("config_path") or "").strip()
+        owned_yaml = ""
+        password = self._password()
+        if not config_path:
+            if not password:
+                raise ValueError(
+                    "Aspera password is missing. Bind a vault secret named in Settings → Secrets "
+                    "or set ASPERA_PASSWORD."
+                )
+            owned_yaml = self._write_temp_yaml(username, password, url)
+            config_path = owned_yaml
+        try:
+            cmd = self._aspera_cmd(config_path, remote_path, local_path)
+            subprocess.run(cmd, check=True, capture_output=True, text=True)
+        finally:
+            if owned_yaml:
+                _shred_file(owned_yaml)
+        self._output_ports["local_path"].value = local_path
+        return {"local_path": local_path}

--- a/gui/workflow_backend/django-project/codes/nodes/io/AsperaSharesLoaderNode.py
+++ b/gui/workflow_backend/django-project/codes/nodes/io/AsperaSharesLoaderNode.py
@@ -140,7 +140,12 @@ class AsperaSharesLoaderNode(Node):
             config_path = owned_yaml
         try:
             cmd = self._aspera_cmd(config_path, remote_path, local_path)
-            subprocess.run(cmd, check=True, capture_output=True, text=True)
+            env = os.environ.copy()
+            aspera = shutil.which("aspera")
+            ascp = shutil.which("ascp")
+            if not aspera and ascp and cmd and cmd[0] == ascp:
+                env["ASPERA_PASSWORD"] = password
+            subprocess.run(cmd, check=True, capture_output=True, text=True, env=env)
         finally:
             if owned_yaml:
                 _shred_file(owned_yaml)

--- a/gui/workflow_backend/django-project/config/settings.py
+++ b/gui/workflow_backend/django-project/config/settings.py
@@ -1,4 +1,5 @@
 import os
+import sys
 from pathlib import Path
 from .config import (
     DB_HOST,
@@ -20,7 +21,9 @@ from .config import (
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
-SECRET_KEY = SECRET_KEY
+SECRET_KEY = SECRET_KEY or (
+    "pytest-django-secret-key" if "pytest" in sys.modules else SECRET_KEY
+)
 
 DEBUG = os.getenv("DJANGO_DEBUG", "false").lower() in ("1", "true", "yes")
 
@@ -61,6 +64,7 @@ LOCAL_APPS = [
     "app.workflow.apps.WorkflowConfig",
     "app.metadata.apps.MetadataConfig",
     "app.chat.apps.ChatConfig",
+    "app.secrets.apps.SecretsConfig",
 ]
 
 INSTALLED_APPS = DJANGO_APPS + THIRD_PARTY_APPS + LOCAL_APPS
@@ -94,6 +98,14 @@ DATABASES = {
         "PORT": DB_PORT,
     }
 }
+
+if "pytest" in sys.modules:
+    DATABASES = {
+        "default": {
+            "ENGINE": "django.db.backends.sqlite3",
+            "NAME": ":memory:",
+        }
+    }
 
 # ==============================================================================
 # AUTHENTICATION & AUTHORIZATION
@@ -285,10 +297,16 @@ DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
+    "filters": {
+        "secret_values": {
+            "()": "app.secrets.logging_filter.SecretValueFilter",
+        },
+    },
     "handlers": {
         "console": {
             "class": "logging.StreamHandler",
             "stream": "ext://sys.stdout",
+            "filters": ["secret_values"],
         },
     },
     'root': {

--- a/gui/workflow_backend/django-project/config/settings.py
+++ b/gui/workflow_backend/django-project/config/settings.py
@@ -21,8 +21,13 @@ from .config import (
 
 BASE_DIR = Path(__file__).resolve().parent.parent
 
+
+def _nw_testing() -> bool:
+    return bool(os.environ.get("NW_TESTING") or os.environ.get("PYTEST_CURRENT_TEST"))
+
+
 SECRET_KEY = SECRET_KEY or (
-    "pytest-django-secret-key" if "pytest" in sys.modules else SECRET_KEY
+    "pytest-django-secret-key" if _nw_testing() else SECRET_KEY
 )
 
 DEBUG = os.getenv("DJANGO_DEBUG", "false").lower() in ("1", "true", "yes")
@@ -99,7 +104,7 @@ DATABASES = {
     }
 }
 
-if "pytest" in sys.modules:
+if _nw_testing():
     DATABASES = {
         "default": {
             "ENGINE": "django.db.backends.sqlite3",

--- a/gui/workflow_backend/django-project/config/urls.py
+++ b/gui/workflow_backend/django-project/config/urls.py
@@ -29,6 +29,7 @@ urlpatterns = [
     path("api/workflow/", include("app.workflow.urls")),
     path("api/metadata/", include("app.metadata.urls")),
     path("api/chat/", include("app.chat.urls")),
+    path("api/secrets/", include("app.secrets.urls")),
     path("api/viewer/<uuid:project_id>/<path:subpath>", viewer_file),
 ]
 

--- a/gui/workflow_backend/django-project/tests/conftest.py
+++ b/gui/workflow_backend/django-project/tests/conftest.py
@@ -2,6 +2,7 @@ import os
 import sys
 from pathlib import Path
 
+os.environ.setdefault("NW_TESTING", "1")
 os.environ.setdefault("DJANGO_SECRET_KEY", "pytest-django-secret-key")
 os.environ.setdefault("DJANGO_DEBUG", "true")
 

--- a/gui/workflow_backend/django-project/tests/conftest.py
+++ b/gui/workflow_backend/django-project/tests/conftest.py
@@ -1,3 +1,14 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("DJANGO_SECRET_KEY", "pytest-django-secret-key")
+os.environ.setdefault("DJANGO_DEBUG", "true")
+
+_CODES = Path(__file__).resolve().parents[1] / "codes"
+if str(_CODES) not in sys.path:
+    sys.path.insert(0, str(_CODES))
+
 import pytest
 from django.contrib.auth import get_user_model
 from rest_framework.test import APIClient

--- a/gui/workflow_backend/django-project/tests/test_aspera_secret.py
+++ b/gui/workflow_backend/django-project/tests/test_aspera_secret.py
@@ -44,3 +44,42 @@ def test_aspera_temp_yaml_shredded(tmp_path, monkeypatch):
         assert "aspera-fixture-secret" not in str(run.call_args)
     finally:
         clear_runtime_secrets()
+
+
+def test_ascp_uses_env_not_argv(tmp_path, monkeypatch):
+    monkeypatch.setenv("TMPDIR", str(tmp_path))
+    if str(CODES) not in sys.path:
+        sys.path.insert(0, str(CODES))
+    install_runtime_secrets({"ASPERA_PASSWORD": "aspera-fixture-secret"})
+    try:
+        from nodes.io.AsperaSharesLoaderNode import AsperaSharesLoaderNode
+
+        node = AsperaSharesLoaderNode("aspera")
+        node.configure(
+            username="user",
+            password=SecretRef("ASPERA_PASSWORD"),
+            url="https://example.invalid",
+            remote_path="/remote",
+            local_path=str(tmp_path / "out"),
+        )
+
+        def _which(name):
+            if name == "aspera":
+                return None
+            if name == "ascp":
+                return "/usr/bin/ascp"
+            return None
+
+        with patch("nodes.io.AsperaSharesLoaderNode.shutil.which", side_effect=_which), patch(
+            "nodes.io.AsperaSharesLoaderNode.subprocess.run"
+        ) as run:
+            node.download()
+        args, kwargs = run.call_args
+        argv = args[0]
+        assert argv[0] == "/usr/bin/ascp"
+        assert "aspera-fixture-secret" not in str(argv)
+        assert kwargs["env"]["ASPERA_PASSWORD"] == "aspera-fixture-secret"
+        leftovers = list(tmp_path.glob("nw-aspera-*"))
+        assert leftovers == []
+    finally:
+        clear_runtime_secrets()

--- a/gui/workflow_backend/django-project/tests/test_aspera_secret.py
+++ b/gui/workflow_backend/django-project/tests/test_aspera_secret.py
@@ -1,0 +1,46 @@
+"""Aspera temp YAML is shredded; schema marks password as secret."""
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+from app.box.services.python_analyzer import PythonNodeAnalyzer
+from neuroworkflow.core.secrets import SecretRef, clear_runtime_secrets, install_runtime_secrets
+
+CODES = Path(__file__).resolve().parents[1] / "codes"
+ASPERA_SRC = CODES / "nodes" / "io" / "AsperaSharesLoaderNode.py"
+
+
+def test_analyzer_sees_secret_password(tmp_path):
+    analyzer = PythonNodeAnalyzer(db_path=str(tmp_path / "nodes.db"))
+    nodes = analyzer.analyze_file_content(ASPERA_SRC.read_text(encoding="utf-8"))
+    params = nodes[0]["parameters"]
+    assert params["password"].get("secret") is True
+    assert params["username"].get("secret") in (None, False)
+
+
+def test_aspera_temp_yaml_shredded(tmp_path, monkeypatch):
+    monkeypatch.setenv("TMPDIR", str(tmp_path))
+    if str(CODES) not in sys.path:
+        sys.path.insert(0, str(CODES))
+    install_runtime_secrets({"ASPERA_PASSWORD": "aspera-fixture-secret"})
+    try:
+        from nodes.io.AsperaSharesLoaderNode import AsperaSharesLoaderNode
+
+        node = AsperaSharesLoaderNode("aspera")
+        node.configure(
+            username="user",
+            password=SecretRef("ASPERA_PASSWORD"),
+            url="https://example.invalid",
+            remote_path="/remote",
+            local_path=str(tmp_path / "out"),
+        )
+        with patch("nodes.io.AsperaSharesLoaderNode.shutil.which", return_value="/bin/true"), patch(
+            "nodes.io.AsperaSharesLoaderNode.subprocess.run"
+        ) as run:
+            node.download()
+        leftovers = list(tmp_path.glob("nw-aspera-*"))
+        assert leftovers == []
+        assert "aspera-fixture-secret" not in str(run.call_args)
+    finally:
+        clear_runtime_secrets()

--- a/gui/workflow_backend/django-project/tests/test_customdb_vault.py
+++ b/gui/workflow_backend/django-project/tests/test_customdb_vault.py
@@ -29,3 +29,55 @@ def test_customdb_vault_ref_not_in_get(auth_client, user_alice):
     assert body.get("api_key") in (None, "", "••••") or "api_key" not in body or body["api_key"] is None
     assert body["config"]["api_key_secret"]["__nw_secret"]["name"] == "DB_API_KEY"
     assert db.resolve_api_key() == FIXTURE_KEY
+
+
+def test_to_adapter_config_does_not_keep_raw_config_key(user_alice):
+    db = CustomDatabase.objects.create(
+        name="demo2",
+        base_url="https://example.invalid",
+        created_by=user_alice,
+        config={"api_key": "raw-config-key", "timeout": 5},
+    )
+    db.set_api_key(FIXTURE_KEY)
+    db.save()
+    cfg = db.to_adapter_config()
+    assert cfg["api_key"] == FIXTURE_KEY
+    assert "raw-config-key" not in str(cfg)
+
+
+def test_suggestions_queryset_excludes_other_owners(user_alice, user_bob):
+    from app.metadata.views import _custom_databases_for_suggestions
+
+    CustomDatabase.objects.create(
+        name="bob-db",
+        base_url="https://bob.example.invalid",
+        created_by=user_bob,
+        is_active=True,
+        is_verified=True,
+    )
+    alice_db = CustomDatabase.objects.create(
+        name="alice-db",
+        base_url="https://alice.example.invalid",
+        created_by=user_alice,
+        is_active=True,
+        is_verified=True,
+    )
+    qs = _custom_databases_for_suggestions(user_alice)
+    assert list(qs) == [alice_db]
+
+
+def test_get_drops_config_api_key(auth_client, user_alice):
+    db = CustomDatabase.objects.create(
+        name="leaky",
+        base_url="https://example.invalid",
+        created_by=user_alice,
+        config={"api_key": FIXTURE_KEY, "timeout": 1},
+    )
+    db.set_api_key(FIXTURE_KEY)
+    db.save()
+    client = auth_client(user_alice)
+    resp = client.get(f"/api/metadata/custom-databases/{db.id}/")
+    assert resp.status_code == 200
+    dumped = str(resp.json())
+    assert FIXTURE_KEY not in dumped
+    assert "api_key" not in (resp.json().get("config") or {})

--- a/gui/workflow_backend/django-project/tests/test_customdb_vault.py
+++ b/gui/workflow_backend/django-project/tests/test_customdb_vault.py
@@ -1,0 +1,31 @@
+"""CustomDatabase vault ref is resolved server-side and never appears as plaintext on GET."""
+
+import pytest
+from django.urls import reverse
+
+from app.metadata.models import CustomDatabase
+from app.secrets.redaction import make_secret_ref
+from app.secrets.services import create_user_secret
+
+pytestmark = pytest.mark.django_db
+
+FIXTURE_KEY = "custom-db-fixture-key"
+
+
+def test_customdb_vault_ref_not_in_get(auth_client, user_alice):
+    secret = create_user_secret(user_alice, name="DB_API_KEY", value=FIXTURE_KEY)
+    db = CustomDatabase.objects.create(
+        name="demo",
+        base_url="https://example.invalid",
+        created_by=user_alice,
+        config={"api_key_secret": make_secret_ref(secret.id, secret.name)},
+    )
+    client = auth_client(user_alice)
+    resp = client.get(f"/api/metadata/custom-databases/{db.id}/")
+    assert resp.status_code == 200
+    body = resp.json()
+    dumped = str(body)
+    assert FIXTURE_KEY not in dumped
+    assert body.get("api_key") in (None, "", "••••") or "api_key" not in body or body["api_key"] is None
+    assert body["config"]["api_key_secret"]["__nw_secret"]["name"] == "DB_API_KEY"
+    assert db.resolve_api_key() == FIXTURE_KEY

--- a/gui/workflow_backend/django-project/tests/test_encrypt_api_key_migration.py
+++ b/gui/workflow_backend/django-project/tests/test_encrypt_api_key_migration.py
@@ -1,0 +1,68 @@
+"""0002 encrypt helper encrypts then drops plaintext api_key."""
+
+import importlib.util
+from pathlib import Path
+
+from app.secrets.crypto import EncryptedBlob, aad_for_custom_db, envelope_decrypt
+from app.secrets.keys import get_kek
+
+PLAIN = "plain-legacy-key"
+_MIGRATION = (
+    Path(__file__).resolve().parents[1]
+    / "app"
+    / "metadata"
+    / "migrations"
+    / "0002_encrypt_api_key.py"
+)
+
+
+def _load_encrypt_helper():
+    spec = importlib.util.spec_from_file_location("nw_encrypt_api_key_migration", _MIGRATION)
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module.encrypt_existing_api_keys
+
+
+class _Row:
+    def __init__(self):
+        self.id = "11111111-1111-1111-1111-111111111111"
+        self.created_by_id = 1
+        self.api_key = PLAIN
+        self.api_key_wrapped_dek = None
+        self.api_key_ciphertext = None
+        self.api_key_nonce = None
+        self.api_key_key_version = 1
+        self.saved_fields = None
+
+    def save(self, update_fields=None):
+        self.saved_fields = update_fields
+
+
+def test_encrypt_existing_api_keys_drops_plaintext():
+    encrypt_existing_api_keys = _load_encrypt_helper()
+    row = _Row()
+
+    class _Manager:
+        def all(self):
+            return [row]
+
+    class _Model:
+        objects = _Manager()
+
+    class _Apps:
+        def get_model(self, app, name):
+            assert app == "metadata"
+            return _Model
+
+    encrypt_existing_api_keys(_Apps(), None)
+    assert row.api_key is None
+    assert row.api_key_ciphertext
+    blob = EncryptedBlob(
+        wrapped_dek=bytes(row.api_key_wrapped_dek),
+        ciphertext=bytes(row.api_key_ciphertext),
+        nonce=bytes(row.api_key_nonce),
+        key_version=row.api_key_key_version,
+    )
+    assert envelope_decrypt(blob, get_kek(), aad_for_custom_db(1, str(row.id))) == PLAIN.encode()
+    assert "api_key" in (row.saved_fields or [])

--- a/gui/workflow_backend/django-project/tests/test_flow_secret_writes.py
+++ b/gui/workflow_backend/django-project/tests/test_flow_secret_writes.py
@@ -1,0 +1,60 @@
+"""Flow PUT and node writes reject plaintext secret parameters."""
+
+import pytest
+from django.urls import reverse
+
+from app.secrets.redaction import make_secret_ref
+from app.secrets.services import create_user_secret
+from app.workflow.models import FlowNode, FlowProject
+
+pytestmark = pytest.mark.django_db
+
+PLAIN = "hunter2"
+
+
+def _aspera_node(password_value):
+    return {
+        "id": "aspera-node-1",
+        "position": {"x": 0, "y": 0},
+        "type": "default",
+        "data": {
+            "label": "Aspera",
+            "nodeType": "io",
+            "schema": {
+                "parameters": {
+                    "password": {
+                        "secret": True,
+                        "default_value": password_value,
+                    }
+                }
+            },
+        },
+    }
+
+
+def test_flow_put_rejects_plaintext_secret_param(auth_client, user_alice):
+    project = FlowProject.objects.create(name="secrets-flow", owner=user_alice)
+    client = auth_client(user_alice)
+    url = reverse("workflow:workflow-flow", kwargs={"workflow_id": project.id})
+    resp = client.put(url, {"nodes": [_aspera_node(PLAIN)], "edges": []}, format="json")
+    assert resp.status_code == 400
+    assert PLAIN not in str(FlowNode.objects.filter(project=project).values_list("data", flat=True))
+    dumped = "".join(str(n.data) for n in FlowNode.objects.filter(project=project))
+    assert PLAIN not in dumped
+
+
+def test_flow_put_accepts_owned_secret_ref(auth_client, user_alice):
+    project = FlowProject.objects.create(name="secrets-flow-ok", owner=user_alice)
+    secret = create_user_secret(user_alice, name="ASPERA_PASSWORD", value=PLAIN)
+    client = auth_client(user_alice)
+    url = reverse("workflow:workflow-flow", kwargs={"workflow_id": project.id})
+    resp = client.put(
+        url,
+        {"nodes": [_aspera_node(make_secret_ref(secret.id, secret.name))], "edges": []},
+        format="json",
+    )
+    assert resp.status_code == 200
+    node = FlowNode.objects.get(project=project)
+    value = node.data["schema"]["parameters"]["password"]["default_value"]
+    assert value["__nw_secret"]["name"] == "ASPERA_PASSWORD"
+    assert PLAIN not in str(node.data)

--- a/gui/workflow_backend/django-project/tests/test_secret_crypto.py
+++ b/gui/workflow_backend/django-project/tests/test_secret_crypto.py
@@ -37,6 +37,20 @@ def test_wrong_kek_fails():
         envelope_decrypt(blob, other, aad)
 
 
+def test_decrypt_blob_uses_previous_master(monkeypatch):
+    from app.secrets.crypto import envelope_encrypt
+    from app.secrets.keys import decrypt_blob, get_kek
+
+    monkeypatch.setenv("SECRETS_MASTER_KEY", "old-master-key-material")
+    aad = aad_for_user_secret(7, "sid-rot")
+    blob = envelope_encrypt(b"fixture-secret", get_kek(), aad)
+    monkeypatch.setenv("SECRETS_MASTER_KEY", "new-master-key-material")
+    monkeypatch.setenv("SECRETS_MASTER_KEY_PREVIOUS", "old-master-key-material")
+    assert decrypt_blob(blob, aad) == b"fixture-secret"
+    with pytest.raises(CryptoError):
+        decrypt_blob(blob, aad_for_user_secret(8, "sid-rot"))
+
+
 def test_truncated_wrapped_dek_fails():
     kek = derive_kek(b"test-master-key", 1)
     aad = b"aad"

--- a/gui/workflow_backend/django-project/tests/test_secret_crypto.py
+++ b/gui/workflow_backend/django-project/tests/test_secret_crypto.py
@@ -1,0 +1,51 @@
+"""Envelope encryption tests — no Django DB required for the crypto module."""
+
+import pytest
+
+from app.secrets.crypto import (
+    CryptoError,
+    EncryptedBlob,
+    aad_for_user_secret,
+    derive_kek,
+    envelope_decrypt,
+    envelope_encrypt,
+)
+
+
+def test_round_trip():
+    kek = derive_kek(b"test-master-key", 1)
+    aad = aad_for_user_secret(7, "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
+    blob = envelope_encrypt(b"super-secret", kek, aad)
+    assert envelope_decrypt(blob, kek, aad) == b"super-secret"
+    assert blob.nonce != blob.wrapped_dek[:12]
+
+
+def test_aad_tamper_fails():
+    kek = derive_kek(b"test-master-key", 1)
+    aad = aad_for_user_secret(7, "sid-1")
+    blob = envelope_encrypt(b"super-secret", kek, aad)
+    with pytest.raises(CryptoError):
+        envelope_decrypt(blob, kek, aad_for_user_secret(8, "sid-1"))
+
+
+def test_wrong_kek_fails():
+    kek = derive_kek(b"test-master-key", 1)
+    other = derive_kek(b"other-master-key", 1)
+    aad = aad_for_user_secret(1, "sid")
+    blob = envelope_encrypt(b"x", kek, aad)
+    with pytest.raises(CryptoError):
+        envelope_decrypt(blob, other, aad)
+
+
+def test_truncated_wrapped_dek_fails():
+    kek = derive_kek(b"test-master-key", 1)
+    aad = b"aad"
+    blob = envelope_encrypt(b"x", kek, aad)
+    bad = EncryptedBlob(
+        wrapped_dek=blob.wrapped_dek[:4],
+        ciphertext=blob.ciphertext,
+        nonce=blob.nonce,
+        key_version=blob.key_version,
+    )
+    with pytest.raises(CryptoError):
+        envelope_decrypt(bad, kek, aad)

--- a/gui/workflow_backend/django-project/tests/test_secret_inject.py
+++ b/gui/workflow_backend/django-project/tests/test_secret_inject.py
@@ -1,0 +1,102 @@
+"""Codegen SecretRef emission, context blocklist, jupyter wrap, slurm wrapper shred."""
+
+from app.secrets.inject import (
+    MissingRuntimeSecrets,
+    collect_secret_names_from_data,
+    redact_with_values,
+    wrap_jupyter_code,
+)
+from app.secrets.redaction import WorkflowContextBlockedError, assert_context_has_no_secrets
+from app.workflow.code_generation_service import CodeGenerationService
+from app.workflow.execution.remote_slurm_executor import _TEMPLATE_PATH
+
+
+FIXTURE_VALUE = "super-secret-fixture-value"
+
+
+def test_configure_emits_secret_ref_not_value():
+    service = CodeGenerationService()
+    node_data = {
+        "schema": {
+            "parameters": {
+                "password": {
+                    "secret": True,
+                    "default_value": {"__nw_secret": {"id": "abc", "name": "FOO"}},
+                },
+                "n": {"default_value": 1},
+            }
+        },
+        "parameter_modifications": {
+            "password": {"is_modified": True},
+            "n": {
+                "is_modified": True,
+                "field_modifications": {"default_value_original": 0},
+            },
+        },
+    }
+    # n is modified 0 -> 1
+    node_data["schema"]["parameters"]["n"]["default_value"] = 2
+    block = service._generate_generic_configure_block("X", node_data)
+    assert "SecretRef(" in block
+    assert "FOO" in block
+    assert "password=" in block
+    assert FIXTURE_VALUE not in block
+    assert "super-secret" not in block
+
+
+def test_literal_secret_value_rejected():
+    service = CodeGenerationService()
+    node_data = {
+        "schema": {
+            "parameters": {
+                "password": {"secret": True, "default_value": FIXTURE_VALUE},
+            }
+        },
+        "parameter_modifications": {"password": {"is_modified": True}},
+    }
+    try:
+        service._generate_generic_configure_block("X", node_data)
+        assert False, "expected ValueError"
+    except ValueError as exc:
+        assert "vault" in str(exc).lower()
+        assert FIXTURE_VALUE not in str(exc)
+
+
+def test_context_blocklist():
+    try:
+        assert_context_has_no_secrets({"aspera_pass": "x", "species": "mouse"})
+        assert False, "expected block"
+    except WorkflowContextBlockedError as exc:
+        assert "aspera_pass" in exc.keys
+
+
+def test_wrap_jupyter_does_not_write_project_paths():
+    wrapped = wrap_jupyter_code("print(1)\n", {"FOO": FIXTURE_VALUE})
+    assert "install_runtime_secrets" in wrapped
+    assert "codes/projects" not in wrapped
+    assert FIXTURE_VALUE in wrapped  # in-process wrap only
+
+
+def test_redact_with_values():
+    assert FIXTURE_VALUE not in redact_with_values(f"pw={FIXTURE_VALUE}", [FIXTURE_VALUE])
+
+
+def test_collect_secret_names():
+    names = collect_secret_names_from_data(
+        {"schema": {"parameters": {"password": {"default_value": {"__nw_secret": {"name": "FOO"}}}}}}
+    )
+    assert names == ["FOO"]
+
+
+def test_slurm_wrapper_shreds_secrets_file():
+    text = _TEMPLATE_PATH.read_text()
+    assert "NW_SECRETS_FILE" in text
+    assert "shred" in text
+    assert ".nw-secrets" in text
+    assert "trap" in text
+
+
+def test_missing_runtime_secrets_names_ref():
+    err = MissingRuntimeSecrets(["ASPERA_PASSWORD"])
+    assert "ASPERA_PASSWORD" in str(err)
+    assert "s3cret" not in str(err)

--- a/gui/workflow_backend/django-project/tests/test_secret_inject.py
+++ b/gui/workflow_backend/django-project/tests/test_secret_inject.py
@@ -1,5 +1,7 @@
 """Codegen SecretRef emission, context blocklist, jupyter wrap, slurm wrapper shred."""
 
+import pytest
+
 from app.secrets.inject import (
     MissingRuntimeSecrets,
     collect_secret_names_from_data,
@@ -100,3 +102,118 @@ def test_missing_runtime_secrets_names_ref():
     err = MissingRuntimeSecrets(["ASPERA_PASSWORD"])
     assert "ASPERA_PASSWORD" in str(err)
     assert "s3cret" not in str(err)
+
+
+@pytest.mark.django_db
+def test_redact_run_text_uses_given_owner(user_alice, user_bob):
+    from app.secrets.services import create_user_secret
+    from app.workflow.models import FlowNode, FlowProject
+    from app.workflow.views import _redact_run_text
+
+    project = FlowProject.objects.create(name="run-redact", owner=user_alice)
+    FlowNode.objects.create(
+        id="n1",
+        project=project,
+        position_x=0,
+        position_y=0,
+        node_type="default",
+        data={
+            "schema": {
+                "parameters": {
+                    "password": {
+                        "secret": True,
+                        "default_value": {"__nw_secret": {"name": "FOO"}},
+                    }
+                }
+            }
+        },
+    )
+    create_user_secret(user_alice, name="FOO", value=FIXTURE_VALUE)
+    create_user_secret(user_bob, name="FOO", value="bob-other-secret")
+    assert FIXTURE_VALUE not in _redact_run_text(user_alice, project, f"out {FIXTURE_VALUE}")
+    assert FIXTURE_VALUE in _redact_run_text(user_bob, project, f"out {FIXTURE_VALUE}")
+
+
+@pytest.mark.django_db
+def test_code_view_redacts_notebook_outputs(auth_client, user_alice, tmp_path, monkeypatch):
+    import json as _json
+
+    from django.urls import reverse
+
+    from app.secrets.services import create_user_secret
+    from app.workflow.models import FlowNode, FlowProject
+
+    project = FlowProject.objects.create(name="nb-redact", owner=user_alice)
+    FlowNode.objects.create(
+        id="n1",
+        project=project,
+        position_x=0,
+        position_y=0,
+        node_type="default",
+        data={
+            "schema": {
+                "parameters": {
+                    "password": {
+                        "secret": True,
+                        "default_value": {"__nw_secret": {"name": "FOO"}},
+                    }
+                }
+            }
+        },
+    )
+    create_user_secret(user_alice, name="FOO", value=FIXTURE_VALUE)
+    nb_path = tmp_path / "workflow.ipynb"
+    nb_path.write_text(
+        _json.dumps(
+            {
+                "cells": [
+                    {
+                        "cell_type": "code",
+                        "source": ["print(1)"],
+                        "outputs": [
+                            {"output_type": "stream", "text": f"{FIXTURE_VALUE}\n"}
+                        ],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr("app.workflow.views.existing_project_dir", lambda project: tmp_path)
+    monkeypatch.setattr("app.workflow.views.code_file_path", lambda project, create=False: tmp_path / "missing.py")
+    monkeypatch.setattr("app.workflow.views.notebook_file_path", lambda project, create=False: nb_path)
+    client = auth_client(user_alice)
+    resp = client.get(reverse("workflow:workflow-code", kwargs={"workflow_id": project.id}))
+    assert resp.status_code == 200
+    body = resp.json()
+    dumped = _json.dumps(body)
+    assert FIXTURE_VALUE not in dumped
+    assert body["notebook_outputs"][0]["outputs"] == ["••••"]
+
+
+def test_jupyter_clears_secrets_if_kernel_create_fails(monkeypatch):
+    import asyncio
+    from unittest.mock import AsyncMock
+
+    monkeypatch.setattr(
+        "app.workflow.jupyter_execution_service.JUPYTERHUB_API_TOKEN", "test-token"
+    )
+    from app.secrets.logging_filter import _secret_values, clear_secret_values
+    from app.workflow.jupyter_execution_service import JupyterExecutionService
+
+    clear_secret_values()
+    svc = JupyterExecutionService()
+    svc._ensure_server_running = AsyncMock()
+    svc._create_kernel = AsyncMock(side_effect=RuntimeError("kernel failed"))
+    svc._delete_kernel = AsyncMock()
+
+    async def consume():
+        try:
+            async for _ in svc.execute_code("print(1)", runtime_secrets={"FOO": FIXTURE_VALUE}):
+                pass
+        except RuntimeError:
+            pass
+        assert _secret_values.get() == ()
+
+    asyncio.run(consume())
+    svc._delete_kernel.assert_not_called()

--- a/gui/workflow_backend/django-project/tests/test_secrets_api.py
+++ b/gui/workflow_backend/django-project/tests/test_secrets_api.py
@@ -1,0 +1,62 @@
+"""Owner-only /api/secrets/ — values never appear in responses."""
+
+import pytest
+from django.urls import reverse
+
+from app.secrets.models import SecretAuditEvent, UserSecret
+from app.secrets.services import create_user_secret
+
+pytestmark = pytest.mark.django_db
+
+
+def test_create_list_never_returns_value(auth_client, user_alice):
+    client = auth_client(user_alice)
+    url = reverse("secrets:secret-list-create")
+    resp = client.post(
+        url,
+        {"name": "ASPERA_PASSWORD", "value": "plain-secret-value", "description": "aspera"},
+        format="json",
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["name"] == "ASPERA_PASSWORD"
+    assert body["is_set"] is True
+    assert "value" not in body or body.get("value") in (None, "", "••••")
+    dumped = str(body)
+    assert "plain-secret-value" not in dumped
+
+    listed = client.get(url)
+    assert listed.status_code == 200
+    assert "plain-secret-value" not in listed.content.decode()
+    assert listed.json()[0]["name"] == "ASPERA_PASSWORD"
+
+    audit = SecretAuditEvent.objects.get(secret_name="ASPERA_PASSWORD", action="create")
+    assert "plain-secret-value" not in str(audit.__dict__)
+
+
+def test_owner_isolation(auth_client, user_alice, user_bob):
+    secret = create_user_secret(user_alice, name="OPENAI_API_KEY", value="sk-alice")
+    bob = auth_client(user_bob)
+    detail = reverse("secrets:secret-detail", kwargs={"secret_id": secret.id})
+    assert bob.get(detail).status_code == 404
+    assert bob.patch(detail, {"value": "sk-bob"}, format="json").status_code == 404
+    assert bob.delete(detail).status_code == 404
+    listed = bob.get(reverse("secrets:secret-list-create"))
+    assert listed.json() == []
+
+
+def test_alice_can_rotate_and_revoke(auth_client, user_alice):
+    client = auth_client(user_alice)
+    created = client.post(
+        reverse("secrets:secret-list-create"),
+        {"name": "DB_PASSWORD", "value": "first"},
+        format="json",
+    ).json()
+    detail = reverse("secrets:secret-detail", kwargs={"secret_id": created["id"]})
+    rotated = client.patch(detail, {"value": "second"}, format="json")
+    assert rotated.status_code == 200
+    assert "second" not in rotated.content.decode()
+    deleted = client.delete(detail)
+    assert deleted.status_code == 204
+    assert UserSecret.objects.get(id=created["id"]).revoked_at is not None
+    assert client.get(detail).status_code == 404

--- a/gui/workflow_backend/django-project/tests/test_secrets_api.py
+++ b/gui/workflow_backend/django-project/tests/test_secrets_api.py
@@ -60,3 +60,18 @@ def test_alice_can_rotate_and_revoke(auth_client, user_alice):
     assert deleted.status_code == 204
     assert UserSecret.objects.get(id=created["id"]).revoked_at is not None
     assert client.get(detail).status_code == 404
+
+
+def test_recreate_same_name_after_revoke(auth_client, user_alice):
+    client = auth_client(user_alice)
+    url = reverse("secrets:secret-list-create")
+    first = client.post(url, {"name": "ASPERA_PASSWORD", "value": "first"}, format="json")
+    assert first.status_code == 201
+    detail = reverse("secrets:secret-detail", kwargs={"secret_id": first.json()["id"]})
+    assert client.delete(detail).status_code == 204
+    second = client.post(url, {"name": "ASPERA_PASSWORD", "value": "second"}, format="json")
+    assert second.status_code == 201
+    assert second.json()["name"] == "ASPERA_PASSWORD"
+    assert "second" not in second.content.decode()
+    dup = client.post(url, {"name": "ASPERA_PASSWORD", "value": "third"}, format="json")
+    assert dup.status_code == 400

--- a/gui/workflow_backend/django-project/tests/test_user_secret_model.py
+++ b/gui/workflow_backend/django-project/tests/test_user_secret_model.py
@@ -40,6 +40,31 @@ def test_empty_secret_rejected(user_alice):
         secret.set_plaintext("")
 
 
+def test_user_secret_decrypts_after_master_rotation(user_alice, monkeypatch):
+    from app.secrets.services import rewrap_owner_secrets, rotate_user_secret
+
+    monkeypatch.setenv("SECRETS_MASTER_KEY", "old-master-key-material")
+    secret = UserSecret(owner=user_alice, name="ROTATION_SECRET")
+    secret.set_plaintext("fixture-secret")
+    secret.save()
+    monkeypatch.setenv("SECRETS_MASTER_KEY", "new-master-key-material")
+    monkeypatch.setenv("SECRETS_MASTER_KEY_PREVIOUS", "old-master-key-material")
+    loaded = UserSecret.objects.get(pk=secret.pk)
+    assert loaded.decrypt_plaintext() == "fixture-secret"
+    rotate_user_secret(loaded, description="rewrapped")
+    monkeypatch.delenv("SECRETS_MASTER_KEY_PREVIOUS", raising=False)
+    assert UserSecret.objects.get(pk=secret.pk).decrypt_plaintext() == "fixture-secret"
+    monkeypatch.setenv("SECRETS_MASTER_KEY", "old-master-key-material")
+    secret2 = UserSecret(owner=user_alice, name="ROTATION_SECRET_2")
+    secret2.set_plaintext("second-secret")
+    secret2.save()
+    monkeypatch.setenv("SECRETS_MASTER_KEY", "new-master-key-material")
+    monkeypatch.setenv("SECRETS_MASTER_KEY_PREVIOUS", "old-master-key-material")
+    rewrap_owner_secrets(user_alice)
+    monkeypatch.delenv("SECRETS_MASTER_KEY_PREVIOUS", raising=False)
+    assert UserSecret.objects.get(pk=secret2.pk).decrypt_plaintext() == "second-secret"
+
+
 def test_custom_database_api_key_encrypted(user_alice):
     from app.metadata.models import CustomDatabase
 

--- a/gui/workflow_backend/django-project/tests/test_user_secret_model.py
+++ b/gui/workflow_backend/django-project/tests/test_user_secret_model.py
@@ -1,0 +1,57 @@
+"""UserSecret persist/decrypt round trip."""
+
+import pytest
+from django.core.exceptions import ValidationError
+
+from app.secrets.crypto import aad_for_user_secret, envelope_decrypt, EncryptedBlob
+from app.secrets.keys import get_kek
+from app.secrets.models import UserSecret
+
+pytestmark = pytest.mark.django_db
+
+
+def test_user_secret_round_trip(user_alice):
+    secret = UserSecret(owner=user_alice, name="ASPERA_PASSWORD", description="aspera")
+    secret.set_plaintext("not-a-real-password")
+    secret.save()
+    loaded = UserSecret.objects.get(pk=secret.pk)
+    assert loaded.decrypt_plaintext() == "not-a-real-password"
+    assert "not-a-real-password" not in str(bytes(loaded.ciphertext))
+
+
+def test_user_secret_aad_binds_owner(user_alice, user_bob):
+    secret = UserSecret(owner=user_alice, name="OPENAI_API_KEY")
+    secret.set_plaintext("sk-test")
+    secret.save()
+    swapped_aad = aad_for_user_secret(user_bob.id, str(secret.id))
+    blob = EncryptedBlob(
+        wrapped_dek=bytes(secret.wrapped_dek),
+        ciphertext=bytes(secret.ciphertext),
+        nonce=bytes(secret.nonce),
+        key_version=secret.key_version,
+    )
+    with pytest.raises(Exception):
+        envelope_decrypt(blob, get_kek(), swapped_aad)
+
+
+def test_empty_secret_rejected(user_alice):
+    secret = UserSecret(owner=user_alice, name="EMPTY_SECRET")
+    with pytest.raises(ValidationError):
+        secret.set_plaintext("")
+
+
+def test_custom_database_api_key_encrypted(user_alice):
+    from app.metadata.models import CustomDatabase
+
+    db = CustomDatabase.objects.create(
+        name="test-db",
+        base_url="https://example.com",
+        created_by=user_alice,
+    )
+    db.set_api_key("db-secret-key")
+    db.save()
+    loaded = CustomDatabase.objects.get(pk=db.pk)
+    assert loaded.get_api_key() == "db-secret-key"
+    field_names = {f.name for f in loaded._meta.local_fields}
+    assert "api_key" not in field_names
+    assert "api_key_ciphertext" in field_names

--- a/gui/workflow_backend/env.template
+++ b/gui/workflow_backend/env.template
@@ -28,6 +28,14 @@ KEYCLOAK_CLIENT_ID=neuroworkflow-app
 
 DJANGO_SECRET_KEY='django-insecure-ps=r$krar9a52wp$n6x#qu64j@l68@ajqtps2&^oxyf*fx09^x'
 
+# --- User secret store (AES-256-GCM envelope encryption) ---
+# Production (DJANGO_DEBUG=false) refuses to start if SECRETS_MASTER_KEY is unset.
+# Generate: python3 -c "import secrets; print(secrets.token_urlsafe(32))"
+# Do not commit a real key. Dev (DEBUG=true) derives a key from DJANGO_SECRET_KEY.
+# SECRETS_MASTER_KEY=
+# Previous key, decrypt-only, during rotation:
+# SECRETS_MASTER_KEY_PREVIOUS=
+
 PYTHONENV=/usr/bin/python3
 
 # --- Deployment / reverse proxy ---

--- a/gui/workflow_backend/pytest.ini
+++ b/gui/workflow_backend/pytest.ini
@@ -2,3 +2,4 @@
 DJANGO_SETTINGS_MODULE = config.settings
 python_files = tests.py test_*.py *_tests.py
 pythonpath = django-project
+addopts = --nomigrations

--- a/gui/workflow_frontend/src/components/WorkflowContextEditor.tsx
+++ b/gui/workflow_frontend/src/components/WorkflowContextEditor.tsx
@@ -13,6 +13,7 @@ import {
   useColorModeValue,
   VStack,
 } from '@chakra-ui/react';
+import { blockedContextKeys } from '../utils/secretRefs';
 
 interface WorkflowContextEditorProps {
   initialContext?: Record<string, any>;
@@ -172,6 +173,14 @@ export const WorkflowContextEditor = ({
     const parsed = safeParseJson(value);
     if (parsed === null) {
       setContextError('Workflow context must be valid JSON.');
+      onChange?.(null, value, false);
+      return;
+    }
+    const blocked = blockedContextKeys(parsed);
+    if (blocked.length > 0) {
+      setContextError(
+        `Do not put ${blocked.join(', ')} in workflow context. Store credentials in Settings → Secrets.`
+      );
       onChange?.(null, value, false);
       return;
     }

--- a/gui/workflow_frontend/src/components/tabs/TabManager.tsx
+++ b/gui/workflow_frontend/src/components/tabs/TabManager.tsx
@@ -9,6 +9,7 @@ import CreateFlowPj from '../../views/file/createView';
 import BoxUpload from '../../views/box/uploadView';
 import NotFoundView from '../../views/notFound/notFound';
 import CustomDatabaseManager from '../../views/home/components/CustomDatabaseManager';
+import SecretVaultPage from '../../views/home/components/SecretVaultPage';
 import UserProfileView from '../../views/user/userProfileView';
 import ChatbotArea from '../../views/home/components/chatbotView';
 import { useViewerStore, type ViewerSnapshot } from '../../stores/viewerStore';
@@ -241,6 +242,7 @@ export const TabManager: React.FC = () => {
                     <Route path="/file/new" element={<CreateFlowPj />} />
                     <Route path="/box/upload" element={<BoxUpload />} />
                     <Route path="/settings/databases" element={<CustomDatabaseManager />} />
+                    <Route path="/settings/secrets" element={<SecretVaultPage />} />
                     <Route path="/user" element={<UserProfileView />} />
                     <Route path="/*" element={<NotFoundView />} />
                   </Routes>

--- a/gui/workflow_frontend/src/shared/header/header.tsx
+++ b/gui/workflow_frontend/src/shared/header/header.tsx
@@ -192,6 +192,15 @@ const Header: React.FC = () => {
             >
               Custom Databases
             </MenuItem>
+            <MenuItem
+              as={RouterLink}
+              to="/settings/secrets"
+              bg={menuBg}
+              color={headerColor}
+              _hover={{ bg: menuHoverBg }}
+            >
+              Secrets
+            </MenuItem>
           </MenuList>
         </Menu>
 

--- a/gui/workflow_frontend/src/utils/secretRefs.test.ts
+++ b/gui/workflow_frontend/src/utils/secretRefs.test.ts
@@ -41,6 +41,40 @@ describe('secretRefs', () => {
     expect(exported.flow?.nodes?.[0]?.data?.schema).toBeTruthy();
   });
 
+  it('strips plaintext from nested field_modifications in exported flow JSON', () => {
+    const exported = stripSecretValuesFromExport({
+      project: { name: 'demo' },
+      flow: {
+        nodes: [
+          {
+            data: {
+              schema: {
+                parameters: {
+                  password: {
+                    secret: true,
+                    default_value: { __nw_secret: { id: 'abc', name: 'ASPERA_PASSWORD' } },
+                  },
+                },
+              },
+              parameter_modifications: {
+                password: {
+                  current_value: 'plain-password-value',
+                  field_modifications: {
+                    default_value: 'plain-password-value',
+                    default_value_original: 'plain-password-value',
+                  },
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+    const dumped = JSON.stringify(exported);
+    expect(dumped).not.toContain('plain-password-value');
+    expect(dumped).toContain('__nw_secret');
+  });
+
   it('flags blocked workflow_context keys', () => {
     expect(blockedContextKeys({ aspera_pass: 'x', species: 'mouse' })).toEqual(['aspera_pass']);
   });

--- a/gui/workflow_frontend/src/utils/secretRefs.test.ts
+++ b/gui/workflow_frontend/src/utils/secretRefs.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import {
+  blockedContextKeys,
+  isSecretRef,
+  secretRefName,
+  stripSecretValuesFromExport,
+} from './secretRefs';
+
+describe('secretRefs', () => {
+  it('reads a vault reference name', () => {
+    const ref = { __nw_secret: { id: '1', name: 'ASPERA_PASSWORD' } };
+    expect(isSecretRef(ref)).toBe(true);
+    expect(secretRefName(ref)).toBe('ASPERA_PASSWORD');
+  });
+
+  it('strips secret values from exported flow JSON', () => {
+    const exported = stripSecretValuesFromExport({
+      project: { name: 'demo' },
+      flow: {
+        nodes: [
+          {
+            data: {
+              schema: {
+                parameters: {
+                  password: {
+                    secret: true,
+                    default_value: { __nw_secret: { id: 'abc', name: 'ASPERA_PASSWORD' } },
+                  },
+                  n: { default_value: 1 },
+                },
+              },
+            },
+          },
+        ],
+      },
+    });
+    const dumped = JSON.stringify(exported);
+    expect(dumped).toContain('ASPERA_PASSWORD');
+    expect(dumped).toContain('__nw_secret');
+    expect(dumped).not.toContain('plain-password-value');
+    expect(exported.flow?.nodes?.[0]?.data?.schema).toBeTruthy();
+  });
+
+  it('flags blocked workflow_context keys', () => {
+    expect(blockedContextKeys({ aspera_pass: 'x', species: 'mouse' })).toEqual(['aspera_pass']);
+  });
+});

--- a/gui/workflow_frontend/src/utils/secretRefs.ts
+++ b/gui/workflow_frontend/src/utils/secretRefs.ts
@@ -1,0 +1,96 @@
+export const SECRET_REF_KEY = '__nw_secret';
+
+export const BLOCKED_CONTEXT_TOKENS = [
+  'password',
+  'secret',
+  'token',
+  'api_key',
+  'apikey',
+  'aspera_pass',
+  'authorization',
+];
+
+export type SecretRef = {
+  [SECRET_REF_KEY]: { id?: string; name?: string };
+};
+
+export function isSecretRef(value: unknown): value is SecretRef {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    SECRET_REF_KEY in value &&
+    typeof (value as SecretRef)[SECRET_REF_KEY] === 'object'
+  );
+}
+
+export function secretRefName(value: unknown): string {
+  if (!isSecretRef(value)) return '';
+  return value[SECRET_REF_KEY]?.name || '';
+}
+
+export function makeSecretRef(id: string, name: string): SecretRef {
+  return { [SECRET_REF_KEY]: { id, name } };
+}
+
+export function blockedContextKeys(context: Record<string, unknown> | null | undefined): string[] {
+  if (!context || typeof context !== 'object') return [];
+  return Object.keys(context).filter((key) => {
+    const lowered = key.toLowerCase().replace(/-/g, '_');
+    return BLOCKED_CONTEXT_TOKENS.some((token) => lowered.includes(token));
+  });
+}
+
+function redactNodeData(data: Record<string, unknown> | undefined): Record<string, unknown> | undefined {
+  if (!data || typeof data !== 'object') return data;
+  const out = structuredClone(data);
+  const schema = (out.schema || {}) as Record<string, unknown>;
+  const params = (schema.parameters || {}) as Record<string, Record<string, unknown>>;
+  for (const param of Object.values(params)) {
+    if (!param || typeof param !== 'object') continue;
+    if (param.secret || isSecretRef(param.default_value)) {
+      const name = secretRefName(param.default_value);
+      if (isSecretRef(param.default_value) || param.default_value) {
+        param.default_value = makeSecretRef(
+          isSecretRef(param.default_value) ? String(param.default_value[SECRET_REF_KEY]?.id || '') : '',
+          name,
+        );
+      }
+    }
+  }
+  const mods = out.parameter_modifications as Record<string, Record<string, unknown>> | undefined;
+  if (mods) {
+    for (const info of Object.values(mods)) {
+      if (!info || typeof info !== 'object') continue;
+      for (const field of ['original_value', 'current_value'] as const) {
+        if (isSecretRef(info[field])) {
+          info[field] = makeSecretRef(
+            String((info[field] as SecretRef)[SECRET_REF_KEY]?.id || ''),
+            secretRefName(info[field]),
+          );
+        } else if (typeof info[field] === 'string' && info[field]) {
+          const paramsMap = params;
+          const match = Object.values(paramsMap).find((p) => p.secret);
+          if (match) info[field] = makeSecretRef('', secretRefName(match.default_value) || 'REDACTED');
+        }
+      }
+    }
+  }
+  out.schema = { ...schema, parameters: params };
+  return out;
+}
+
+export function stripSecretValuesFromExport(exportData: {
+  project?: unknown;
+  flow?: { nodes?: Array<{ data?: Record<string, unknown> }> };
+}): typeof exportData {
+  const cloned = structuredClone(exportData);
+  const nodes = cloned.flow?.nodes;
+  if (Array.isArray(nodes)) {
+    for (const node of nodes) {
+      if (node && typeof node === 'object' && node.data) {
+        node.data = redactNodeData(node.data) as Record<string, unknown>;
+      }
+    }
+  }
+  return cloned;
+}

--- a/gui/workflow_frontend/src/utils/secretRefs.ts
+++ b/gui/workflow_frontend/src/utils/secretRefs.ts
@@ -73,6 +73,20 @@ function redactNodeData(data: Record<string, unknown> | undefined): Record<strin
           if (match) info[field] = makeSecretRef('', secretRefName(match.default_value) || 'REDACTED');
         }
       }
+      const fieldMods = info.field_modifications as Record<string, unknown> | undefined;
+      if (fieldMods && typeof fieldMods === 'object') {
+        for (const [fk, fv] of Object.entries(fieldMods)) {
+          if (isSecretRef(fv)) {
+            fieldMods[fk] = makeSecretRef(
+              String(fv[SECRET_REF_KEY]?.id || ''),
+              secretRefName(fv),
+            );
+          } else if (typeof fv === 'string' && fv) {
+            const match = Object.values(params).find((p) => p.secret);
+            if (match) fieldMods[fk] = makeSecretRef('', secretRefName(match.default_value) || 'REDACTED');
+          }
+        }
+      }
     }
   }
   out.schema = { ...schema, parameters: params };

--- a/gui/workflow_frontend/src/views/home/components/CustomDatabaseModal.tsx
+++ b/gui/workflow_frontend/src/views/home/components/CustomDatabaseModal.tsx
@@ -81,6 +81,7 @@ const CustomDatabaseModal: React.FC<CustomDatabaseModalProps> = ({
   const [authType, setAuthType] = useState('api_key');
   const [apiKeyHeader, setApiKeyHeader] = useState('X-API-Key');
   const [customConfigJson, setCustomConfigJson] = useState('');
+  const [apiKeySecretName, setApiKeySecretName] = useState('');
   const toast = useToast();
 
   const isEditMode = !!database;
@@ -103,6 +104,7 @@ const CustomDatabaseModal: React.FC<CustomDatabaseModalProps> = ({
       setAuthType(config.auth_type || 'api_key');
       setApiKeyHeader(config.api_key_header || 'X-API-Key');
       setCustomConfigJson(JSON.stringify(config, null, 2));
+      setApiKeySecretName(config.api_key_secret?.__nw_secret?.name || '');
       setTestResult(null);
     } else if (isOpen && !database) {
       // Reset form for create mode
@@ -120,6 +122,7 @@ const CustomDatabaseModal: React.FC<CustomDatabaseModalProps> = ({
       setAuthType('api_key');
       setApiKeyHeader('X-API-Key');
       setCustomConfigJson('');
+      setApiKeySecretName('');
       setTestResult(null);
       setShowAdvanced(false);
     }
@@ -272,6 +275,7 @@ const CustomDatabaseModal: React.FC<CustomDatabaseModalProps> = ({
           description: formData.description || undefined,
           base_url: formData.base_url,
           api_key: formData.api_key || undefined,
+          api_key_secret_name: apiKeySecretName || undefined,
           adapter_type: formData.adapter_type,
           is_active: formData.is_active,
           config: config,
@@ -402,7 +406,17 @@ const CustomDatabaseModal: React.FC<CustomDatabaseModalProps> = ({
                 placeholder="Your API key (if required)"
                 type="password"
               />
-              <FormHelperText>API key if authentication is required</FormHelperText>
+              <FormHelperText>Leave blank to keep the stored key. The value is never shown after save.</FormHelperText>
+            </FormControl>
+
+            <FormControl>
+              <FormLabel>Vault secret name (optional)</FormLabel>
+              <Input
+                value={apiKeySecretName}
+                onChange={(e) => setApiKeySecretName(e.target.value.toUpperCase())}
+                placeholder="MY_DB_API_KEY"
+              />
+              <FormHelperText>Use a secret from Settings → Secrets instead of pasting a raw key.</FormHelperText>
             </FormControl>
 
             <FormControl>

--- a/gui/workflow_frontend/src/views/home/components/CustomDatabaseModal.tsx
+++ b/gui/workflow_frontend/src/views/home/components/CustomDatabaseModal.tsx
@@ -181,7 +181,8 @@ const CustomDatabaseModal: React.FC<CustomDatabaseModalProps> = ({
         },
         body: JSON.stringify({
           base_url: formData.base_url,
-          api_key: formData.api_key || undefined,
+          api_key: apiKeySecretName ? undefined : (formData.api_key || undefined),
+          api_key_secret_name: apiKeySecretName || undefined,
           config: config,
         }),
       });

--- a/gui/workflow_frontend/src/views/home/components/SecretParamEditor.tsx
+++ b/gui/workflow_frontend/src/views/home/components/SecretParamEditor.tsx
@@ -1,0 +1,136 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Button,
+  Code,
+  HStack,
+  Input,
+  Select,
+  Text,
+  VStack,
+  useToast,
+} from '@chakra-ui/react';
+import { createAuthHeaders } from '../../../api/authHeaders';
+import { isSecretRef, makeSecretRef, secretRefName } from '../../../utils/secretRefs';
+
+type VaultSecret = { id: string; name: string; is_set?: boolean };
+
+interface SecretParamEditorProps {
+  value: unknown;
+  isWorkflowNode: boolean;
+  onBind: (ref: ReturnType<typeof makeSecretRef>) => Promise<void> | void;
+}
+
+const SecretParamEditor: React.FC<SecretParamEditorProps> = ({
+  value,
+  isWorkflowNode,
+  onBind,
+}) => {
+  const toast = useToast();
+  const [secrets, setSecrets] = useState<VaultSecret[]>([]);
+  const [selected, setSelected] = useState(secretRefName(value));
+  const [newValue, setNewValue] = useState('');
+  const [newName, setNewName] = useState('NODE_SECRET');
+
+  useEffect(() => {
+    setSelected(secretRefName(value));
+  }, [value]);
+
+  useEffect(() => {
+    (async () => {
+      const response = await fetch('/api/secrets/', { headers: await createAuthHeaders() });
+      if (!response.ok) return;
+      const data = await response.json();
+      setSecrets(Array.isArray(data) ? data : []);
+    })();
+  }, []);
+
+  const boundName = secretRefName(value);
+  const showRef = isSecretRef(value) && boundName;
+
+  const rejectSidebar = () => {
+    toast({
+      title: 'Use the vault',
+      description: 'Secret parameters cannot be written into node source. Open Settings → Secrets.',
+      status: 'warning',
+      duration: 4000,
+      isClosable: true,
+    });
+  };
+
+  const bindExisting = async () => {
+    if (!isWorkflowNode) {
+      rejectSidebar();
+      return;
+    }
+    const match = secrets.find((s) => s.name === selected);
+    if (!match) return;
+    await onBind(makeSecretRef(match.id, match.name));
+  };
+
+  const createAndBind = async () => {
+    if (!isWorkflowNode) {
+      rejectSidebar();
+      return;
+    }
+    const response = await fetch('/api/secrets/', {
+      method: 'POST',
+      headers: { ...(await createAuthHeaders()), 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name: newName, value: newValue }),
+    });
+    if (!response.ok) {
+      const body = await response.json().catch(() => ({}));
+      toast({
+        title: 'Could not create secret',
+        description: typeof body.error === 'string' ? body.error : `HTTP ${response.status}`,
+        status: 'error',
+      });
+      return;
+    }
+    const created = await response.json();
+    setNewValue('');
+    await onBind(makeSecretRef(created.id, created.name));
+  };
+
+  return (
+    <VStack align="stretch" spacing={2} flex="1">
+      <HStack>
+        <Text fontSize="xs">••••</Text>
+        {showRef ? <Code fontSize="xs">{boundName}</Code> : <Text fontSize="xs">not bound</Text>}
+      </HStack>
+      <Select
+        size="xs"
+        value={selected}
+        onChange={(e) => setSelected(e.target.value)}
+        placeholder="Select from my secrets"
+      >
+        {secrets.map((secret) => (
+          <option key={secret.id} value={secret.name}>
+            {secret.name}
+          </option>
+        ))}
+      </Select>
+      <Button size="xs" onClick={bindExisting} isDisabled={!selected}>
+        Bind selected
+      </Button>
+      <Input
+        size="xs"
+        value={newName}
+        onChange={(e) => setNewName(e.target.value.toUpperCase())}
+        placeholder="NEW_SECRET_NAME"
+      />
+      <Input
+        size="xs"
+        type="password"
+        value={newValue}
+        onChange={(e) => setNewValue(e.target.value)}
+        placeholder="New value"
+        autoComplete="new-password"
+      />
+      <Button size="xs" onClick={createAndBind} isDisabled={!newName || !newValue}>
+        Save to vault and bind
+      </Button>
+    </VStack>
+  );
+};
+
+export default SecretParamEditor;

--- a/gui/workflow_frontend/src/views/home/components/SecretVaultPage.tsx
+++ b/gui/workflow_frontend/src/views/home/components/SecretVaultPage.tsx
@@ -1,0 +1,254 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Alert,
+  AlertIcon,
+  Box,
+  Button,
+  Code,
+  FormControl,
+  FormHelperText,
+  FormLabel,
+  HStack,
+  IconButton,
+  Input,
+  Spinner,
+  Table,
+  TableContainer,
+  Tbody,
+  Td,
+  Text,
+  Th,
+  Thead,
+  Tr,
+  useToast,
+  VStack,
+} from '@chakra-ui/react';
+import { DeleteIcon } from '@chakra-ui/icons';
+import { createAuthHeaders } from '../../api/authHeaders';
+
+type VaultSecret = {
+  id: string;
+  name: string;
+  description?: string;
+  is_set: boolean;
+  created_at?: string;
+  updated_at?: string;
+};
+
+const SecretVaultPage: React.FC = () => {
+  const [secrets, setSecrets] = useState<VaultSecret[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [name, setName] = useState('ASPERA_PASSWORD');
+  const [value, setValue] = useState('');
+  const [description, setDescription] = useState('');
+  const [saving, setSaving] = useState(false);
+  const toast = useToast();
+
+  const fetchSecrets = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch('/api/secrets/', { headers: await createAuthHeaders() });
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      const data = await response.json();
+      setSecrets(Array.isArray(data) ? data : []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to list secrets');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchSecrets();
+  }, []);
+
+  const createSecret = async () => {
+    setSaving(true);
+    try {
+      const response = await fetch('/api/secrets/', {
+        method: 'POST',
+        headers: { ...(await createAuthHeaders()), 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, value, description }),
+      });
+      if (!response.ok) {
+        const body = await response.json().catch(() => ({}));
+        throw new Error(body.error || `HTTP ${response.status}`);
+      }
+      setValue('');
+      toast({ title: 'Secret saved', status: 'success', duration: 2000, isClosable: true });
+      await fetchSecrets();
+    } catch (err) {
+      toast({
+        title: 'Could not save secret',
+        description: err instanceof Error ? err.message : 'Unknown error',
+        status: 'error',
+        duration: 4000,
+        isClosable: true,
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const rotateSecret = async (secret: VaultSecret, nextValue: string) => {
+    const response = await fetch(`/api/secrets/${secret.id}/`, {
+      method: 'PATCH',
+      headers: { ...(await createAuthHeaders()), 'Content-Type': 'application/json' },
+      body: JSON.stringify({ value: nextValue }),
+    });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+  };
+
+  const deleteSecret = async (secret: VaultSecret) => {
+    const response = await fetch(`/api/secrets/${secret.id}/`, {
+      method: 'DELETE',
+      headers: await createAuthHeaders(),
+    });
+    if (!response.ok && response.status !== 204) throw new Error(`HTTP ${response.status}`);
+    await fetchSecrets();
+  };
+
+  const copyName = async (secretName: string) => {
+    await navigator.clipboard.writeText(secretName);
+    toast({ title: 'Copied name', status: 'info', duration: 1500, isClosable: true });
+  };
+
+  return (
+    <Box p={6} overflowY="auto" h="100%">
+      <VStack align="stretch" spacing={6} maxW="900px">
+        <Box>
+          <Text fontSize="2xl" fontWeight="bold">
+            Secrets
+          </Text>
+          <Text mt={2} color="gray.500">
+            Store credentials here (or set Jupyter env <Code>NW_SECRET_NAME</Code> for local
+            notebooks). Never put passwords in node parameters — the workflow JSON only keeps a
+            named reference.
+          </Text>
+        </Box>
+
+        {error && (
+          <Alert status="error">
+            <AlertIcon />
+            {error}
+          </Alert>
+        )}
+
+        <Box borderWidth="1px" borderRadius="md" p={4}>
+          <Text fontWeight="semibold" mb={3}>
+            Create secret
+          </Text>
+          <VStack align="stretch" spacing={3}>
+            <FormControl>
+              <FormLabel>Name</FormLabel>
+              <Input
+                value={name}
+                onChange={(e) => setName(e.target.value.toUpperCase())}
+                placeholder="ASPERA_PASSWORD"
+              />
+              <FormHelperText>Must match ^[A-Z][A-Z0-9_]{'{1,63}'}$</FormHelperText>
+            </FormControl>
+            <FormControl>
+              <FormLabel>Value</FormLabel>
+              <Input
+                type="password"
+                value={value}
+                onChange={(e) => setValue(e.target.value)}
+                placeholder="••••"
+                autoComplete="new-password"
+              />
+            </FormControl>
+            <FormControl>
+              <FormLabel>Description</FormLabel>
+              <Input value={description} onChange={(e) => setDescription(e.target.value)} />
+            </FormControl>
+            <Button
+              colorScheme="blue"
+              onClick={createSecret}
+              isLoading={saving}
+              isDisabled={!name || !value}
+              alignSelf="flex-start"
+            >
+              Save
+            </Button>
+          </VStack>
+        </Box>
+
+        {loading ? (
+          <Spinner />
+        ) : (
+          <TableContainer>
+            <Table size="sm">
+              <Thead>
+                <Tr>
+                  <Th>Name</Th>
+                  <Th>Description</Th>
+                  <Th>Value</Th>
+                  <Th></Th>
+                </Tr>
+              </Thead>
+              <Tbody>
+                {secrets.map((secret) => (
+                  <Tr key={secret.id}>
+                    <Td>
+                      <Code>{secret.name}</Code>
+                    </Td>
+                    <Td>{secret.description || '—'}</Td>
+                    <Td>{secret.is_set ? '••••' : '—'}</Td>
+                    <Td>
+                      <HStack>
+                        <Button size="xs" onClick={() => copyName(secret.name)}>
+                          Copy name
+                        </Button>
+                        <Button
+                          size="xs"
+                          onClick={async () => {
+                            const next = window.prompt(`New value for ${secret.name}`);
+                            if (!next) return;
+                            try {
+                              await rotateSecret(secret, next);
+                              toast({ title: 'Rotated', status: 'success', duration: 2000 });
+                              await fetchSecrets();
+                            } catch (err) {
+                              toast({
+                                title: 'Rotate failed',
+                                description: err instanceof Error ? err.message : 'Unknown error',
+                                status: 'error',
+                              });
+                            }
+                          }}
+                        >
+                          Rotate
+                        </Button>
+                        <IconButton
+                          aria-label="Delete secret"
+                          icon={<DeleteIcon />}
+                          size="xs"
+                          onClick={async () => {
+                            try {
+                              await deleteSecret(secret);
+                            } catch (err) {
+                              toast({
+                                title: 'Delete failed',
+                                description: err instanceof Error ? err.message : 'Unknown error',
+                                status: 'error',
+                              });
+                            }
+                          }}
+                        />
+                      </HStack>
+                    </Td>
+                  </Tr>
+                ))}
+              </Tbody>
+            </Table>
+          </TableContainer>
+        )}
+      </VStack>
+    </Box>
+  );
+};
+
+export default SecretVaultPage;

--- a/gui/workflow_frontend/src/views/home/components/SecretVaultPage.tsx
+++ b/gui/workflow_frontend/src/views/home/components/SecretVaultPage.tsx
@@ -43,6 +43,8 @@ const SecretVaultPage: React.FC = () => {
   const [value, setValue] = useState('');
   const [description, setDescription] = useState('');
   const [saving, setSaving] = useState(false);
+  const [rotateId, setRotateId] = useState<string | null>(null);
+  const [rotateValue, setRotateValue] = useState('');
   const toast = useToast();
 
   const fetchSecrets = async () => {
@@ -202,26 +204,61 @@ const SecretVaultPage: React.FC = () => {
                         <Button size="xs" onClick={() => copyName(secret.name)}>
                           Copy name
                         </Button>
-                        <Button
-                          size="xs"
-                          onClick={async () => {
-                            const next = window.prompt(`New value for ${secret.name}`);
-                            if (!next) return;
-                            try {
-                              await rotateSecret(secret, next);
-                              toast({ title: 'Rotated', status: 'success', duration: 2000 });
-                              await fetchSecrets();
-                            } catch (err) {
-                              toast({
-                                title: 'Rotate failed',
-                                description: err instanceof Error ? err.message : 'Unknown error',
-                                status: 'error',
-                              });
-                            }
-                          }}
-                        >
-                          Rotate
-                        </Button>
+                        {rotateId === secret.id ? (
+                          <HStack>
+                            <Input
+                              type="password"
+                              size="xs"
+                              value={rotateValue}
+                              onChange={(e) => setRotateValue(e.target.value)}
+                              placeholder="New value"
+                              autoComplete="new-password"
+                              w="140px"
+                            />
+                            <Button
+                              size="xs"
+                              colorScheme="blue"
+                              isDisabled={!rotateValue}
+                              onClick={async () => {
+                                try {
+                                  await rotateSecret(secret, rotateValue);
+                                  setRotateId(null);
+                                  setRotateValue('');
+                                  toast({ title: 'Rotated', status: 'success', duration: 2000 });
+                                  await fetchSecrets();
+                                } catch (err) {
+                                  toast({
+                                    title: 'Rotate failed',
+                                    description: err instanceof Error ? err.message : 'Unknown error',
+                                    status: 'error',
+                                  });
+                                }
+                              }}
+                            >
+                              Save
+                            </Button>
+                            <Button
+                              size="xs"
+                              variant="ghost"
+                              onClick={() => {
+                                setRotateId(null);
+                                setRotateValue('');
+                              }}
+                            >
+                              Cancel
+                            </Button>
+                          </HStack>
+                        ) : (
+                          <Button
+                            size="xs"
+                            onClick={() => {
+                              setRotateId(secret.id);
+                              setRotateValue('');
+                            }}
+                          >
+                            Rotate
+                          </Button>
+                        )}
                         <IconButton
                           aria-label="Delete secret"
                           icon={<DeleteIcon />}

--- a/gui/workflow_frontend/src/views/home/components/nodeDetailModal.tsx
+++ b/gui/workflow_frontend/src/views/home/components/nodeDetailModal.tsx
@@ -23,6 +23,7 @@ import { CalculationNodeData, SchemaFields } from '../type';
 import { Node } from '@xyflow/react';
 import { createAuthHeaders } from '../../../api/authHeaders';
 import ParameterSuggestionModal from './ParameterSuggestionModal';
+import SecretParamEditor from './SecretParamEditor';
 import { JUPYTER_BASE_URL } from '../../../config/urls';
 
 interface NodeDetailsContentProps {
@@ -734,8 +735,18 @@ const NodeDetailsContent: React.FC<NodeDetailsContentProps> = ({ nodeData, onNod
               )}
 
               <VStack align="stretch" spacing={2}>
-                {/* Default Value - editable */}
-                {(param.default_value !== undefined || getNodeParameterValue(key, 'default_value') !== undefined) && (
+                {param.secret ? (
+                  <HStack align="start" spacing={2}>
+                    <Text fontSize="xs" color={subtextColor} minW="80px">secret:</Text>
+                    <SecretParamEditor
+                      value={getNodeParameterValue(key, 'default_value')}
+                      isWorkflowNode={!!(localNodeData && !localNodeData.id.startsWith('sidebar_'))}
+                      onBind={async (ref) => {
+                        await updateParameter(key, ref, 'default_value');
+                      }}
+                    />
+                  </HStack>
+                ) : (param.default_value !== undefined || getNodeParameterValue(key, 'default_value') !== undefined) && (
                   <HStack align="start" spacing={2}>
                     <Text fontSize="xs" color={subtextColor} minW="80px">default_value:</Text>
                     {editingParam === key && editingField === 'default_value' ? (

--- a/gui/workflow_frontend/src/views/home/components/nodeDetailModal.tsx
+++ b/gui/workflow_frontend/src/views/home/components/nodeDetailModal.tsx
@@ -113,7 +113,6 @@ const NodeDetailsContent: React.FC<NodeDetailsContentProps> = ({ nodeData, onNod
 
       // The body of a successful response is also output to the log.
       const responseText = await response.text();
-      console.log('Success response body:', responseText);
 
       // Re-acquire the latest data from the DB or update the local state
       if (localNodeData && onNodeUpdate) {
@@ -181,7 +180,6 @@ const NodeDetailsContent: React.FC<NodeDetailsContentProps> = ({ nodeData, onNod
       console.log('Workflow ID:', workflowId);
       console.log('Is Workflow Node:', isWorkflowNode);
       console.log('Parameter Key:', parameterKey);
-      console.log('Parameter Value:', parameterValue);
       console.log('Parameter Field:', parameterField);
 
       let response;
@@ -197,7 +195,6 @@ const NodeDetailsContent: React.FC<NodeDetailsContentProps> = ({ nodeData, onNod
           parameter_field: parameterField,
           parameter_value: parameterValue
         };
-        console.log('Request body for workflow node:', JSON.stringify(requestBody, null, 2));
 
         const paramAuthHeaders = await createAuthHeaders();
         response = await fetch(endpoint, {
@@ -219,7 +216,6 @@ const NodeDetailsContent: React.FC<NodeDetailsContentProps> = ({ nodeData, onNod
           parameter_value: parameterValue,
           filename: localNodeData.data.file_name
         };
-        console.log('Request body for sidebar node:', JSON.stringify(requestBody, null, 2));
 
         const authHeaders = await createAuthHeaders();
         response = await fetch(endpoint, {
@@ -243,14 +239,12 @@ const NodeDetailsContent: React.FC<NodeDetailsContentProps> = ({ nodeData, onNod
 
       // The body of a successful response is also output to the log.
       const responseText = await response.text();
-      console.log('Success response body:', responseText);
 
       // If the response is not empty, parse it as JSON
       let responseData = null;
       if (responseText.trim()) {
         try {
           responseData = JSON.parse(responseText);
-          console.log('Parsed response data:', responseData);
         } catch (e) {
           console.log('Response is not valid JSON, treating as plain text');
         }
@@ -501,6 +495,8 @@ const NodeDetailsContent: React.FC<NodeDetailsContentProps> = ({ nodeData, onNod
   // Handle accepting a suggestion
   const handleAcceptSuggestion = async (suggestion: { value: any; source: string; confidence: number; description: string; species?: string | null; citation?: string | null; metadata?: Record<string, any> }) => {
     if (!suggestingParam) return;
+    const param = localNodeData?.data?.schema?.parameters?.[suggestingParam];
+    if (param?.secret) return;
 
     // Update the parameter with the suggested value
     const success = await updateParameter(suggestingParam, suggestion.value, 'default_value');
@@ -713,6 +709,7 @@ const NodeDetailsContent: React.FC<NodeDetailsContentProps> = ({ nodeData, onNod
             <VStack align="stretch" spacing={3}>
               <HStack justify="space-between" align="center">
                 <Text fontWeight="bold" fontSize="md" color="orange.400">"{key}"</Text>
+                {!param.secret && (
                 <Tooltip label="Get AI suggestions for this parameter" hasArrow>
                   <IconButton
                     aria-label="Suggest values"
@@ -723,6 +720,7 @@ const NodeDetailsContent: React.FC<NodeDetailsContentProps> = ({ nodeData, onNod
                     onClick={() => openSuggestionModal(key)}
                   />
                 </Tooltip>
+                )}
               </HStack>
 
               {param.description && (

--- a/gui/workflow_frontend/src/views/home/homeView.tsx
+++ b/gui/workflow_frontend/src/views/home/homeView.tsx
@@ -31,6 +31,7 @@ import { JUPYTER_BASE_URL, API_BASE_URL } from '../../config/urls';
 import '@xyflow/react/dist/style.css';
 import SideBoxArea from '../box/boxView';
 import { CalculationNodeData, Project, FlowData } from './type';
+import { stripSecretValuesFromExport } from '../../utils/secretRefs';
 import { ProjectSelector } from './components/projectSelector';
 import { EdgeMenu } from './components/edgeMenu';
 import { NodeMenu } from './components/nodeMenu';
@@ -916,14 +917,14 @@ const HomeView = () => {
       const flowData = reactFlowInstance.current.toObject();
       
       // Include project information
-      const exportData = {
+      const exportData = stripSecretValuesFromExport({
         project: {
           id: selectedProject,
           name: projects.find(p => p.id === selectedProject)?.name || 'Unknown',
           exportedAt: new Date().toISOString()
         },
         flow: flowData
-      };
+      });
 
       // Download as JSON file
       const jsonString = JSON.stringify(exportData, null, 2);
@@ -948,8 +949,6 @@ const HomeView = () => {
         duration: 3000,
         isClosable: true,
       });
-      
-      console.log('Exported flow data:', exportData);
     } catch (error) {
       console.error('Failed to export flow:', error);
       toast({

--- a/gui/workflow_frontend/src/views/home/homeView.tsx
+++ b/gui/workflow_frontend/src/views/home/homeView.tsx
@@ -1059,7 +1059,6 @@ const HomeView = () => {
 
       // Get flow data for React Flow
       const flowData = reactFlowInstance.current.toObject();
-      console.log('Sending flow data to API:', flowData);
 
       const headers = await createAuthHeaders();
       const response = await fetch(`/api/workflow/${selectedProject}/generate-code/`, {
@@ -1085,7 +1084,6 @@ const HomeView = () => {
       }
 
       const result = await response.json();
-      console.log('Code generation result:', result);
 
       toast({
         title: "Code Generated Successfully! ✅",

--- a/gui/workflow_frontend/src/views/home/type.ts
+++ b/gui/workflow_frontend/src/views/home/type.ts
@@ -33,6 +33,7 @@ export interface ParameterField {
   optimization_range?: [number, number] | number[];
   is_objective?: boolean;
   objective_range?: [number, number] | number[];
+  secret?: boolean;
 }
 
 export interface Method {

--- a/gui/workflow_frontend/vite.config.ts
+++ b/gui/workflow_frontend/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest/config" />
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import tsconfigPaths from "vite-tsconfig-paths";
@@ -48,6 +49,10 @@ export default defineConfig({
         secure: false,
       },
     },
+  },
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
   },
   resolve: {
     alias: {

--- a/src/neuroworkflow/core/__init__.py
+++ b/src/neuroworkflow/core/__init__.py
@@ -14,3 +14,4 @@ from neuroworkflow.core.schema import (
 from neuroworkflow.core.port import Port, InputPort, OutputPort
 from neuroworkflow.core.node import Node, ProcessStep
 from neuroworkflow.core.workflow import Workflow, WorkflowBuilder, Connection
+from neuroworkflow.core.secrets import SecretRef, SecretStr, resolve, MissingSecretError

--- a/src/neuroworkflow/core/node.py
+++ b/src/neuroworkflow/core/node.py
@@ -10,6 +10,7 @@ import inspect
 
 from neuroworkflow.core.schema import NodeDefinitionSchema, PortDefinition, ParameterDefinition, MethodDefinition
 from neuroworkflow.core.port import InputPort, OutputPort, PortType
+from neuroworkflow.core.secrets import MissingSecretError, SecretStr, is_secret_ref, resolve
 
 
 class ProcessStep:
@@ -65,12 +66,37 @@ class Node:
         
         # Auto-create ports from NODE_DEFINITION
         self._define_ports_from_definition()
+
+    @staticmethod
+    def _param_is_secret(param_def) -> bool:
+        if isinstance(param_def, ParameterDefinition):
+            return bool(param_def.secret)
+        if isinstance(param_def, dict):
+            return bool(param_def.get("secret"))
+        return False
+
+    def _store_secret_parameter(self, name: str, value) -> None:
+        try:
+            if is_secret_ref(value):
+                plaintext = resolve(value)
+            elif isinstance(value, SecretStr):
+                plaintext = value.get_secret()
+            elif value in (None, ""):
+                plaintext = ""
+            else:
+                plaintext = str(value)
+        except MissingSecretError:
+            raise
+        self._parameters[name] = SecretStr(plaintext)
     
     def _initialize_parameters(self) -> None:
         """Initialize parameters from NODE_DEFINITION schema."""
         for name, param_def in self.__class__.NODE_DEFINITION.parameters.items():
             if isinstance(param_def, ParameterDefinition):
-                self._parameters[name] = param_def.default_value
+                if param_def.secret:
+                    self._store_secret_parameter(name, param_def.default_value)
+                else:
+                    self._parameters[name] = param_def.default_value
                 
                 # Store optimization metadata if parameter is optimizable
                 if param_def.optimizable:
@@ -81,7 +107,9 @@ class Node:
                     }
             elif isinstance(param_def, dict):
                 # Handle dictionary format
-                if 'default_value' in param_def:
+                if self._param_is_secret(param_def):
+                    self._store_secret_parameter(name, param_def.get('default_value'))
+                elif 'default_value' in param_def:
                     self._parameters[name] = param_def['default_value']
                 
                 # Store optimization metadata if parameter is optimizable
@@ -398,6 +426,10 @@ class Node:
             if param_name in self._parameters:
                 # Get parameter definition
                 param_def = self.__class__.NODE_DEFINITION.parameters.get(param_name)
+
+                if self._param_is_secret(param_def):
+                    self._store_secret_parameter(param_name, value)
+                    continue
                 
                 # Check parameter constraints
                 if isinstance(param_def, ParameterDefinition) and param_def.constraints:

--- a/src/neuroworkflow/core/schema.py
+++ b/src/neuroworkflow/core/schema.py
@@ -96,6 +96,7 @@ class ParameterDefinition:
         is_objective: Whether this parameter serves as an optimization objective/target
         objective_range: [min, max] acceptable range for the objective value
         suggested_values: List of suggested values for the parameter
+        secret: If True, the parameter holds a vault SecretRef, never a plaintext credential
     """
     default_value: Any = None
     description: str = ""
@@ -107,6 +108,7 @@ class ParameterDefinition:
     metadata_sources: List[str] = field(default_factory=list)
     species_specific: bool = False
     suggested_values: List[Dict[str, Any]] = field(default_factory=list)
+    secret: bool = False
 
 
 @dataclass

--- a/src/neuroworkflow/core/secrets.py
+++ b/src/neuroworkflow/core/secrets.py
@@ -1,0 +1,128 @@
+"""Runtime secret references. Django-free — used by generated Jupyter/Slurm code.
+
+Generated workflows call ``load_runtime_secrets()`` (file or ``NW_SECRET_*`` env)
+then ``configure(password=SecretRef("ASPERA_PASSWORD"))``. Node code should
+``resolve()`` secret parameters before using them as credentials.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from typing import Any, Mapping
+
+SECRET_REF_KEY = "__nw_secret"
+_SECRETS_FILE_ENV = "NW_SECRETS_FILE"
+_SECRETS_ENV_PREFIX = "NW_SECRET_"
+
+_installed: dict[str, str] = {}
+
+
+class MissingSecretError(ValueError):
+    """A SecretRef could not be resolved from the runtime mapping."""
+
+
+@dataclass(frozen=True)
+class SecretRef:
+    name: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {SECRET_REF_KEY: {"id": "", "name": self.name}}
+
+
+class SecretStr:
+    """Holds a secret in memory; repr/str never echo the value."""
+
+    def __init__(self, value: str):
+        self._value = value if value is not None else ""
+
+    def get_secret(self) -> str:
+        return self._value
+
+    def __str__(self) -> str:
+        return "••••" if self._value else ""
+
+    def __repr__(self) -> str:
+        return "SecretStr(••••)" if self._value else "SecretStr('')"
+
+    def __bool__(self) -> bool:
+        return bool(self._value)
+
+    def __eq__(self, other: object) -> bool:
+        if isinstance(other, SecretStr):
+            return self._value == other._value
+        return False
+
+
+def install_runtime_secrets(mapping: Mapping[str, str] | None) -> None:
+    global _installed
+    _installed = {str(k): str(v) for k, v in (mapping or {}).items() if k}
+
+
+def clear_runtime_secrets() -> None:
+    global _installed
+    _installed = {}
+
+
+def load_runtime_secrets() -> dict[str, str]:
+    """Load from ``NW_SECRETS_FILE`` JSON and/or ``NW_SECRET_<NAME>`` env vars."""
+    mapping: dict[str, str] = dict(_installed)
+    path = os.environ.get(_SECRETS_FILE_ENV, "").strip()
+    if path:
+        with open(path, encoding="utf-8") as handle:
+            data = json.load(handle)
+        if isinstance(data, dict):
+            mapping.update({str(k): str(v) for k, v in data.items()})
+    for key, value in os.environ.items():
+        if key.startswith(_SECRETS_ENV_PREFIX) and key != _SECRETS_FILE_ENV:
+            name = key[len(_SECRETS_ENV_PREFIX) :]
+            if name:
+                mapping[name] = value
+    install_runtime_secrets(mapping)
+    return dict(_installed)
+
+
+def is_secret_ref(value: Any) -> bool:
+    if isinstance(value, SecretRef):
+        return True
+    return isinstance(value, dict) and SECRET_REF_KEY in value
+
+
+def secret_ref_name(value: Any) -> str | None:
+    if isinstance(value, SecretRef):
+        return value.name
+    if isinstance(value, dict) and SECRET_REF_KEY in value:
+        inner = value.get(SECRET_REF_KEY) or {}
+        if isinstance(inner, dict):
+            return inner.get("name") or None
+    return None
+
+
+def resolve(value: Any, *, required_name: str | None = None) -> Any:
+    """Return the plaintext for a SecretRef/dict ref, or passthrough."""
+    if isinstance(value, SecretStr):
+        return value.get_secret()
+    if not is_secret_ref(value):
+        return value
+    name = secret_ref_name(value) or required_name
+    if not name:
+        raise MissingSecretError("Secret reference is missing a name")
+    if name not in _installed:
+        load_runtime_secrets()
+    if name not in _installed:
+        raise MissingSecretError(f"Secret '{name}' is not available in this run")
+    return _installed[name]
+
+
+def wrap_resolved(value: Any, *, secret: bool) -> Any:
+    if not secret:
+        return value
+    if isinstance(value, SecretStr):
+        return value
+    plaintext = resolve(value) if is_secret_ref(value) else (value if isinstance(value, str) else "")
+    if is_secret_ref(value) or (isinstance(value, str) and value):
+        if is_secret_ref(value):
+            plaintext = resolve(value)
+        return SecretStr(str(plaintext or ""))
+    return SecretStr("")

--- a/src/neuroworkflow/nodes/io/AsperaSharesLoaderNode.py
+++ b/src/neuroworkflow/nodes/io/AsperaSharesLoaderNode.py
@@ -1,0 +1,148 @@
+"""Load files from an IBM Aspera Shares source.
+
+Passwords are vault SecretRefs (secret=True). At runtime the node writes a
+mode-0600 YAML under TMPDIR (never under results/), runs the transfer, then
+overwrites and deletes the YAML. Operators may still set ASPERA_PASSWORD.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+from typing import Any
+
+from neuroworkflow.core.node import Node
+from neuroworkflow.core.port import PortType
+from neuroworkflow.core.schema import (
+    MethodDefinition,
+    NodeDefinitionSchema,
+    ParameterDefinition,
+    PortDefinition,
+)
+from neuroworkflow.core.secrets import resolve
+
+
+def _shred_file(path: str) -> None:
+    if not path or not os.path.isfile(path):
+        return
+    try:
+        size = os.path.getsize(path)
+        with open(path, "r+b") as handle:
+            handle.write(b"\0" * size)
+            handle.flush()
+            os.fsync(handle.fileno())
+    except OSError:
+        pass
+    try:
+        os.remove(path)
+    except OSError:
+        pass
+
+
+class AsperaSharesLoaderNode(Node):
+    NODE_DEFINITION = NodeDefinitionSchema(
+        type="aspera_shares_loader",
+        description="Download from IBM Aspera Shares using a vault password reference",
+        stage="io",
+        tool="Aspera",
+        parameters={
+            "url": ParameterDefinition(
+                default_value="",
+                description="Aspera Shares base URL",
+            ),
+            "username": ParameterDefinition(
+                default_value="",
+                description="Aspera username (not secret)",
+            ),
+            "password": ParameterDefinition(
+                default_value="",
+                description="Vault secret for the Aspera password",
+                secret=True,
+            ),
+            "remote_path": ParameterDefinition(
+                default_value="",
+                description="Remote path to download",
+            ),
+            "local_path": ParameterDefinition(
+                default_value=".",
+                description="Local destination directory",
+            ),
+            "config_path": ParameterDefinition(
+                default_value="",
+                description="Optional existing Aspera YAML (overrides username/password)",
+            ),
+        },
+        outputs={
+            "local_path": PortDefinition(
+                type=PortType.STR,
+                description="Local path of the downloaded files",
+            )
+        },
+        methods={
+            "download": MethodDefinition(
+                description="Download via ascp/aspera using a shredded temp YAML",
+                inputs=[],
+                outputs=["local_path"],
+            )
+        },
+    )
+
+    def __init__(self, name: str):
+        super().__init__(name)
+        self._define_process_steps()
+
+    def _define_process_steps(self) -> None:
+        self.add_process_step("download", self.download, method_key="download")
+
+    def _password(self) -> str:
+        raw = self._parameters.get("password")
+        value = resolve(raw)
+        if value:
+            return str(value)
+        return os.environ.get("ASPERA_PASSWORD", "")
+
+    def _write_temp_yaml(self, username: str, password: str, url: str) -> str:
+        tmpdir = os.environ.get("TMPDIR") or tempfile.gettempdir()
+        fd, path = tempfile.mkstemp(prefix="nw-aspera-", suffix=".yml", dir=tmpdir)
+        os.fchmod(fd, 0o600)
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            handle.write(f"user: {username}\n")
+            handle.write("password: " + password.replace("\n", "") + "\n")
+            handle.write(f"url: {url}\n")
+        return path
+
+    def _aspera_cmd(self, config_path: str, remote_path: str, local_path: str) -> list[str]:
+        aspera = shutil.which("aspera")
+        ascp = shutil.which("ascp")
+        if aspera:
+            return [aspera, "shares", "download", "--config", config_path, remote_path, local_path]
+        if ascp:
+            return [ascp, "-QT", remote_path, local_path]
+        raise FileNotFoundError("Neither aspera nor ascp is on PATH")
+
+    def download(self) -> dict[str, Any]:
+        url = str(self._parameters.get("url") or "")
+        username = str(self._parameters.get("username") or "")
+        remote_path = str(self._parameters.get("remote_path") or "")
+        local_path = str(self._parameters.get("local_path") or ".")
+        config_path = str(self._parameters.get("config_path") or "").strip()
+        owned_yaml = ""
+        password = self._password()
+        if not config_path:
+            if not password:
+                raise ValueError(
+                    "Aspera password is missing. Bind a vault secret named in Settings → Secrets "
+                    "or set ASPERA_PASSWORD."
+                )
+            owned_yaml = self._write_temp_yaml(username, password, url)
+            config_path = owned_yaml
+        try:
+            cmd = self._aspera_cmd(config_path, remote_path, local_path)
+            subprocess.run(cmd, check=True, capture_output=True, text=True)
+        finally:
+            if owned_yaml:
+                _shred_file(owned_yaml)
+        self._output_ports["local_path"].value = local_path
+        return {"local_path": local_path}

--- a/src/neuroworkflow/nodes/io/AsperaSharesLoaderNode.py
+++ b/src/neuroworkflow/nodes/io/AsperaSharesLoaderNode.py
@@ -140,7 +140,12 @@ class AsperaSharesLoaderNode(Node):
             config_path = owned_yaml
         try:
             cmd = self._aspera_cmd(config_path, remote_path, local_path)
-            subprocess.run(cmd, check=True, capture_output=True, text=True)
+            env = os.environ.copy()
+            aspera = shutil.which("aspera")
+            ascp = shutil.which("ascp")
+            if not aspera and ascp and cmd and cmd[0] == ascp:
+                env["ASPERA_PASSWORD"] = password
+            subprocess.run(cmd, check=True, capture_output=True, text=True, env=env)
         finally:
             if owned_yaml:
                 _shred_file(owned_yaml)

--- a/tests/test_core_secrets.py
+++ b/tests/test_core_secrets.py
@@ -1,0 +1,97 @@
+"""Django-free tests for neuroworkflow.core.secrets and secret parameters."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from neuroworkflow.core.node import Node
+from neuroworkflow.core.schema import NodeDefinitionSchema, ParameterDefinition
+from neuroworkflow.core.secrets import (
+    MissingSecretError,
+    SecretRef,
+    SecretStr,
+    clear_runtime_secrets,
+    install_runtime_secrets,
+    load_runtime_secrets,
+    resolve,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_runtime_secrets():
+    clear_runtime_secrets()
+    yield
+    clear_runtime_secrets()
+
+
+def test_resolve_passthrough():
+    assert resolve(42) == 42
+    assert resolve("plain") == "plain"
+
+
+def test_resolve_secret_ref():
+    install_runtime_secrets({"ASPERA_PASSWORD": "s3cret"})
+    assert resolve(SecretRef("ASPERA_PASSWORD")) == "s3cret"
+    assert resolve({"__nw_secret": {"id": "x", "name": "ASPERA_PASSWORD"}}) == "s3cret"
+
+
+def test_missing_secret_names_ref_not_value():
+    with pytest.raises(MissingSecretError, match="ASPERA_PASSWORD") as exc:
+        resolve(SecretRef("ASPERA_PASSWORD"))
+    assert "s3cret" not in str(exc.value)
+
+
+def test_secret_str_masks_repr():
+    wrapped = SecretStr("s3cret-value")
+    assert str(wrapped) == "••••"
+    assert "s3cret" not in repr(wrapped)
+    assert wrapped.get_secret() == "s3cret-value"
+
+
+def test_load_runtime_secrets_from_file(tmp_path: Path):
+    path = tmp_path / "nw-secrets.json"
+    path.write_text('{"FOO": "bar"}', encoding="utf-8")
+    os.environ["NW_SECRETS_FILE"] = str(path)
+    try:
+        loaded = load_runtime_secrets()
+        assert loaded["FOO"] == "bar"
+        assert resolve(SecretRef("FOO")) == "bar"
+    finally:
+        os.environ.pop("NW_SECRETS_FILE", None)
+
+
+def test_load_runtime_secrets_from_env():
+    os.environ["NW_SECRET_TOKEN_X"] = "from-env"
+    try:
+        loaded = load_runtime_secrets()
+        assert loaded["TOKEN_X"] == "from-env"
+    finally:
+        os.environ.pop("NW_SECRET_TOKEN_X", None)
+
+
+class _SecretNode(Node):
+    NODE_DEFINITION = NodeDefinitionSchema(
+        type="secret_test",
+        description="test",
+        parameters={
+            "password": ParameterDefinition(default_value="", description="pw", secret=True),
+            "n": ParameterDefinition(default_value=1, description="count"),
+        },
+    )
+
+
+def test_configure_resolves_secret_and_masks_str():
+    install_runtime_secrets({"ASPERA_PASSWORD": "s3cret-value"})
+    node = _SecretNode("n1")
+    node.configure(password=SecretRef("ASPERA_PASSWORD"), n=2)
+    assert node._parameters["n"] == 2
+    assert str(node._parameters["password"]) == "••••"
+    assert "s3cret-value" not in str(node)
+    assert node._parameters["password"].get_secret() == "s3cret-value"
+
+
+def test_configure_missing_secret_fails_closed():
+    node = _SecretNode("n1")
+    with pytest.raises(MissingSecretError, match="MISSING_NAME"):
+        node.configure(password=SecretRef("MISSING_NAME"))


### PR DESCRIPTION
## Summary
- Owner-only encrypted secret vault in existing Postgres (AES-GCM envelope). Flow JSON, export, codegen, MCP, and GET /code/ store SecretRef names only.
- Jupyter injects in-process; Slurm writes mode-0600 .nw-secrets then shreds; LocalExecutor uses NW_SECRET_* env. Missing secrets fail closed. Non-owners cannot decrypt or inject.

## Test plan
- [ ] poetry run pytest django-project/tests/test_secret_crypto.py django-project/tests/test_user_secret_model.py django-project/tests/test_secrets_api.py django-project/tests/test_secret_inject.py django-project/tests/test_aspera_secret.py django-project/tests/test_customdb_vault.py
- [ ] PYTHONPATH=src pytest tests/test_core_secrets.py
- [ ] npx vitest run src/utils/secretRefs.test.ts (frontend)
- [ ] Create ASPERA_PASSWORD in Settings → Secrets, bind on AsperaSharesLoaderNode password, confirm UI shows •••• + name
- [ ] Export Flow JSON / GET /code/ contain SecretRef("ASPERA_PASSWORD") only
- [ ] Do not deploy without setting SECRETS_MASTER_KEY

## Ops note
Set `SECRETS_MASTER_KEY` before deploying (python3 -c "import secrets; print(secrets.token_urlsafe(32))"). Production (`DEBUG=false`) must not boot if the master key is missing. `SECRETS_MASTER_KEY_PREVIOUS` is for rotation. Do not put a real key in git. This PR does not deploy to dbrain.jp / /data/neuro-workflow.