### PR TITLE
Add node catalog drawer and fix README install links

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,36 @@ curl -o NODE_CREATION_GUIDE.md https://raw.githubusercontent.com/oist/neuro-work
 
 ---
 
+## Installation
+
+### Python library
+
+Requires Python 3.8+.
+
+```bash
+pip install git+https://github.com/oist/neuro-workflow.git
+```
+
+Optional extras from [`pyproject.toml`](pyproject.toml):
+
+```bash
+pip install "neuroworkflow[nest] @ git+https://github.com/oist/neuro-workflow.git"
+pip install "neuroworkflow[visualization] @ git+https://github.com/oist/neuro-workflow.git"
+pip install "neuroworkflow[pointnet] @ git+https://github.com/oist/neuro-workflow.git"
+```
+
+For local development: `pip install -e ".[dev]"`.
+
+### Web application
+
+Docker Compose, Keycloak, JupyterHub, and the React UI are documented in **[gui/README.md](gui/README.md)**. Follow that file for env templates, `BIND_HOST`, and the URLs of each service.
+
+### In the GUI
+
+After login, **Nodes → Node catalog** lists every node type you can use: name, category, ports, and the short description from `NODE_DEFINITION`. This is a glossary of workflow node types, not a dataset browser. Drag a type onto the canvas from the left palette.
+
+---
+
 ## Current Status
 
 ### Neuro-Workflow Python API
@@ -98,7 +128,7 @@ Neuro-Workflow provides a comprehensive Python API for building and executing co
 
 #### Node System
 
-- **Node Storage**: All available nodes are stored in `src/neuroworkflow/nodes/`
+- **Node Storage**: All available nodes are stored in [`src/neuroworkflow/nodes/`](src/neuroworkflow/nodes/)
 - **Organization**: Nodes are organized in customizable categories for easy navigation
 - **Extensibility**: New custom nodes can be created and integrated into the system
 
@@ -106,9 +136,10 @@ Neuro-Workflow provides a comprehensive Python API for building and executing co
 
 For developers interested in extending Neuro-Workflow with custom functionality:
 
-- **📋 Node Schema**: See `NODE_SCHEMA.md` for detailed node structure specifications
-- **📝 Template**: Use `CustomNodeTemplate.py` as a starting point for new nodes
-- **📖 Tutorial**: Follow `CUSTOM_NODE_TUTORIAL.md` for step-by-step node creation guide
+- **Node Schema**: [NODE_SCHEMA.md](NODE_SCHEMA.md) — node structure specifications
+- **Template**: [CustomNodeTemplate.py](CustomNodeTemplate.py) — starting point for new nodes
+- **Tutorial**: [CUSTOM_NODE_TUTORIAL.md](CUSTOM_NODE_TUTORIAL.md) — step-by-step library tutorial
+- **Agent guide**: [NODE_CREATION_GUIDE.md](NODE_CREATION_GUIDE.md) and the [create-node skill](.claude/skills/create-node/SKILL.md)
 
 #### Python API Examples
 
@@ -116,37 +147,72 @@ The following examples demonstrate how to use the Neuro-Workflow Python API to c
 
 **Examples folder:**
 
-- `sonata_simulation.py` - Basic simulation example
-- `neuron_optimization.py` - Parameter optimization example (in development)
-- `epilepsy_rs.py` - Epileptic resting state simulation using The Virtual Brain (TVB)
+- [`examples/sonata_simulation.py`](examples/sonata_simulation.py) — basic simulation example
+- [`examples/neuron_optimization.py`](examples/neuron_optimization.py) — parameter optimization example (in development)
+- [`examples/epilepsy_rs.py`](examples/epilepsy_rs.py) — epileptic resting state simulation using The Virtual Brain (TVB)
 
 **Notebooks folder:**
 
-- `01_Basic_Simulation.ipynb` - Interactive basic simulation tutorial
-- `epilepsy_rs.ipynb` - Interactive epileptic resting state example with TVB
-- `SNNbuilder_example1.ipynb` - Spiking Neural Network building with SNNbuilder custom nodes
+- [`notebooks/01_Basic_Simulation.ipynb`](notebooks/01_Basic_Simulation.ipynb) — interactive basic simulation tutorial
+- [`notebooks/epilepsy_rs.ipynb`](notebooks/epilepsy_rs.ipynb) — interactive epileptic resting state example with TVB
+- [`notebooks/SNNbuilder_example1.ipynb`](notebooks/SNNbuilder_example1.ipynb) — spiking neural network building with SNNbuilder custom nodes
 
 ### Neuro-Workflow Web Application
 
-For users who prefer a graphical interface, Neuro-Workflow includes a comprehensive web application that provides visual workflow building capabilities.
-
-#### Installation
-
-To set up the web application, follow the detailed instructions in `gui/README.md`.
+For users who prefer a graphical interface, Neuro-Workflow includes a comprehensive web application that provides visual workflow building capabilities. **Install it using [gui/README.md](gui/README.md).**
 
 #### Important Setup Notes
 
 **Node Synchronization:**
 
-- The web app requires nodes to be copied from `src/neuroworkflow/nodes/` to `gui/workflow_backend/django-project/codes/nodes/`
+- The web app requires nodes to be copied from [`src/neuroworkflow/nodes/`](src/neuroworkflow/nodes/) to [`gui/workflow_backend/django-project/codes/nodes/`](gui/workflow_backend/django-project/codes/nodes/)
 - This copy is regularly performed by administrators
 - **For developers**: If you create new custom nodes, ensure they are copied to the web app directory to make them available in the GUI
 
 **Core API Synchronization:**
 
-- The Python API base code from `src/neuroworkflow/core/` is also copied to the web application
-- Web app location: `gui/workflow_backend/django-project/codes/neuroworkflow/core/`
+- The Python API base code from [`src/neuroworkflow/core/`](src/neuroworkflow/core/) is also copied to the web application
+- Web app location: [`gui/workflow_backend/django-project/codes/neuroworkflow/core/`](gui/workflow_backend/django-project/codes/neuroworkflow/core/)
 - This ensures the web app stays synchronized with the latest API updates
+
+---
+
+## Add a node (manual / agent)
+
+Creating a **node type** (a `.py` class with `NODE_DEFINITION`) is different from **placing** an existing type on the canvas. The [Creating Nodes and Porting Your Model](https://youtu.be/9KRuuHBY9Zo) and [Building a Workflow in the GUI with the AI Agent](https://youtu.be/Sbo7z2iWthg) videos are supplements, not the only path.
+
+### Manual — create a type (GUI)
+
+1. Write a Python class that subclasses `Node` and declares `NODE_DEFINITION`. Use [CustomNodeTemplate.py](CustomNodeTemplate.py), [NODE_SCHEMA.md](NODE_SCHEMA.md), and [CUSTOM_NODE_TUTORIAL.md](CUSTOM_NODE_TUTORIAL.md) for the library shape. For agent-oriented fields (`stage`, `tool`, `model_source`), use [NODE_CREATION_GUIDE.md](NODE_CREATION_GUIDE.md).
+2. Optional local check: `python hackathon/check_node.py YourNode.py` ([hackathon/check_node.py](hackathon/check_node.py)).
+3. In the web app: **Nodes → Upload** (`/box/upload`). Drop a `.py` file (max 10 MB). Choose a category: `analysis`, `io`, `network`, `optimization`, `simulation`, or `stimulus`.
+4. After analysis, the class appears in the left palette and in **Nodes → Node catalog**. Drag it onto the canvas.
+
+Stage names in [NODE_CREATION_GUIDE.md](NODE_CREATION_GUIDE.md) are not the same as GUI folders. Map `neuron` / `population` / `synapse` / `connectivity` to category **`network`**; other stages use the matching folder name. See [hackathon/AGENTS.md](hackathon/AGENTS.md).
+
+### Manual — place an existing type on the canvas
+
+Open a project, then drag from the left palette (search by name). There is no header “Add Node” button.
+
+### Manual — Python library (admin sync)
+
+Put the file under [`src/neuroworkflow/nodes/<category>/`](src/neuroworkflow/nodes/). Administrators copy it to [`gui/workflow_backend/django-project/codes/nodes/`](gui/workflow_backend/django-project/codes/nodes/) (see Important Setup Notes above). This is not the same path as GUI upload.
+
+### Agent — in-app assistant
+
+The canvas AI Assistant talks to the MCP server ([`gui/mcp_server/workflow_mcp.py`](gui/mcp_server/workflow_mcp.py)):
+
+- **New type:** ask it to write a `Node` class with `NODE_DEFINITION` and upload it. That uses MCP `upload_python_file` (same `POST /api/box/upload/` as the Upload page). Say the **category**. The default chat prompt does not advertise this tool, so you must ask explicitly.
+- **Existing type on this workflow:** ask it to add the class by name. That uses MCP `add_node`, which looks up definitions already returned by `list_nodes_definitions` (`GET /api/box/uploaded-nodes/`).
+
+### Agent — Claude Code / local skill
+
+From the Preview curl commands (or [hackathon/SETUP.md](hackathon/SETUP.md) / [hackathon/README.md](hackathon/README.md)):
+
+1. Install the [create-node skill](.claude/skills/create-node/SKILL.md) and [NODE_CREATION_GUIDE.md](NODE_CREATION_GUIDE.md).
+2. Run `/create-node` (or the Codex equivalent). Files land in the folder the skill chooses (`my_nodes/`, `src/neuroworkflow/nodes/sandbox/`, or `./nodes/`).
+3. Run `python hackathon/check_node.py` on the generated file.
+4. **Still upload** the `.py` in the GUI (**Nodes → Upload**) or ask the in-app assistant to `upload_python_file`. The skill does not register the node in the web app by itself.
 
 ---
 
@@ -211,4 +277,4 @@ Neuro-Workflow is currently under preparation for publication. If you use it in 
 
 ## License
 
-This project is licensed under the [PolyForm Noncommercial License 1.0.0](https://polyformproject.org/licenses/noncommercial/1.0.0) — free for research and non-commercial use. See the LICENSE file for details.
+This project is licensed under the [PolyForm Noncommercial License 1.0.0](https://polyformproject.org/licenses/noncommercial/1.0.0) — free for research and non-commercial use. See the [LICENSE](LICENSE) file for details.

--- a/deployment/task11-docs-catalog-progress.log
+++ b/deployment/task11-docs-catalog-progress.log
@@ -197,3 +197,150 @@ pnpm-lock.yaml left uncommitted (install churn; vitest already in
 package.json).
 
 ================================================================================
+
+## Audit follow-up — plan match + production hardening (PR #93)
+
+Date: 2026-09-02
+Worktree: /home/nw-kirill/neuro-workflow-docs-catalog
+Branch: feat/docs-node-catalog
+PR: https://github.com/oist/neuro-workflow/pull/93
+Original plan: docs_node_catalog_92a9aca9 (not rewritten)
+This pass: task_11_production_audit_3bc9bc01
+
+Architecture match vs original plan
+-----------------------------------
+Delivered:
+- Root README relative markdown links (Jeanne 404).
+- Top-level Installation linking to gui/README.md (Kenji).
+- Add a node (manual GUI / Python / in-app MCP / Claude skill).
+- In-app Node catalog drawer on GET /api/box/uploaded-nodes/
+  (name, category, ports, parameters, description). No new endpoint.
+- Header Nodes → Node catalog + palette book icon.
+- Upload and nodeDetailModal unchanged.
+- Dataset Catalog not invented on origin/main.
+- DEPLOY_APP_SERVER.md not on origin/main; gui/README does not 404-link it.
+
+Non-goals kept:
+- NODE_CATALOG.md, Fuse.js, rename Catalog, merge/deploy, /data writes.
+
+Findings to harden (this pass)
+------------------------------
+1. Drawer always mounted → useUploadedNodes on every authenticated page
+   (HomeView already fetches; catalog adds a second GET that writes
+   .settings). Fetch only while drawer is open.
+2. DrawerOverlay zIndex 1500; DrawerContent zIndex ignored in Chakra v2
+   unless containerProps. Overlay can sit above the panel. Remove custom
+   zIndex; use theme modal (1400) above chat (1010).
+3. nodeKey uses category-local list index; lookup uses visible-flat index.
+   Use node.id or class_name::file_name (no index).
+4. pnpm/tsc cannot resolve zustand and @chakra-ui/theme-tools (already
+   imported; Docker npm hoists them). Declare as direct deps; update
+   package-lock.json via npm.
+5. List rows lack type=button / aria-current; no initialFocusRef; missing
+   schema shown as empty ports instead of parse-stub copy.
+6. Tests omit port-type match and stable key. gui/env.template lacks
+   BIND_HOST comment (users cp that file).
+
+Law for this pass: same worktree/PR; append-only log; no merge; no live
+deploy; no UploadedNodesView GET change; no Fuse.js; no dataset Catalog
+nav; no DEPLOY_APP_SERVER.md.
+
+================================================================================
+
+## Audit Step 1 — Append audit header to the progress log
+
+Done. Header appended above. No code changes.
+
+Verify: Steps 1–10 of the original implementation log are unchanged.
+This file grew. Pass.
+
+================================================================================
+
+## Audit Step 3 — Stable selection keys; Chakra stacking
+
+Done.
+- Exported nodeCatalogKey(node): node.id or `${class_name}::${file_name}`
+  (no list index). Drawer uses it for React keys, selected state, and
+  detail lookup.
+- Removed zIndex={1500} from DrawerOverlay and DrawerContent. Theme
+  modal (1400) sits above chat (1010).
+
+Verify: no numeric zIndex in nodeCatalog/; nodeCatalogKey used for list
+and detail. Pass.
+
+================================================================================
+
+## Audit Step 2 — Fetch node types only when the catalog is open
+
+Done.
+- useUploadedNodes(options?: { enabled?: boolean }), default enabled true.
+  Effect skipped when enabled is false. Last payload is kept (no clear on
+  disable). Debug console.log removed from the fetch.
+- NodeCatalogDrawer: useUploadedNodes({ enabled: isOpen }).
+- HomeView still calls useUploadedNodes() with default enabled (canvas
+  palette unchanged).
+- UploadedNodesView GET not changed. No second node-list API.
+
+Verify: HomeView fetch path unchanged; drawer fetch gated on isOpen. Pass.
+
+================================================================================
+
+## Audit Step 4 — Drawer completeness (a11y + parse stubs)
+
+Done.
+- List rows: type="button", aria-current="true" on the selected row.
+- Drawer initialFocusRef on the live search Input.
+- Missing/null schema: "Schema was not parsed for this file." Name and
+  category still shown. Empty port lists still say None when schema exists.
+- No drag-from-catalog. nodeDetailModal unchanged.
+
+Verify: no TODO/TBD in nodeCatalog/ except the search Input placeholder.
+Pass.
+
+================================================================================
+
+## Audit Step 5 — Declare imports the app already uses
+
+Done.
+- package.json direct deps: zustand ^5.0.13, @chakra-ui/theme-tools ^2.2.9
+- npm install --no-fund --no-audit (exit 0). Registry reachable.
+- package-lock.json packages[""].dependencies lists both. node_modules
+  has zustand 5.0.13 and @chakra-ui/theme-tools 2.2.9.
+- Fuse.js not added. pnpm-lock.yaml not committed (pre-existing dirty).
+- Lockfile also dropped some libc metadata and unmarked zustand as
+  peer-only (npm install side-effect; no version bumps).
+
+Verify: both packages listed at app root. Pass.
+
+================================================================================
+
+## Audit Step 6 — Tests + BIND_HOST on the template people copy
+
+Done.
+- nodeCatalogSearch.test.ts: match by port type (float); nodeCatalogKey
+  without index; missing-schema node still listed on empty query.
+- gui/env.template: commented BIND_HOST=0.0.0.0 (same intent as
+  gui/.env.example). gui/README BIND_HOST section unchanged.
+
+Verify: tests run in Audit Step 7 with npm/pnpm test.
+
+================================================================================
+
+## Audit Step 7 — Isolated verification
+
+Worktree only. No live compose. No /data writes.
+
+- npm test (vitest run) in gui/workflow_frontend: PASS, 11 tests
+  (nodeCatalogSearch.test.ts)
+- npm run build (tsc -b && vite build): PASS. zustand and
+  @chakra-ui/theme-tools resolve. Vite chunk-size warning only
+  (pre-existing).
+- Linked README/gui README paths exist (gui/README.md, NODE_SCHEMA.md,
+  CUSTOM_NODE_TUTORIAL.md, NODE_CREATION_GUIDE.md, CustomNodeTemplate.py,
+  create-node skill, hackathon/*, gui/mcp_server/workflow_mcp.py, three
+  env templates).
+- nodeCatalog/: no TODO/TBD except search Input placeholder; no zIndex=.
+
+Pass.
+
+================================================================================

--- a/deployment/task11-docs-catalog-progress.log
+++ b/deployment/task11-docs-catalog-progress.log
@@ -1,0 +1,140 @@
+================================================================================
+Task 11 progress log (append-only)
+Created: 2026-09-02
+================================================================================
+
+Task
+----
+Task 11 (tasks.csv row 11): Docs 404 / weak GitHub README / no in-app node catalog
+Who: Jeanne, Kenji
+Interpretation: Broken link …/neuro-workflowREADME.md; missing install + add-node
+steps; users want a node glossary in the UI.
+How to implement (short): Fix README links; add Install → gui/README.md; add
+“Add a node (manual / agent)” section; in-app Node catalog drawer (name,
+category, ports, short description from schema).
+
+Worktree
+--------
+Path:   /home/nw-kirill/neuro-workflow-docs-catalog
+Branch: feat/docs-node-catalog
+Source: /home/nw-kirill/neuro-workflow-catalog (origin/main)
+
+Decisions
+---------
+- GitHub PR only
+- No live deploy
+- No /data writes
+- No new backend endpoint
+
+Non-goals
+---------
+- NODE_CATALOG.md static file
+- Renaming dataset Catalog
+- Fuse.js
+- Merge/deploy
+
+Integrity (do not change)
+-------------------------
+- uploaded-nodes GET
+- palette drag
+- nodeDetailModal
+- dataset /catalog
+
+================================================================================
+
+## Step 1 — Worktree and progress log
+
+Done. Worktree already existed at /home/nw-kirill/neuro-workflow-docs-catalog
+on feat/docs-node-catalog from origin/main (created via
+/home/nw-kirill/neuro-workflow-catalog).
+
+Verify:
+- git status -sb: ## feat/docs-node-catalog...origin/main
+  (untracked: this log file)
+- git log -1 --oneline: e1218777 Merge pull request #87 from oist/feat/node-figure-display
+- Log file created (this file). Pass.
+
+Note: origin/main at this commit has no dataset /catalog route or header
+Catalog button (that lives on feat/catalog-search). Node catalog is added
+under Nodes without introducing a dataset Catalog nav item.
+
+================================================================================
+
+## Step 2 — Root README: real links + Installation
+
+Done. README.md:
+- Converted NODE_SCHEMA.md, CUSTOM_NODE_TUTORIAL.md, CustomNodeTemplate.py,
+  NODE_CREATION_GUIDE.md, create-node skill, example/notebook paths, node
+  sync paths, and LICENSE to GitHub-relative markdown links.
+- Added top-level ## Installation with Python library (pip + extras) and
+  Web application (link to gui/README.md). Removed the nested
+  #### Installation that only backtick-cited gui/README.md.
+- Added ### In the GUI pointing at Nodes → Node catalog.
+
+Verify: no remaining `See \`gui/README.md\`` citations. Relative links
+resolve to blob/main/... not .../neuro-workflowREADME.md. Pass.
+
+================================================================================
+
+## Step 3 — Complete gui/README.md
+
+Done. Replaced the 38-line recipe with a full local-install guide:
+prerequisites, three env templates (names only, no secrets), BIND_HOST
+for 127.0.0.1 vs 0.0.0.0 vs production localhost, NEST image build,
+docker compose from gui/, URLs including MCP :8001 and Keycloak :8080,
+Node catalog vs dataset Catalog, link to root Add a node.
+
+DEPLOY_APP_SERVER.md is not on origin/main, so it is not linked (would
+be a 404). Production note: keep Docker ports on localhost behind a
+host reverse proxy.
+
+Verify: no TBD/placeholder sections. Linked templates exist. Pass.
+
+================================================================================
+
+## Step 4 — README section “Add a node (manual / agent)”
+
+Done. Root README section covers:
+- Manual GUI upload (/box/upload, categories, check_node.py)
+- Place on canvas (drag palette)
+- Python library + admin sync
+- In-app MCP upload_python_file / add_node
+- Claude skill + still upload in GUI
+- Links to NODE_CREATION_GUIDE.md, CUSTOM_NODE_TUTORIAL.md,
+  hackathon/README.md, hackathon/AGENTS.md, workflow_mcp.py
+
+Verify: every path exists on this worktree. Pass.
+
+================================================================================
+
+## Step 5 — Catalog search module + vitest
+
+Added:
+- gui/workflow_frontend/src/views/home/nodeCatalog/nodeCatalogSearch.ts
+- gui/workflow_frontend/src/views/home/nodeCatalog/nodeCatalogSearch.test.ts
+- gui/workflow_frontend/vitest.config.ts (origin/main had none)
+- "test": "vitest run" in package.json
+
+Tests cover: empty query sort, label match, input port name, description,
+category filter, unique categories, optional===false required, default format.
+
+Verify in Step 8 (pnpm test).
+
+================================================================================
+
+## Step 6 — Node catalog drawer
+
+Added NodeCatalogContext + NodeCatalogDrawer (right, size xl, live search,
+category filter, master-detail, inputs/outputs/parameters from schema).
+No new API; uses GET /api/box/uploaded-nodes/ via useUploadedNodes.
+Drawer mounted from router under NodeCatalogProvider.
+
+================================================================================
+
+## Step 7 — Wire Header + palette
+
+Header Nodes menu: Node catalog (opens drawer) + existing Upload.
+Palette: FiBookOpen in panel header and per-card (opens focused type).
+Edit (nodeDetailModal) unchanged. No dataset Catalog nav item on origin/main.
+
+================================================================================

--- a/deployment/task11-docs-catalog-progress.log
+++ b/deployment/task11-docs-catalog-progress.log
@@ -344,3 +344,37 @@ Worktree only. No live compose. No /data writes.
 Pass.
 
 ================================================================================
+
+## Audit Step 8 — Commit, push to PR #93, close-out
+
+Commit: b1a39efd2b9fd9705e6abcf296432e47dad324ea
+Message: Keep the node catalog from extra uploaded-nodes fetches and a
+  broken drawer stack
+Branch: feat/docs-node-catalog
+Push: origin feat/docs-node-catalog (5c110748..b1a39efd), no force
+PR: https://github.com/oist/neuro-workflow/pull/93 (updated, not merged)
+
+Files in that commit:
+- gui/workflow_frontend/src/hooks/useUploadedNodes.ts
+- gui/workflow_frontend/src/views/home/nodeCatalog/NodeCatalogDrawer.tsx
+- gui/workflow_frontend/src/views/home/nodeCatalog/nodeCatalogSearch.ts
+- gui/workflow_frontend/src/views/home/nodeCatalog/nodeCatalogSearch.test.ts
+- gui/workflow_frontend/package.json
+- gui/workflow_frontend/package-lock.json
+- gui/env.template
+- deployment/task11-docs-catalog-progress.log
+
+pnpm-lock.yaml left unstaged (install churn).
+
+Verification:
+- npm test: 11 passed
+- npm run build: passed
+
+Not merged. Not deployed. No /data runtime writes.
+
+Remaining risk: live https://neuro-workflow.dbrain.jp/ still serves the
+old frontend until this PR is merged and the app is rebuilt. Node catalog
+will not appear there until then. GET /api/box/uploaded-nodes/ still
+writes .settings; this pass only stops the extra always-on catalog GET.
+
+================================================================================

--- a/deployment/task11-docs-catalog-progress.log
+++ b/deployment/task11-docs-catalog-progress.log
@@ -138,3 +138,62 @@ Palette: FiBookOpen in panel header and per-card (opens focused type).
 Edit (nodeDetailModal) unchanged. No dataset Catalog nav item on origin/main.
 
 ================================================================================
+
+## Step 8 — Isolated verification
+
+Worktree only. pnpm via npx pnpm@9 (system Node 18.19.1).
+
+pnpm test: PASS
+  Test Files  1 passed (1)
+  Tests  8 passed (8)
+  nodeCatalogSearch.test.ts 17ms
+
+pnpm run build (tsc -b && vite build): FAIL on PRE-EXISTING undeclared
+direct deps, not Task 11 files:
+  src/stores/{chat,flow,run,viewer}Store.ts: Cannot find module 'zustand'
+  src/styles/theme.tsx: Cannot find module '@chakra-ui/theme-tools'
+vite build (without tsc): same theme-tools error in theme.tsx.
+Docker/npm hoists these transitives; pnpm does not. Did not add those
+packages (plan: no extra npm deps beyond the vitest test script).
+
+Markdown: all linked files exist (gui/README.md, NODE_SCHEMA.md,
+CUSTOM_NODE_TUTORIAL.md, NODE_CREATION_GUIDE.md, CustomNodeTemplate.py,
+create-node skill, hackathon/check_node.py, hackathon/README.md,
+hackathon/AGENTS.md, gui/mcp_server/workflow_mcp.py).
+
+No live compose. No /data writes.
+
+================================================================================
+
+## Step 9 — Commit, push, open PR
+
+Commit: ec8f7b44f0569ade297f8ea9c71a3f0df7df5134
+Branch: feat/docs-node-catalog
+PR: https://github.com/oist/neuro-workflow/pull/93
+Not merged. Not deployed.
+
+================================================================================
+
+## Step 10 — Close-out
+
+Files changed (this PR):
+- README.md
+- gui/README.md
+- gui/workflow_frontend/src/views/home/nodeCatalog/*
+- gui/workflow_frontend/src/shared/header/header.tsx
+- gui/workflow_frontend/src/router.tsx
+- gui/workflow_frontend/src/views/box/boxView.tsx
+- gui/workflow_frontend/package.json (test script)
+- gui/workflow_frontend/vitest.config.ts
+- gui/workflow_frontend/tsconfig.app.json (exclude *.test.ts)
+- deployment/task11-docs-catalog-progress.log
+
+Remaining risk: live https://neuro-workflow.dbrain.jp/ still serves the
+old frontend until this PR is merged and the app is rebuilt. Node catalog
+will not appear there until then. Dataset Catalog on the live site is from
+unmerged/local catalog work, not origin/main.
+
+pnpm-lock.yaml left uncommitted (install churn; vitest already in
+package.json).
+
+================================================================================

--- a/gui/README.md
+++ b/gui/README.md
@@ -1,36 +1,96 @@
-## Installation
+# Neuro-Workflow web application
 
-Create the Docker image for the NEST JupyterLab environment
+Local install of the Docker Compose stack: React UI, Django API, PostgreSQL, JupyterHub, MCP, and Keycloak. This is the file the root [README](../README.md) **Installation → Web application** section links to.
+
+Do **not** follow [`workflow_backend/README.md`](workflow_backend/README.md) for this stack — that file describes a separate compose tree. Always run Compose from `gui/`.
+
+## Prerequisites
+
+- Git
+- Docker with Compose v2
+- A clone of [oist/neuro-workflow](https://github.com/oist/neuro-workflow)
 
 ```bash
-cd ./gui/workflow_backend/django-project/neuroworkflow
+git clone https://github.com/oist/neuro-workflow.git
+cd neuro-workflow
+```
+
+## Environment files
+
+Copy the three templates. Fill in values; **do not commit** the resulting `.env` files or paste real API keys into git.
+
+| File | Template | Role |
+|---|---|---|
+| `gui/.env` | [`gui/env.template`](env.template) | Compose interpolation (`NODES_DIR`, `HOST_PROJECT_PATH`, `OPENAI_*`, `ANTHROPIC_*`, `JUPYTERHUB_API_TOKEN`) |
+| `gui/workflow_backend/.env` | [`gui/workflow_backend/env.template`](workflow_backend/env.template) | Django, Postgres, Keycloak |
+| `gui/workflow_frontend/.env` | [`gui/workflow_frontend/env.template`](workflow_frontend/env.template) | Vite + browser Keycloak URL |
+
+```bash
+cp gui/env.template gui/.env
+cp gui/workflow_backend/env.template gui/workflow_backend/.env
+cp gui/workflow_frontend/env.template gui/workflow_frontend/.env
+```
+
+Then edit:
+
+- **`HOST_PROJECT_PATH`** — absolute path to `gui/workflow_backend/django-project` on **this** machine.
+- **`NODES_DIR`** — path Compose mounts as the node library (template default: `../src/neuroworkflow/nodes`).
+- **`DJANGO_SECRET_KEY`**, **`DB_PASSWORD`**, **`JUPYTERHUB_API_TOKEN`** — replace template placeholders for anything beyond a throwaway laptop.
+- **`OPENAI_API_KEY` / `ANTHROPIC_API_KEY`** — only if you use the in-app or notebook agents. Leave the placeholders unused rather than committing real keys.
+- **Keycloak** — defaults in the templates (`KEYCLOAK_REALM=neuroworkflow`, `KEYCLOAK_CLIENT_ID=neuroworkflow-app`, `VITE_KEYCLOAK_URL=http://localhost:8080/auth`) are correct for this local compose file.
+
+### `BIND_HOST` (port publish)
+
+Compose publishes service ports as `${BIND_HOST:-127.0.0.1}:<port>`. Set this in **`gui/.env`** (Compose reads `gui/.env` for interpolation):
+
+- **Local laptop, browser on the same machine:** leave unset (binds `127.0.0.1`).
+- **Local laptop, browser on another host on your LAN:** `BIND_HOST=0.0.0.0`.
+- **Production behind nginx:** leave the default `127.0.0.1`. Publishing Docker ports on `0.0.0.0` on a public app server bypasses the host firewall. Do not do that.
+
+`BIND_HOST` is documented in [`workflow_backend/env.template`](workflow_backend/env.template); Compose interpolates the value from `gui/.env`.
+
+## NEST Jupyter image
+
+Build the NEST JupyterLab image used by JupyterHub:
+
+```bash
+cd gui/workflow_backend/django-project/neuroworkflow
 docker build -t nest-jupyterlab -f Dockerfile.nest .
+cd ../../..
 ```
 
-Edit the .env files to set environment variables.
-rename env.template to .env and set environment variables
-
-**`gui/.env`** — Docker Compose level:
-| Variable | Description |
-|---|---|
-| `NODES_DIR` | Path to the nodes directory (`./workflow_backend/django-project/codes/nodes`) |
-| `HOST_PROJECT_PATH` | Absolute path to `gui/workflow_backend/django-project` on the host machine |
-
-Add 2 more .env files based on the templates.
-
-- ./gui/workflow_backend/.env
-- ./gui/workflow_frontend/.env
-
-Start the Docker containers using docker-compose
+## Start the stack
 
 ```bash
-cd ./gui
-docker-compose build
-docker-compose up
+cd gui
+docker compose build
+docker compose up
 ```
 
-Open your web browser
+(`docker-compose` as a hyphenated command also works if that is what you have installed.)
 
-```
-http://localhost:5173
-```
+## URLs (local)
+
+With the default bind, open these on the same machine:
+
+| Service | URL |
+|---|---|
+| Frontend | http://localhost:5173 |
+| Backend API | http://localhost:3000 |
+| JupyterHub | http://localhost:8000 |
+| MCP | http://localhost:8001 |
+| Keycloak | http://localhost:8080 |
+
+Log in through Keycloak (realm `neuroworkflow`). The frontend uses `onLoad: login-required`. Create a user in the Keycloak admin console if the realm has none.
+
+After login:
+
+- **Nodes → Node catalog** — glossary of workflow node types (name, category, ports, schema description).
+- **Nodes → Upload** — register a new `.py` node type.
+- If a deployment also shows a **Catalog** header link, that is a **dataset** browser (DANDI / CBS / …), not the node glossary.
+
+How to add a node (GUI upload, Python library, in-app agent, Claude skill): root README section **[Add a node (manual / agent)](../README.md#add-a-node-manual--agent)**.
+
+## Production reverse proxy
+
+This file is the **local** Docker install. A public deployment should keep Docker ports on localhost and terminate TLS on a host reverse proxy (SSH / HTTP / HTTPS only). Do not copy a production nginx site into git from this README.

--- a/gui/env.template
+++ b/gui/env.template
@@ -3,6 +3,10 @@ NODES_DIR=../src/neuroworkflow/nodes
 # Absolute path (add a path to your cloned repository (local folder django-project))
 HOST_PROJECT_PATH=/home/ubuntu/brain/neuro-workflow/gui/workflow_backend/django-project
 
+# Port binding: set to 0.0.0.0 for local dev, leave unset (defaults to
+# 127.0.0.1) on a public app server where nginx is the public entry point.
+# BIND_HOST=0.0.0.0
+
 OPENAI_API_KEY="sk-xxx"
 OPENAI_MODEL="gpt-5-mini"
 # Set to "none" for gpt-5.6 family models (function tools require reasoning

--- a/gui/workflow_frontend/package-lock.json
+++ b/gui/workflow_frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@aspida/fetch": "^1.14.0",
         "@chakra-ui/icons": "^2.2.4",
         "@chakra-ui/react": "^2.8.0",
+        "@chakra-ui/theme-tools": "^2.2.9",
         "@emotion/react": "^11.14.0",
         "@emotion/styled": "^11.14.0",
         "@xyflow/react": "^12.5.5",
@@ -22,7 +23,8 @@
         "react-dom": "19.2.6",
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.5.0",
-        "zundo": "^2.3.0"
+        "zundo": "^2.3.0",
+        "zustand": "^5.0.13"
       },
       "devDependencies": {
         "@aspida/axios": "^1.14.0",
@@ -1424,9 +1426,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1441,9 +1440,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1458,9 +1454,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1475,9 +1468,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1492,9 +1482,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1509,9 +1496,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1526,9 +1510,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1543,9 +1524,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1560,9 +1538,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1577,9 +1552,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1594,9 +1566,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1611,9 +1580,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1628,9 +1594,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -5480,8 +5443,10 @@
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
       "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
-      "extraneous": true,
+      "dev": true,
       "license": "ISC",
+      "optional": true,
+      "peer": true,
       "bin": {
         "yaml": "bin.mjs"
       },
@@ -5528,7 +5493,6 @@
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.13.tgz",
       "integrity": "sha512-efI2tVaVQPqtOh114loML/Z80Y4NP3yc+Ff0fYiZJPauNeWZeIp/bRFD7I9bfmCOYBh/PHxlglQ9+wvlwnPikQ==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12.20.0"
       },

--- a/gui/workflow_frontend/package.json
+++ b/gui/workflow_frontend/package.json
@@ -17,6 +17,7 @@
     "@aspida/fetch": "^1.14.0",
     "@chakra-ui/icons": "^2.2.4",
     "@chakra-ui/react": "^2.8.0",
+    "@chakra-ui/theme-tools": "^2.2.9",
     "@emotion/react": "^11.14.0",
     "@emotion/styled": "^11.14.0",
     "@xyflow/react": "^12.5.5",
@@ -28,7 +29,8 @@
     "react-dom": "19.2.6",
     "react-icons": "^5.5.0",
     "react-router-dom": "^7.5.0",
-    "zundo": "^2.3.0"
+    "zundo": "^2.3.0",
+    "zustand": "^5.0.13"
   },
   "devDependencies": {
     "@aspida/axios": "^1.14.0",

--- a/gui/workflow_frontend/package.json
+++ b/gui/workflow_frontend/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
+    "test": "vitest run",
     "preview": "vite preview",
     "api:build": "aspida --config aspida.config.cjs",
     "api:watch": "aspida --config aspida.config.cjs --watch",

--- a/gui/workflow_frontend/src/hooks/useUploadedNodes.ts
+++ b/gui/workflow_frontend/src/hooks/useUploadedNodes.ts
@@ -39,17 +39,24 @@ interface UseUploadedNodesReturn {
   refetch: () => Promise<void>;
 }
 
+interface UseUploadedNodesOptions {
+  enabled?: boolean;
+}
+
 /**
  * A custom hook to get the list of uploaded nodes
  */
-export const useUploadedNodes = (): UseUploadedNodesReturn => {
+export const useUploadedNodes = (
+  options?: UseUploadedNodesOptions
+): UseUploadedNodesReturn => {
+  const enabled = options?.enabled ?? true;
   const { user, loading: authLoading } = useAuth();
   const [data, setData] = useState<UploadedNodesResponse | null>(null);
-  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [isLoading, setIsLoading] = useState<boolean>(enabled);
   const [error, setError] = useState<string | null>(null);
 
   const fetchUploadedNodes = useCallback(async () => {
-    if (authLoading) {
+    if (!enabled || authLoading) {
       return;
     }
 
@@ -80,8 +87,6 @@ export const useUploadedNodes = (): UseUploadedNodesReturn => {
 
       const result: UploadedNodesResponse = await response.json();
 
-      console.log("This is response data", result);
-
       setData(result);
     } catch (err) {
       console.error("Failed to fetch uploaded nodes:", err);
@@ -90,11 +95,14 @@ export const useUploadedNodes = (): UseUploadedNodesReturn => {
     } finally {
       setIsLoading(false);
     }
-  }, [authLoading, user]);
+  }, [authLoading, user, enabled]);
 
   useEffect(() => {
+    if (!enabled) {
+      return;
+    }
     void fetchUploadedNodes();
-  }, [fetchUploadedNodes]);
+  }, [fetchUploadedNodes, enabled]);
 
   return {
     data,

--- a/gui/workflow_frontend/src/router.tsx
+++ b/gui/workflow_frontend/src/router.tsx
@@ -6,6 +6,8 @@ import ProtectedRoute from './protectedRoute';
 import { AuthProvider } from './auth/authContext';
 import ReAuthGate from './auth/ReAuthGate';
 import TabManager from './components/tabs/TabManager';
+import { NodeCatalogProvider } from './views/home/nodeCatalog/NodeCatalogContext';
+import NodeCatalogDrawer from './views/home/nodeCatalog/NodeCatalogDrawer';
 
 function Router() {
   return (
@@ -21,14 +23,17 @@ function Router() {
             path="/*"
             element={
               <ProtectedRoute>
-                <Flex direction="column" h="100vh" overflow="hidden">
-                  <Box flexShrink={0}>
-                    <Header />
-                  </Box>
-                  <Box flex="1" minH="0" overflow="hidden" display="flex" flexDirection="column">
-                    <TabManager />
-                  </Box>
-                </Flex>
+                <NodeCatalogProvider>
+                  <Flex direction="column" h="100vh" overflow="hidden">
+                    <Box flexShrink={0}>
+                      <Header />
+                    </Box>
+                    <Box flex="1" minH="0" overflow="hidden" display="flex" flexDirection="column">
+                      <TabManager />
+                    </Box>
+                  </Flex>
+                  <NodeCatalogDrawer />
+                </NodeCatalogProvider>
               </ProtectedRoute>
             }
           />

--- a/gui/workflow_frontend/src/shared/header/header.tsx
+++ b/gui/workflow_frontend/src/shared/header/header.tsx
@@ -20,9 +20,11 @@ import {
 import { Link as RouterLink } from 'react-router-dom'
 import { ChevronDownIcon, MoonIcon, SunIcon } from '@chakra-ui/icons'
 import { useAuth } from '../../auth/authContext'
+import { useNodeCatalog } from '../../views/home/nodeCatalog/NodeCatalogContext'
 
 const Header: React.FC = () => {
   const { user, signOut } = useAuth();
+  const { open: openNodeCatalog } = useNodeCatalog();
   const toast = useToast();
   const { colorMode, toggleColorMode } = useColorMode();
 
@@ -158,6 +160,14 @@ const Header: React.FC = () => {
             Nodes
           </MenuButton>
           <MenuList bg={menuBg} borderColor={menuBorder}>
+            <MenuItem
+              bg={menuBg}
+              color={headerColor}
+              _hover={{ bg: menuHoverBg }}
+              onClick={() => openNodeCatalog()}
+            >
+              Node catalog
+            </MenuItem>
             <MenuItem
               as={RouterLink}
               to="/box/upload"

--- a/gui/workflow_frontend/src/views/box/boxView.tsx
+++ b/gui/workflow_frontend/src/views/box/boxView.tsx
@@ -36,11 +36,12 @@ import {
 } from '@chakra-ui/react';
 import { useEffect, useState, useRef } from 'react';
 import { IconType } from 'react-icons';
-import { FiBox, FiCopy, FiTrash2, FiEdit2, FiCode, FiRefreshCw, FiChevronDown, FiChevronRight, FiMenu } from 'react-icons/fi'; // Use as default icon
+import { FiBox, FiCopy, FiTrash2, FiEdit2, FiCode, FiRefreshCw, FiChevronDown, FiChevronRight, FiMenu, FiBookOpen } from 'react-icons/fi'; // Use as default icon
 import { SchemaFields } from '../home/type';
 import { createAuthHeaders } from '../../api/authHeaders';
 import { JUPYTER_BASE_URL } from '../../config/urls';
 import { useTabContext } from '../../components/tabs/TabManager';
+import { useNodeCatalog } from '../home/nodeCatalog/NodeCatalogContext';
 
 interface SidebarProps {
   nodes: UploadedNodesResponse | null;
@@ -103,6 +104,7 @@ const SideBoxArea: React.FC<SidebarProps> = ({ nodes, isLoading = false, error, 
 
   // Use the tab system context
   const { addJupyterTab } = useTabContext();
+  const { open: openNodeCatalog } = useNodeCatalog();
 
   const bg = useColorModeValue('white', 'gray.800');
   const panelBg = useColorModeValue('#f7f7f8', 'gray.900');
@@ -594,6 +596,29 @@ const SideBoxArea: React.FC<SidebarProps> = ({ nodes, isLoading = false, error, 
                     </Text>
                   )}
                   <Tooltip
+                    label="Node catalog — name, category, ports, description"
+                    hasArrow
+                    placement="bottom"
+                    bg={tooltipBg}
+                    color="white"
+                    fontSize="sm"
+                  >
+                    <IconButton
+                      position="absolute"
+                      right="36px"
+                      aria-label="Open node catalog"
+                      icon={<Icon as={FiBookOpen} />}
+                      size="sm"
+                      colorScheme="blue"
+                      variant="ghost"
+                      onClick={() => openNodeCatalog()}
+                      _hover={{
+                        bg: "blue.600",
+                        color: "white"
+                      }}
+                    />
+                  </Tooltip>
+                  <Tooltip
                     label="Node Refresh - Sync node data from server"
                     hasArrow
                     placement="bottom"
@@ -820,6 +845,30 @@ const SideBoxArea: React.FC<SidebarProps> = ({ nodes, isLoading = false, error, 
                                         e.preventDefault();
                                         //onViewCode?.(node);
                                         OpenJupyter(node.file_name, node.category);
+                                      }}
+                                      onMouseDown={(e) => {
+                                        e.stopPropagation();
+                                      }}
+                                      onDragStart={(e) => {
+                                        e.stopPropagation();
+                                        e.preventDefault();
+                                      }}
+                                      draggable={false}
+                                    />
+                                    <IconButton
+                                      aria-label="Open in node catalog"
+                                      icon={<FiBookOpen />}
+                                      size="xs"
+                                      variant="ghost"
+                                      color={subtextColor}
+                                      _hover={{
+                                        color: "teal.300",
+                                        bg: "teal.700"
+                                      }}
+                                      onClick={(e) => {
+                                        e.stopPropagation();
+                                        e.preventDefault();
+                                        openNodeCatalog(node.id);
                                       }}
                                       onMouseDown={(e) => {
                                         e.stopPropagation();

--- a/gui/workflow_frontend/src/views/home/nodeCatalog/NodeCatalogContext.tsx
+++ b/gui/workflow_frontend/src/views/home/nodeCatalog/NodeCatalogContext.tsx
@@ -1,0 +1,47 @@
+import React, { createContext, useCallback, useContext, useMemo, useState } from "react";
+
+type NodeCatalogContextValue = {
+  isOpen: boolean;
+  initialNodeId: string | null;
+  open: (nodeId?: string) => void;
+  close: () => void;
+};
+
+const NodeCatalogContext = createContext<NodeCatalogContextValue | undefined>(
+  undefined
+);
+
+export const useNodeCatalog = (): NodeCatalogContextValue => {
+  const value = useContext(NodeCatalogContext);
+  if (!value) {
+    throw new Error("useNodeCatalog must be used within NodeCatalogProvider");
+  }
+  return value;
+};
+
+export const NodeCatalogProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [isOpen, setIsOpen] = useState(false);
+  const [initialNodeId, setInitialNodeId] = useState<string | null>(null);
+
+  const open = useCallback((nodeId?: string) => {
+    setInitialNodeId(nodeId ?? null);
+    setIsOpen(true);
+  }, []);
+
+  const close = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  const value = useMemo(
+    () => ({ isOpen, initialNodeId, open, close }),
+    [isOpen, initialNodeId, open, close]
+  );
+
+  return (
+    <NodeCatalogContext.Provider value={value}>
+      {children}
+    </NodeCatalogContext.Provider>
+  );
+};

--- a/gui/workflow_frontend/src/views/home/nodeCatalog/NodeCatalogDrawer.tsx
+++ b/gui/workflow_frontend/src/views/home/nodeCatalog/NodeCatalogDrawer.tsx
@@ -1,0 +1,379 @@
+import React, { useEffect, useMemo, useState } from "react";
+import {
+  Alert,
+  AlertIcon,
+  Badge,
+  Box,
+  Drawer,
+  DrawerBody,
+  DrawerCloseButton,
+  DrawerContent,
+  DrawerHeader,
+  DrawerOverlay,
+  Flex,
+  Heading,
+  HStack,
+  Input,
+  InputGroup,
+  InputLeftElement,
+  Select,
+  Spinner,
+  Text,
+  useColorModeValue,
+  VStack,
+} from "@chakra-ui/react";
+import { SearchIcon } from "@chakra-ui/icons";
+import { useUploadedNodes } from "../../../hooks/useUploadedNodes";
+import { useNodeCatalog } from "./NodeCatalogContext";
+import {
+  filterNodeCatalog,
+  formatParamDefault,
+  groupNodesByCategory,
+  isPortRequired,
+  uniqueCatalogCategories,
+  type CatalogNode,
+} from "./nodeCatalogSearch";
+import type { InputField, OutputField, ParameterField } from "../type";
+
+function nodeKey(node: CatalogNode, index: number): string {
+  return node.id || `${node.class_name}-${node.file_name}-${index}`;
+}
+
+const SectionLabel: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const muted = useColorModeValue("gray.500", "gray.400");
+  return (
+    <Text
+      fontSize="xs"
+      textTransform="uppercase"
+      letterSpacing="0.04em"
+      color={muted}
+      mb={2}
+      fontWeight="semibold"
+    >
+      {children}
+    </Text>
+  );
+};
+
+const PortRow: React.FC<{
+  name: string;
+  field: InputField | OutputField;
+}> = ({ name, field }) => {
+  const muted = useColorModeValue("gray.500", "gray.400");
+  const required = isPortRequired(field);
+  return (
+    <Box py={2} borderBottomWidth="1px" borderColor={useColorModeValue("#eee", "gray.700")}>
+      <HStack spacing={2} align="center" flexWrap="wrap">
+        <Text fontWeight="semibold" fontSize="sm">
+          {name}
+        </Text>
+        {field.type && (
+          <Badge fontFamily="mono" fontSize="xs" variant="subtle" colorScheme="blue">
+            {field.type}
+          </Badge>
+        )}
+        {required && (
+          <Badge fontSize="xs" colorScheme="orange">
+            required
+          </Badge>
+        )}
+      </HStack>
+      {field.description ? (
+        <Text fontSize="sm" color={muted} mt={1}>
+          {field.description}
+        </Text>
+      ) : null}
+    </Box>
+  );
+};
+
+const ParamRow: React.FC<{ name: string; field: ParameterField }> = ({
+  name,
+  field,
+}) => {
+  const muted = useColorModeValue("gray.500", "gray.400");
+  const defaultText = formatParamDefault(field.default_value);
+  return (
+    <Box py={2} borderBottomWidth="1px" borderColor={useColorModeValue("#eee", "gray.700")}>
+      <HStack spacing={2} align="center" flexWrap="wrap">
+        <Text fontWeight="semibold" fontSize="sm">
+          {name}
+        </Text>
+        {field.type && (
+          <Badge fontFamily="mono" fontSize="xs" variant="subtle" colorScheme="purple">
+            {field.type}
+          </Badge>
+        )}
+      </HStack>
+      {field.description ? (
+        <Text fontSize="sm" color={muted} mt={1}>
+          {field.description}
+        </Text>
+      ) : null}
+      {defaultText !== null && (
+        <Text fontSize="xs" color={muted} mt={1} fontFamily="mono">
+          default: {defaultText}
+        </Text>
+      )}
+    </Box>
+  );
+};
+
+const NodeDetail: React.FC<{ node: CatalogNode }> = ({ node }) => {
+  const muted = useColorModeValue("gray.500", "gray.400");
+  const inputs = Object.entries(node.schema?.inputs ?? {});
+  const outputs = Object.entries(node.schema?.outputs ?? {});
+  const parameters = Object.entries(node.schema?.parameters ?? {});
+
+  return (
+    <VStack align="stretch" spacing={5}>
+      <Box>
+        <Heading size="sm">{node.label}</Heading>
+        <HStack mt={2} spacing={2} flexWrap="wrap">
+          {node.category && <Badge colorScheme="blue">{node.category}</Badge>}
+          {node.class_name && node.class_name !== node.label && (
+            <Badge variant="outline">{node.class_name}</Badge>
+          )}
+        </HStack>
+        {node.file_name && (
+          <Text fontSize="xs" color={muted} mt={2} fontFamily="mono">
+            {node.file_name}
+          </Text>
+        )}
+      </Box>
+      {node.description ? (
+        <Box>
+          <SectionLabel>Description</SectionLabel>
+          <Text whiteSpace="pre-wrap">{node.description}</Text>
+        </Box>
+      ) : null}
+      <Box>
+        <SectionLabel>Inputs ({inputs.length})</SectionLabel>
+        {inputs.length === 0 ? (
+          <Text fontSize="sm" color={muted}>
+            None
+          </Text>
+        ) : (
+          inputs.map(([name, field]) => (
+            <PortRow key={`in-${name}`} name={name} field={field} />
+          ))
+        )}
+      </Box>
+      <Box>
+        <SectionLabel>Outputs ({outputs.length})</SectionLabel>
+        {outputs.length === 0 ? (
+          <Text fontSize="sm" color={muted}>
+            None
+          </Text>
+        ) : (
+          outputs.map(([name, field]) => (
+            <PortRow key={`out-${name}`} name={name} field={field} />
+          ))
+        )}
+      </Box>
+      <Box>
+        <SectionLabel>Parameters ({parameters.length})</SectionLabel>
+        {parameters.length === 0 ? (
+          <Text fontSize="sm" color={muted}>
+            None
+          </Text>
+        ) : (
+          parameters.map(([name, field]) => (
+            <ParamRow key={`p-${name}`} name={name} field={field} />
+          ))
+        )}
+      </Box>
+    </VStack>
+  );
+};
+
+const NodeCatalogDrawer: React.FC = () => {
+  const { isOpen, close, initialNodeId } = useNodeCatalog();
+  const { data, isLoading, error } = useUploadedNodes();
+  const [query, setQuery] = useState("");
+  const [category, setCategory] = useState("all");
+  const [selectedKey, setSelectedKey] = useState<string | null>(null);
+
+  const cardBg = useColorModeValue("white", "gray.800");
+  const borderColor = useColorModeValue("#e5e5e5", "gray.700");
+  const muted = useColorModeValue("gray.500", "gray.400");
+  const hoverBg = useColorModeValue("#f5f5f5", "gray.700");
+  const selectedBg = useColorModeValue("blue.50", "gray.700");
+  const listBg = useColorModeValue("#f7f7f8", "gray.900");
+
+  const nodes = (data?.nodes ?? []) as CatalogNode[];
+  const categories = useMemo(() => uniqueCatalogCategories(nodes), [nodes]);
+  const visible = useMemo(
+    () => filterNodeCatalog(nodes, query, category),
+    [nodes, query, category]
+  );
+  const grouped = useMemo(() => groupNodesByCategory(visible), [visible]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    if (initialNodeId) {
+      setSelectedKey(initialNodeId);
+      const match = nodes.find((n) => n.id === initialNodeId);
+      if (match?.category) {
+        setCategory("all");
+        setQuery("");
+      }
+      return;
+    }
+    if (!selectedKey && visible.length > 0) {
+      setSelectedKey(nodeKey(visible[0], 0));
+    }
+  }, [isOpen, initialNodeId, nodes, selectedKey, visible]);
+
+  const selected = useMemo(() => {
+    if (!selectedKey) {
+      return visible[0] ?? null;
+    }
+    return (
+      visible.find((n, i) => nodeKey(n, i) === selectedKey) ||
+      nodes.find((n) => n.id === selectedKey) ||
+      null
+    );
+  }, [selectedKey, visible, nodes]);
+
+  return (
+    <Drawer
+      isOpen={isOpen}
+      placement="right"
+      onClose={close}
+      size="xl"
+      autoFocus
+    >
+      <DrawerOverlay zIndex={1500} />
+      <DrawerContent bg={cardBg} zIndex={1500} maxW={{ base: "100vw", md: "900px" }}>
+        <DrawerCloseButton />
+        <DrawerHeader borderBottomWidth="1px" borderColor={borderColor} pr={12}>
+          <Heading size="md">Node catalog</Heading>
+          <Text fontSize="sm" color={muted} fontWeight="normal" mt={1}>
+            Workflow node types: name, category, ports, and schema description.
+            This is not a dataset browser.
+          </Text>
+          <Text fontSize="xs" color={muted} mt={1}>
+            {visible.length} of {nodes.length} types
+          </Text>
+        </DrawerHeader>
+        <DrawerBody p={0}>
+          <Flex direction={{ base: "column", md: "row" }} h="100%">
+            <Box
+              w={{ base: "100%", md: "340px" }}
+              borderRightWidth={{ base: 0, md: "1px" }}
+              borderColor={borderColor}
+              bg={listBg}
+              display="flex"
+              flexDirection="column"
+              minH={{ base: "240px", md: "100%" }}
+            >
+              <Box p={3} borderBottomWidth="1px" borderColor={borderColor}>
+                <InputGroup size="sm" mb={2}>
+                  <InputLeftElement pointerEvents="none">
+                    <SearchIcon color={muted} />
+                  </InputLeftElement>
+                  <Input
+                    placeholder="Search name, description, ports…"
+                    value={query}
+                    onChange={(e) => setQuery(e.target.value)}
+                    bg={cardBg}
+                  />
+                </InputGroup>
+                <Select
+                  size="sm"
+                  value={category}
+                  onChange={(e) => setCategory(e.target.value)}
+                  bg={cardBg}
+                >
+                  <option value="all">All categories</option>
+                  {categories.map((cat) => (
+                    <option key={cat} value={cat}>
+                      {cat}
+                    </option>
+                  ))}
+                </Select>
+              </Box>
+              <Box flex="1" overflowY="auto" p={2}>
+                {isLoading && (
+                  <HStack justify="center" py={8}>
+                    <Spinner size="sm" />
+                    <Text fontSize="sm" color={muted}>
+                      Loading node types…
+                    </Text>
+                  </HStack>
+                )}
+                {error && (
+                  <Alert status="error" borderRadius="md">
+                    <AlertIcon />
+                    {error}
+                  </Alert>
+                )}
+                {!isLoading && !error && visible.length === 0 && (
+                  <Text fontSize="sm" color={muted} p={3}>
+                    {nodes.length === 0
+                      ? "No node types are available for your account."
+                      : "No node types match this search."}
+                  </Text>
+                )}
+                {grouped.map(([cat, catNodes]) => (
+                  <Box key={cat} mb={3}>
+                    <Text
+                      fontSize="xs"
+                      fontWeight="bold"
+                      color={muted}
+                      px={2}
+                      py={1}
+                      textTransform="uppercase"
+                    >
+                      {cat}
+                    </Text>
+                    {catNodes.map((node, index) => {
+                      const key = nodeKey(node, index);
+                      const isSelected = selectedKey === key || selectedKey === node.id;
+                      return (
+                        <Box
+                          key={key}
+                          as="button"
+                          textAlign="left"
+                          w="100%"
+                          px={3}
+                          py={2}
+                          mb={1}
+                          borderRadius="md"
+                          bg={isSelected ? selectedBg : "transparent"}
+                          _hover={{ bg: isSelected ? selectedBg : hoverBg }}
+                          onClick={() => setSelectedKey(node.id || key)}
+                        >
+                          <Text fontSize="sm" fontWeight="semibold" noOfLines={1}>
+                            {node.label}
+                          </Text>
+                          {node.description ? (
+                            <Text fontSize="xs" color={muted} noOfLines={2}>
+                              {node.description}
+                            </Text>
+                          ) : null}
+                        </Box>
+                      );
+                    })}
+                  </Box>
+                ))}
+              </Box>
+            </Box>
+            <Box flex="1" overflowY="auto" p={5}>
+              {!isLoading && selected ? (
+                <NodeDetail node={selected} />
+              ) : !isLoading && !error ? (
+                <Text color={muted}>Select a node type to see ports and parameters.</Text>
+              ) : null}
+            </Box>
+          </Flex>
+        </DrawerBody>
+      </DrawerContent>
+    </Drawer>
+  );
+};
+
+export default NodeCatalogDrawer;

--- a/gui/workflow_frontend/src/views/home/nodeCatalog/NodeCatalogDrawer.tsx
+++ b/gui/workflow_frontend/src/views/home/nodeCatalog/NodeCatalogDrawer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import {
   Alert,
   AlertIcon,
@@ -30,14 +30,11 @@ import {
   formatParamDefault,
   groupNodesByCategory,
   isPortRequired,
+  nodeCatalogKey,
   uniqueCatalogCategories,
   type CatalogNode,
 } from "./nodeCatalogSearch";
 import type { InputField, OutputField, ParameterField } from "../type";
-
-function nodeKey(node: CatalogNode, index: number): string {
-  return node.id || `${node.class_name}-${node.file_name}-${index}`;
-}
 
 const SectionLabel: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const muted = useColorModeValue("gray.500", "gray.400");
@@ -121,6 +118,7 @@ const ParamRow: React.FC<{ name: string; field: ParameterField }> = ({
 
 const NodeDetail: React.FC<{ node: CatalogNode }> = ({ node }) => {
   const muted = useColorModeValue("gray.500", "gray.400");
+  const schemaMissing = node.schema == null;
   const inputs = Object.entries(node.schema?.inputs ?? {});
   const outputs = Object.entries(node.schema?.outputs ?? {});
   const parameters = Object.entries(node.schema?.parameters ?? {});
@@ -147,52 +145,61 @@ const NodeDetail: React.FC<{ node: CatalogNode }> = ({ node }) => {
           <Text whiteSpace="pre-wrap">{node.description}</Text>
         </Box>
       ) : null}
-      <Box>
-        <SectionLabel>Inputs ({inputs.length})</SectionLabel>
-        {inputs.length === 0 ? (
-          <Text fontSize="sm" color={muted}>
-            None
-          </Text>
-        ) : (
-          inputs.map(([name, field]) => (
-            <PortRow key={`in-${name}`} name={name} field={field} />
-          ))
-        )}
-      </Box>
-      <Box>
-        <SectionLabel>Outputs ({outputs.length})</SectionLabel>
-        {outputs.length === 0 ? (
-          <Text fontSize="sm" color={muted}>
-            None
-          </Text>
-        ) : (
-          outputs.map(([name, field]) => (
-            <PortRow key={`out-${name}`} name={name} field={field} />
-          ))
-        )}
-      </Box>
-      <Box>
-        <SectionLabel>Parameters ({parameters.length})</SectionLabel>
-        {parameters.length === 0 ? (
-          <Text fontSize="sm" color={muted}>
-            None
-          </Text>
-        ) : (
-          parameters.map(([name, field]) => (
-            <ParamRow key={`p-${name}`} name={name} field={field} />
-          ))
-        )}
-      </Box>
+      {schemaMissing ? (
+        <Text fontSize="sm" color={muted}>
+          Schema was not parsed for this file.
+        </Text>
+      ) : (
+        <>
+          <Box>
+            <SectionLabel>Inputs ({inputs.length})</SectionLabel>
+            {inputs.length === 0 ? (
+              <Text fontSize="sm" color={muted}>
+                None
+              </Text>
+            ) : (
+              inputs.map(([name, field]) => (
+                <PortRow key={`in-${name}`} name={name} field={field} />
+              ))
+            )}
+          </Box>
+          <Box>
+            <SectionLabel>Outputs ({outputs.length})</SectionLabel>
+            {outputs.length === 0 ? (
+              <Text fontSize="sm" color={muted}>
+                None
+              </Text>
+            ) : (
+              outputs.map(([name, field]) => (
+                <PortRow key={`out-${name}`} name={name} field={field} />
+              ))
+            )}
+          </Box>
+          <Box>
+            <SectionLabel>Parameters ({parameters.length})</SectionLabel>
+            {parameters.length === 0 ? (
+              <Text fontSize="sm" color={muted}>
+                None
+              </Text>
+            ) : (
+              parameters.map(([name, field]) => (
+                <ParamRow key={`p-${name}`} name={name} field={field} />
+              ))
+            )}
+          </Box>
+        </>
+      )}
     </VStack>
   );
 };
 
 const NodeCatalogDrawer: React.FC = () => {
   const { isOpen, close, initialNodeId } = useNodeCatalog();
-  const { data, isLoading, error } = useUploadedNodes();
+  const { data, isLoading, error } = useUploadedNodes({ enabled: isOpen });
   const [query, setQuery] = useState("");
   const [category, setCategory] = useState("all");
   const [selectedKey, setSelectedKey] = useState<string | null>(null);
+  const searchInputRef = useRef<HTMLInputElement>(null);
 
   const cardBg = useColorModeValue("white", "gray.800");
   const borderColor = useColorModeValue("#e5e5e5", "gray.700");
@@ -223,7 +230,7 @@ const NodeCatalogDrawer: React.FC = () => {
       return;
     }
     if (!selectedKey && visible.length > 0) {
-      setSelectedKey(nodeKey(visible[0], 0));
+      setSelectedKey(nodeCatalogKey(visible[0]));
     }
   }, [isOpen, initialNodeId, nodes, selectedKey, visible]);
 
@@ -232,8 +239,8 @@ const NodeCatalogDrawer: React.FC = () => {
       return visible[0] ?? null;
     }
     return (
-      visible.find((n, i) => nodeKey(n, i) === selectedKey) ||
-      nodes.find((n) => n.id === selectedKey) ||
+      visible.find((n) => nodeCatalogKey(n) === selectedKey) ||
+      nodes.find((n) => nodeCatalogKey(n) === selectedKey) ||
       null
     );
   }, [selectedKey, visible, nodes]);
@@ -245,9 +252,10 @@ const NodeCatalogDrawer: React.FC = () => {
       onClose={close}
       size="xl"
       autoFocus
+      initialFocusRef={searchInputRef}
     >
-      <DrawerOverlay zIndex={1500} />
-      <DrawerContent bg={cardBg} zIndex={1500} maxW={{ base: "100vw", md: "900px" }}>
+      <DrawerOverlay />
+      <DrawerContent bg={cardBg} maxW={{ base: "100vw", md: "900px" }}>
         <DrawerCloseButton />
         <DrawerHeader borderBottomWidth="1px" borderColor={borderColor} pr={12}>
           <Heading size="md">Node catalog</Heading>
@@ -276,6 +284,7 @@ const NodeCatalogDrawer: React.FC = () => {
                     <SearchIcon color={muted} />
                   </InputLeftElement>
                   <Input
+                    ref={searchInputRef}
                     placeholder="Search name, description, ports…"
                     value={query}
                     onChange={(e) => setQuery(e.target.value)}
@@ -330,13 +339,15 @@ const NodeCatalogDrawer: React.FC = () => {
                     >
                       {cat}
                     </Text>
-                    {catNodes.map((node, index) => {
-                      const key = nodeKey(node, index);
-                      const isSelected = selectedKey === key || selectedKey === node.id;
+                    {catNodes.map((node) => {
+                      const key = nodeCatalogKey(node);
+                      const isSelected = selectedKey === key;
                       return (
                         <Box
                           key={key}
                           as="button"
+                          type="button"
+                          aria-current={isSelected ? "true" : undefined}
                           textAlign="left"
                           w="100%"
                           px={3}
@@ -345,7 +356,7 @@ const NodeCatalogDrawer: React.FC = () => {
                           borderRadius="md"
                           bg={isSelected ? selectedBg : "transparent"}
                           _hover={{ bg: isSelected ? selectedBg : hoverBg }}
-                          onClick={() => setSelectedKey(node.id || key)}
+                          onClick={() => setSelectedKey(key)}
                         >
                           <Text fontSize="sm" fontWeight="semibold" noOfLines={1}>
                             {node.label}

--- a/gui/workflow_frontend/src/views/home/nodeCatalog/nodeCatalogSearch.test.ts
+++ b/gui/workflow_frontend/src/views/home/nodeCatalog/nodeCatalogSearch.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from "vitest";
+import type { SchemaFields } from "../type";
+import {
+  filterNodeCatalog,
+  formatParamDefault,
+  isPortRequired,
+  uniqueCatalogCategories,
+  type CatalogNode,
+} from "./nodeCatalogSearch";
+
+const schema: SchemaFields = {
+  inputs: {
+    adjacency_matrix: {
+      type: "object",
+      description: "Square connectivity matrix",
+      optional: false,
+    },
+  },
+  outputs: {
+    firing_rate_hz: {
+      type: "float",
+      description: "Mean rate",
+    },
+  },
+  parameters: {
+    n_neurons: {
+      type: "int",
+      description: "Population size",
+      default_value: 100,
+    },
+  },
+  methods: {},
+};
+
+const nodes: CatalogNode[] = [
+  {
+    id: "a",
+    label: "AsperaSharesLoaderNode",
+    description: "Loads mat file from Aspera Shares",
+    category: "I/O",
+    file_name: "AsperaSharesLoaderNode.py",
+    class_name: "AsperaSharesLoaderNode",
+    schema: {
+      inputs: {},
+      outputs: { mat_data: { type: "object", description: "Loaded mat" } },
+      parameters: { remote_path: { type: "string", description: "mat path" } },
+      methods: {},
+    },
+  },
+  {
+    id: "b",
+    label: "NW_Connectivity",
+    description: "Build a structural network",
+    category: "Network",
+    file_name: "NW_Connectivity.py",
+    class_name: "NW_Connectivity",
+    schema,
+  },
+];
+
+describe("filterNodeCatalog", () => {
+  it("returns all nodes sorted by category then label when the query is empty", () => {
+    const result = filterNodeCatalog(nodes, "   ", "all");
+    expect(result.map((n) => n.label)).toEqual([
+      "AsperaSharesLoaderNode",
+      "NW_Connectivity",
+    ]);
+  });
+
+  it("matches by label", () => {
+    const result = filterNodeCatalog(nodes, "aspera");
+    expect(result.map((n) => n.label)).toEqual(["AsperaSharesLoaderNode"]);
+  });
+
+  it("matches by input port name", () => {
+    const result = filterNodeCatalog(nodes, "adjacency_matrix");
+    expect(result.map((n) => n.label)).toEqual(["NW_Connectivity"]);
+  });
+
+  it("matches by description", () => {
+    const result = filterNodeCatalog(nodes, "aspera shares");
+    expect(result.map((n) => n.label)).toEqual(["AsperaSharesLoaderNode"]);
+  });
+
+  it("filters by category equality", () => {
+    const result = filterNodeCatalog(nodes, "", "Network");
+    expect(result.map((n) => n.label)).toEqual(["NW_Connectivity"]);
+  });
+});
+
+describe("uniqueCatalogCategories", () => {
+  it("returns sorted unique categories", () => {
+    expect(uniqueCatalogCategories(nodes)).toEqual(["I/O", "Network"]);
+  });
+});
+
+describe("isPortRequired", () => {
+  it("treats optional === false as required", () => {
+    expect(isPortRequired({ optional: false })).toBe(true);
+    expect(isPortRequired({ optional: true })).toBe(false);
+    expect(isPortRequired({ required: true })).toBe(true);
+  });
+});
+
+describe("formatParamDefault", () => {
+  it("stringifies non-strings", () => {
+    expect(formatParamDefault(100)).toBe("100");
+    expect(formatParamDefault(undefined)).toBeNull();
+    expect(formatParamDefault("hz")).toBe("hz");
+  });
+});

--- a/gui/workflow_frontend/src/views/home/nodeCatalog/nodeCatalogSearch.test.ts
+++ b/gui/workflow_frontend/src/views/home/nodeCatalog/nodeCatalogSearch.test.ts
@@ -4,6 +4,7 @@ import {
   filterNodeCatalog,
   formatParamDefault,
   isPortRequired,
+  nodeCatalogKey,
   uniqueCatalogCategories,
   type CatalogNode,
 } from "./nodeCatalogSearch";
@@ -85,6 +86,42 @@ describe("filterNodeCatalog", () => {
   it("filters by category equality", () => {
     const result = filterNodeCatalog(nodes, "", "Network");
     expect(result.map((n) => n.label)).toEqual(["NW_Connectivity"]);
+  });
+
+  it("matches by port type", () => {
+    const result = filterNodeCatalog(nodes, "float");
+    expect(result.map((n) => n.label)).toEqual(["NW_Connectivity"]);
+  });
+
+  it("still lists nodes with missing schema on empty query", () => {
+    const stub: CatalogNode = {
+      label: "UnparsedNode",
+      description: "Uploaded but not parsed",
+      category: "Analysis",
+      file_name: "UnparsedNode.py",
+      class_name: "UnparsedNode",
+    };
+    const result = filterNodeCatalog([...nodes, stub], "", "all");
+    expect(result.map((n) => n.label)).toEqual([
+      "UnparsedNode",
+      "AsperaSharesLoaderNode",
+      "NW_Connectivity",
+    ]);
+  });
+});
+
+describe("nodeCatalogKey", () => {
+  it("prefers id and otherwise uses class_name::file_name without an index", () => {
+    expect(nodeCatalogKey(nodes[0])).toBe("a");
+    expect(
+      nodeCatalogKey({
+        label: "UnparsedNode",
+        description: "",
+        category: "Analysis",
+        file_name: "UnparsedNode.py",
+        class_name: "UnparsedNode",
+      })
+    ).toBe("UnparsedNode::UnparsedNode.py");
   });
 });
 

--- a/gui/workflow_frontend/src/views/home/nodeCatalog/nodeCatalogSearch.ts
+++ b/gui/workflow_frontend/src/views/home/nodeCatalog/nodeCatalogSearch.ts
@@ -12,6 +12,13 @@ export type CatalogNode = {
 
 const ALL_CATEGORIES = "all";
 
+export function nodeCatalogKey(node: CatalogNode): string {
+  if (node.id) {
+    return node.id;
+  }
+  return `${node.class_name}::${node.file_name}`;
+}
+
 function fieldHaystack(
   name: string,
   field: InputField | OutputField | ParameterField | undefined

--- a/gui/workflow_frontend/src/views/home/nodeCatalog/nodeCatalogSearch.ts
+++ b/gui/workflow_frontend/src/views/home/nodeCatalog/nodeCatalogSearch.ts
@@ -1,0 +1,120 @@
+import type { InputField, OutputField, ParameterField, SchemaFields } from "../type";
+
+export type CatalogNode = {
+  id?: string;
+  label: string;
+  description: string;
+  category: string;
+  file_name: string;
+  class_name: string;
+  schema?: SchemaFields | null;
+};
+
+const ALL_CATEGORIES = "all";
+
+function fieldHaystack(
+  name: string,
+  field: InputField | OutputField | ParameterField | undefined
+): string {
+  if (!field) {
+    return name;
+  }
+  return [name, field.type ?? "", field.description ?? ""].join(" ");
+}
+
+export function nodeCatalogHaystack(node: CatalogNode): string {
+  const parts: string[] = [
+    node.label ?? "",
+    node.description ?? "",
+    node.category ?? "",
+    node.file_name ?? "",
+    node.class_name ?? "",
+  ];
+  const schema = node.schema;
+  if (schema) {
+    for (const [name, field] of Object.entries(schema.inputs ?? {})) {
+      parts.push(fieldHaystack(name, field));
+    }
+    for (const [name, field] of Object.entries(schema.outputs ?? {})) {
+      parts.push(fieldHaystack(name, field));
+    }
+    for (const [name, field] of Object.entries(schema.parameters ?? {})) {
+      parts.push(fieldHaystack(name, field));
+    }
+  }
+  return parts.join(" ").toLowerCase();
+}
+
+export function filterNodeCatalog(
+  nodes: CatalogNode[],
+  query: string,
+  category: string = ALL_CATEGORIES
+): CatalogNode[] {
+  const q = query.trim().toLowerCase();
+  const filtered = nodes.filter((node) => {
+    if (category && category !== ALL_CATEGORIES && node.category !== category) {
+      return false;
+    }
+    if (!q) {
+      return true;
+    }
+    return nodeCatalogHaystack(node).includes(q);
+  });
+  return [...filtered].sort((a, b) => {
+    const byCategory = (a.category || "").localeCompare(b.category || "");
+    if (byCategory !== 0) {
+      return byCategory;
+    }
+    return (a.label || "").localeCompare(b.label || "");
+  });
+}
+
+export function uniqueCatalogCategories(nodes: CatalogNode[]): string[] {
+  const seen = new Set<string>();
+  for (const node of nodes) {
+    if (node.category) {
+      seen.add(node.category);
+    }
+  }
+  return [...seen].sort((a, b) => a.localeCompare(b));
+}
+
+export function groupNodesByCategory(
+  nodes: CatalogNode[]
+): Array<[string, CatalogNode[]]> {
+  const map = new Map<string, CatalogNode[]>();
+  for (const node of nodes) {
+    const category = node.category || "Uncategorized";
+    const list = map.get(category);
+    if (list) {
+      list.push(node);
+    } else {
+      map.set(category, [node]);
+    }
+  }
+  return [...map.entries()].sort((a, b) => a[0].localeCompare(b[0]));
+}
+
+export function isPortRequired(field: {
+  required?: boolean;
+  optional?: boolean;
+}): boolean {
+  if (field.optional === false) {
+    return true;
+  }
+  return field.required === true;
+}
+
+export function formatParamDefault(value: unknown): string | null {
+  if (value === undefined) {
+    return null;
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch {
+    return String(value);
+  }
+}

--- a/gui/workflow_frontend/tsconfig.app.json
+++ b/gui/workflow_frontend/tsconfig.app.json
@@ -25,5 +25,6 @@
     "noFallthroughCasesInSwitch": true,
     "noUncheckedSideEffectImports": true
   },
-  "include": ["src"]
+  "include": ["src"],
+  "exclude": ["src/**/*.test.ts"]
 }

--- a/gui/workflow_frontend/vitest.config.ts
+++ b/gui/workflow_frontend/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+  test: {
+    environment: "node",
+    include: ["src/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary
- Fix GitHub README 404s by using relative markdown links; add Installation that links to gui/README.md
- Document Add a node (GUI upload, Python library, in-app MCP, Claude create-node skill)
- In-app Node catalog drawer (Nodes menu + palette) showing name, category, ports, parameters, and schema descriptions from GET /api/box/uploaded-nodes/ — not the dataset catalog

## Test plan
- [ ] pnpm test in gui/workflow_frontend (nodeCatalogSearch.test.ts)
- [ ] After login: Nodes → Node catalog lists types; search by port name; category filter
- [ ] Palette book icon opens the same drawer focused on that type; Edit still opens the parameter modal
- [ ] Drag from palette still works; Upload menu item still goes to /box/upload
- [ ] README links on GitHub: gui/README.md, NODE_SCHEMA.md, CUSTOM_NODE_TUTORIAL.md open (not neuro-workflowREADME.md)

Not deployed. Live dbrain.jp still serves the old bundle until merge + rebuild.